### PR TITLE
Remove Duplicate MetaMask Event Handlers Causing Wallet Connection Errors

### DIFF
--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -641,9 +641,6 @@ class MasterInitializer {
             }
         });
 
-        // Note: Wallet account change handlers are already set up in setupWalletIntegration()
-        // to avoid duplication and ensure proper optional chaining
-
         // Set up wallet connection event listeners for contract manager initialization
         this.setupContractManagerIntegration();
     }

--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -641,26 +641,8 @@ class MasterInitializer {
             }
         });
 
-        // Wallet account change handler
-        if (window.ethereum) {
-            window.ethereum.on('accountsChanged', (accounts) => {
-                if (window.walletManager) {
-                    if (accounts.length === 0) {
-                        window.walletManager.disconnect();
-                    } else {
-                        window.walletManager.account = accounts[0];
-                        window.walletManager.updateUI();
-                    }
-                }
-            });
-
-            window.ethereum.on('chainChanged', (chainId) => {
-                console.log('Chain changed:', chainId);
-                if (window.notificationManager) {
-                    window.notificationManager.info('Network Changed', 'Please refresh the page if needed');
-                }
-            });
-        }
+        // Note: Wallet account change handlers are already set up in setupWalletIntegration()
+        // to avoid duplication and ensure proper optional chaining
 
         // Set up wallet connection event listeners for contract manager initialization
         this.setupContractManagerIntegration();


### PR DESCRIPTION
### Reason for PR
- Fixed a bug causing `TypeError: window.walletManager.updateUI is not a function` when users connected their wallet for the first time
- Duplicate event handlers were being registered for MetaMask's `accountsChanged` and `chainChanged` events, with one lacking proper safety checks

### Changes Made
- **Removed duplicate MetaMask event handlers** from `setupGlobalHandlers()` method (lines 644-663)
  - Eliminated redundant `accountsChanged` handler that called `updateUI()` without optional chaining
  - Eliminated redundant `chainChanged` handler
- **Retained properly implemented handlers** in `setupWalletIntegration()` method
  - These handlers use safe optional chaining (`?.()`) to prevent crashes when methods don't exist
  - Include proper logging and error handling

### Impact
- ✅ Wallet connections now work without throwing errors
- ✅ Improved code maintainability by eliminating duplication
- ✅ Better separation of concerns (wallet-specific logic stays in wallet integration, global handlers focus on app-wide error handling)
- ✅ More defensive programming with optional chaining