### PR TITLE
Make footer links Liberdus specific

### DIFF
--- a/index.html
+++ b/index.html
@@ -850,13 +850,13 @@
             <div class="footer-content">
                 <span class="footer-text">© 2024 Liberdus LP Stake. All rights reserved.</span>
                 <div class="social-links">
-                    <a href="https://github.com" target="_blank" rel="noopener" class="social-link" title="Visit our GitHub">
+                    <a href="https://github.com/Liberdus/lib-lp-staking-frontend" target="_blank" rel="noopener" class="social-link" title="Visit our GitHub">
                         <span class="material-icons">code</span>
                     </a>
-                    <a href="https://twitter.com" target="_blank" rel="noopener" class="social-link" title="Follow us on Twitter">
+                    <a href="https://x.com/liberdus" target="_blank" rel="noopener" class="social-link" title="Follow us on X">
                         <span class="material-icons">alternate_email</span>
                     </a>
-                    <a href="https://telegram.org" target="_blank" rel="noopener" class="social-link" title="Join our Telegram">
+                    <a href="https://telegram.me/liberdus" target="_blank" rel="noopener" class="social-link" title="Join our Telegram">
                         <span class="material-icons">send</span>
                     </a>
                 </div>


### PR DESCRIPTION
Update footer links to point to Liberdus-specific social media and GitHub pages.