### PR TITLE
Use theme text color variable instead of hardcoded white

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -997,7 +997,7 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    color: #ffffff;
+    color: var(--text-primary);
     cursor: pointer;
 }
 


### PR DESCRIPTION
Replace hardcoded white color with a theme variable checkbox label so its not white on white in light mode

<img width="438" height="159" alt="image" src="https://github.com/user-attachments/assets/6aef1095-148b-41d4-85b6-bc3395592a85" />
