### PR TITLE
Refactor admin role handling and update development mode settings

### DIFF
--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -14,11 +14,12 @@ class AdminPage {
         this.isRefreshing = false; // Prevent overlapping refreshes
         this.autoRefreshActive = false; // Prevent multiple auto-refresh timers
 
-        // Admin role constant (should match contract)
-        this.ADMIN_ROLE = '0x0000000000000000000000000000000000000000000000000000000000000000'; // DEFAULT_ADMIN_ROLE
+        // Admin role constant (will be fetched from contract)
+        /* this.ADMIN_ROLE = null; // Will be fetched from contract during initialization */
 
         // Development mode from centralized config
-        this.DEVELOPMENT_MODE = window.DEV_CONFIG?.ADMIN_DEVELOPMENT_MODE ?? true;
+        // SECURITY: Default to false (production mode) if DEV_CONFIG is not loaded
+        this.DEVELOPMENT_MODE = window.DEV_CONFIG?.ADMIN_DEVELOPMENT_MODE ?? false;
 
         // Professional Mock Data System
         this.mockProposals = new Map();
@@ -476,10 +477,7 @@ class AdminPage {
             if (window.contractManager?.stakingContract) {
                 try {
                     // Try to call hasRole function
-                    const hasAdminRole = await window.contractManager.stakingContract.hasRole(
-                        this.ADMIN_ROLE,
-                        this.userAddress
-                    );
+                    const hasAdminRole = await window.contractManager.hasAdminRole(this.userAddress);
 
                     this.isAuthorized = hasAdminRole;
                     console.log(`🔐 Contract role check: ${hasAdminRole ? 'AUTHORIZED' : 'DENIED'}`);

--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -14,9 +14,6 @@ class AdminPage {
         this.isRefreshing = false; // Prevent overlapping refreshes
         this.autoRefreshActive = false; // Prevent multiple auto-refresh timers
 
-        // Admin role constant (will be fetched from contract)
-        /* this.ADMIN_ROLE = null; // Will be fetched from contract during initialization */
-
         // Development mode from centralized config
         // SECURITY: Default to false (production mode) if DEV_CONFIG is not loaded
         this.DEVELOPMENT_MODE = window.DEV_CONFIG?.ADMIN_DEVELOPMENT_MODE ?? false;

--- a/js/config/dev-config.js
+++ b/js/config/dev-config.js
@@ -10,13 +10,13 @@ window.DEV_CONFIG = {
     MOCK_USER_ADDRESS: '0x1234567890123456789012345678901234567890',
 
     // Authorized Admin Addresses (for production mode)
-    AUTHORIZED_ADMINS: [
+    /* AUTHORIZED_ADMINS: [
         '0x9249cFE964C49Cf2d2D0DBBbB33E99235707aa61', // Governance Signer 1
         '0xea7bb30fbcCBB2646B0eFeB31382D3A4da07a3cC', // Governance Signer 2
         '0x2fBe1cd4BC1718B7625932f35e3cb03E6847289F', // Governance Signer 3
         '0xd3ac493dc0dA16077CC589A838ac473bC010324F', // Governance Signer 4
         '0x0B046B290C50f3FDf1C61ecE442d42D9D79BD814'  // Your wallet
-    ],
+    ], */
     
     // Contract Settings
     MOCK_CONTRACT_DATA: true,     // Use mock data when contracts unavailable

--- a/js/config/dev-config.js
+++ b/js/config/dev-config.js
@@ -10,13 +10,13 @@ window.DEV_CONFIG = {
     MOCK_USER_ADDRESS: '0x1234567890123456789012345678901234567890',
 
     // Authorized Admin Addresses (for production mode)
-    /* AUTHORIZED_ADMINS: [
+    AUTHORIZED_ADMINS: [
         '0x9249cFE964C49Cf2d2D0DBBbB33E99235707aa61', // Governance Signer 1
         '0xea7bb30fbcCBB2646B0eFeB31382D3A4da07a3cC', // Governance Signer 2
         '0x2fBe1cd4BC1718B7625932f35e3cb03E6847289F', // Governance Signer 3
         '0xd3ac493dc0dA16077CC589A838ac473bC010324F', // Governance Signer 4
         '0x0B046B290C50f3FDf1C61ecE442d42D9D79BD814'  // Your wallet
-    ], */
+    ],
     
     // Contract Settings
     MOCK_CONTRACT_DATA: true,     // Use mock data when contracts unavailable

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -1895,8 +1895,6 @@ class ContractManager {
             if (!userAddress) {
                 throw new Error('No address provided and no signer available');
             }
-
-            // DEFAULT_ADMIN_ROLE is bytes32(0)
             const ADMIN_ROLE = await window.contractManager.stakingContract.ADMIN_ROLE();
             return await this.stakingContract.hasRole(ADMIN_ROLE, userAddress);
         }, 'hasAdminRole');

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -1303,16 +1303,6 @@ class ContractManager {
     // ============ ADMIN CONTRACT FUNCTIONS ============
 
     /**
-     * Check if an address has admin role
-     */
-    async hasAdminRole(address) {
-        return await this.executeWithRetry(async () => {
-            const ADMIN_ROLE = '0x0000000000000000000000000000000000000000000000000000000000000000'; // DEFAULT_ADMIN_ROLE
-            return await this.stakingContract.hasRole(ADMIN_ROLE, address);
-        }, 'hasAdminRole');
-    }
-
-    /**
      * Get action counter for multi-signature proposals with RPC failover
      */
     async getActionCounter() {
@@ -1907,7 +1897,7 @@ class ContractManager {
             }
 
             // DEFAULT_ADMIN_ROLE is bytes32(0)
-            const ADMIN_ROLE = '0x0000000000000000000000000000000000000000000000000000000000000000';
+            const ADMIN_ROLE = await window.contractManager.stakingContract.ADMIN_ROLE();
             return await this.stakingContract.hasRole(ADMIN_ROLE, userAddress);
         }, 'hasAdminRole');
     }


### PR DESCRIPTION
- Change ADMIN_ROLE to be fetched from the contract during initialization for better security.
- Update DEVELOPMENT_MODE to default to false in production if DEV_CONFIG is not loaded.
- Simplify admin role check in ContractManager by removing the old method and using the new approach that queries for admin_role