### PR TITLE
fix proposal description turning black on focus

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -1843,7 +1843,8 @@
 .modal-body textarea:focus {
     outline: none;
     border-color: #00d4ff !important;
-    background: #000000 !important;
+    background: var(--background-paper) !important;
+    color: var(--text-primary) !important;
     box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.12);
 }
 


### PR DESCRIPTION
Proposal description text areas were turning black and unreadable when focused in light mode. Now the text area will match the selected light or dark mode.

<img width="623" height="555" alt="image" src="https://github.com/user-attachments/assets/e5f9ec67-0c24-4c71-adee-7c9b1e2db309" />
<img width="648" height="562" alt="image" src="https://github.com/user-attachments/assets/d2736587-cf19-4586-9610-fcd472ad84f8" />
