### PR TITLE
Fix wallet disconnect timeout and preserve read-only contract access

### DIFF
--- a/js/wallet/wallet-manager.js
+++ b/js/wallet/wallet-manager.js
@@ -619,14 +619,19 @@ class WalletManager {
             // User switched accounts or reconnected
             this.address = accounts[0];
             
-            // If we were disconnected, re-initialize provider and signer
+            // Re-initialize provider/signer if reconnecting after disconnect
             if (wasDisconnected && window.ethereum) {
                 this.log('Re-initializing provider and signer after reconnection');
                 try {
                     this.provider = new ethers.providers.Web3Provider(window.ethereum);
                     this.signer = this.provider.getSigner();
                     this.chainId = await this.provider.getNetwork().then(n => n.chainId);
-                    this.walletType = 'metamask';
+                    
+                    // Detect wallet type: prioritize specific wallet flags, fallback to metamask/injected
+                    this.walletType = window.ethereum.isTrust ? 'trust' : 
+                                     window.ethereum.isCoinbaseWallet ? 'coinbase' :
+                                     window.ethereum.isBraveWallet ? 'brave' :
+                                     window.ethereum.isMetaMask ? 'metamask' : 'injected';
                 } catch (error) {
                     this.logError('Failed to re-initialize provider/signer:', error);
                 }

--- a/js/wallet/wallet-manager.js
+++ b/js/wallet/wallet-manager.js
@@ -625,7 +625,7 @@ class WalletManager {
                 try {
                     this.provider = new ethers.providers.Web3Provider(window.ethereum);
                     this.signer = this.provider.getSigner();
-                    this.chainId = await this.provider.getNetwork().then(n => n.chainId);
+                    this.chainId = (await this.provider.getNetwork()).chainId;
                     
                     // Detect wallet type: prioritize specific wallet flags, fallback to metamask/injected
                     this.walletType = window.ethereum.isTrust ? 'trust' : 


### PR DESCRIPTION
## **PR Summary:**

### **Problems Resolved:**

• **10-second timeout error on UI disconnect** - Users experienced "Contract manager not ready after timeout" when clicking the Disconnect button in the app UI

• **"Unknown account #0" errors on MetaMask disconnect** - When users disconnected directly from MetaMask extension, contract calls failed with `UNSUPPORTED_OPERATION` errors trying to access stale cached accounts

• **Loss of blockchain data after disconnect** - Disconnecting destroyed the entire ContractManager, preventing users from viewing pool data (TVL, APR, weights) without reconnecting their wallet

### **Root Cause:**

The disconnect handler called `contractManager.cleanup()` which completely destroyed the provider, contracts, ABIs, and all initialization state. Additionally, the Web3Provider instance retained cached account references that caused errors when contracts were called after MetaMask disconnection.

### **Changes Made:**

**File 1:** `js/master-initializer.js` (15 lines changed)

• **Replaced destructive cleanup with graceful downgrade** - Changed from `cleanup()` to setting `signer = null` while preserving provider and contracts

• **Recreate fresh Web3Provider on disconnect** - Creates new provider instance to clear cached account references, mimicking clean page refresh behavior

• **Reinitialize contracts with clean provider** - Reuses existing `initializeContracts()` method to rebind all contracts to fresh provider

• **Made handler async** - Added `async/await` to properly handle asynchronous contract reinitialization

**File 2:** `js/wallet/wallet-manager.js` (24 lines changed)

• **Detect reconnection vs account switch** - Tracks if wallet was previously disconnected to handle reconnection properly

• **Re-initialize provider/signer on reconnection** - When user reconnects after disconnect, creates fresh provider and signer instances

• **Made handler async** - Added `async/await` for proper network detection during reconnection

### **Technical Details:**

**Why fresh provider is needed:** Web3Provider caches account data internally. After MetaMask disconnects, the old provider instance still tries to access `account #0`, causing `UNSUPPORTED_OPERATION` errors. Creating a fresh provider clears this cache.

**Why this matches refresh behavior:** On page refresh, `_initializeReadOnlyInternal()` creates a new Web3Provider. The fix replicates this clean initialization on disconnect.

### **Result:**

✅ UI disconnect works instantly with no timeout errors  
✅ MetaMask disconnect has no account access errors  
✅ Blockchain data remains accessible in read-only mode  
✅ User reconnection properly re-initializes wallet state  
✅ Minimal changes (39 lines total), reuses existing methods