### PR TITLE
Improve UX by resetting form inputs only after successful transactions

### DIFF
--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -804,6 +804,28 @@ class StakingModalNew {
         // Restore body scroll
         document.body.style.overflow = '';
     }
+    
+    /**
+     * Clear all input values and reset state after successful transaction
+     */
+    clearInputs() {
+        // Clear state
+        this.stakeAmount = '';
+        this.unstakeAmount = '';
+        this.isApproved = false;
+        this.needsApproval = false;
+        this.isApproving = false;
+        
+        // Clear DOM inputs and sliders for both stake and unstake
+        ['stake', 'unstake'].forEach(type => {
+            const input = document.getElementById(`${type}-amount-input`);
+            const slider = document.getElementById(`${type}-slider`);
+            if (input) input.value = '';
+            if (slider) slider.value = '0';
+        });
+        
+        console.log('🧹 Input values cleared');
+    }
 
     updatePairInfo() {
         const pairInfoElement = document.getElementById('modal-pair-info');
@@ -1158,10 +1180,10 @@ class StakingModalNew {
 
             console.log('✅ Staking transaction successful:', result.hash);
 
-            // Reset approval state
-            this.isApproved = false;
-            this.needsApproval = false;
-
+            // Clear inputs after successful transaction
+            this.clearInputs();
+            
+            // Close modal
             this.close();
 
             // Wait for blockchain state to update before refreshing
@@ -1230,6 +1252,11 @@ class StakingModalNew {
             }
 
             console.log('✅ Unstaking transaction successful:', result.hash);
+            
+            // Clear inputs after successful transaction
+            this.clearInputs();
+            
+            // Close modal
             this.close();
 
             // Wait for blockchain state to update before refreshing
@@ -1297,6 +1324,11 @@ class StakingModalNew {
             }
 
             console.log('✅ Claim transaction successful:', result.hash);
+            
+            // Clear inputs after successful transaction
+            this.clearInputs();
+            
+            // Close modal
             this.close();
 
             // Wait for blockchain state to update before refreshing


### PR DESCRIPTION
**Changes:**
- Added `clearInputs()` method to reset modal state and DOM elements
  - Clears `stakeAmount` and `unstakeAmount` state variables
  - Resets approval flags (`isApproved`, `needsApproval`, `isApproving`)
  - Clears input fields and sliders for both stake/unstake tabs using efficient loop
- Integrated `clearInputs()` into success flows:
  - Called after successful stake transaction (before closing modal)
  - Called after successful unstake transaction (before closing modal)
  - Called after successful claim transaction (before closing modal)
- Inputs now persist if user manually closes modal without completing transaction
- Uses array iteration `['stake', 'unstake'].forEach()` for clean, maintainable code

**User Impact:**
-  Form inputs clear automatically after successful transactions
-  Inputs remain intact if user closes modal without submitting
-  Better UX - users see fresh form when reopening after transaction completion