### PR TITLE
Force fresh data refresh in admin panel

### DIFF
--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -2118,26 +2118,21 @@ class AdminPage {
         console.log('🔄 Refreshing admin panel data...');
 
         try {
+            // IMPORTANT: Clear proposal cache to force fresh data
+            this.proposalsCache.clear();
+            this.proposalStates.clear();
+
             // Always refresh contract stats AND contract information (lightweight)
             await Promise.all([
                 this.loadContractStats(),
                 this.loadContractInformation()
             ]);
 
-            // Try selective proposal updates first
-            if (this.isSelectiveUpdateEnabled && this.isUsingRealData) {
-                const selectiveUpdateSuccess = await this.trySelectiveProposalUpdate();
-
-                if (selectiveUpdateSuccess) {
-                    console.log('✅ Admin panel data refreshed using selective updates (with contract info)');
-                    return;
-                }
-            }
-
-            // Fall back to full refresh if selective updates failed or disabled
-            console.log('🔄 Using full refresh...');
+            // ALWAYS do full refresh to ensure we get latest data from blockchain
+            // Selective updates are disabled during manual refresh to guarantee fresh data
+            console.log('🔄 Using full refresh to get latest blockchain data...');
             await this.loadMultiSignPanel();
-            console.log('✅ Admin panel data refreshed using full refresh (with contract info)');
+            console.log('✅ Admin panel data refreshed with fresh blockchain data');
 
         } catch (error) {
             console.error('❌ Failed to refresh data:', error);

--- a/js/utils/multicall-service.js
+++ b/js/utils/multicall-service.js
@@ -108,6 +108,7 @@
         async tryAggregate(calls, options = {}) {
             const requireSuccess = options.requireSuccess === true;
             const timeout = options.timeout || 10000; // 10s default timeout
+            const blockTag = options.blockTag; // Support blockTag for fresh queries
 
             if (!this.isAvailable) {
                 console.warn('⚠️ Multicall not available, returning null for fallback');
@@ -122,8 +123,9 @@
                 const startTime = performance.now();
                 this.stats.totalCalls++;
 
-                // Execute with timeout
-                const callPromise = this.multicallContract.tryAggregate(requireSuccess, calls);
+                // Execute with timeout and optional blockTag
+                const callOptions = blockTag ? { blockTag } : {};
+                const callPromise = this.multicallContract.tryAggregate(requireSuccess, calls, callOptions);
                 const timeoutPromise = new Promise((_, reject) =>
                     setTimeout(() => reject(new Error('Multicall timeout')), timeout)
                 );
@@ -139,7 +141,8 @@
                 this.stats.totalTimeSaved += timeSaved;
                 this.stats.successfulCalls++;
 
-                console.log(`⚡ Multicall: ${calls.length} calls in ${timeTaken.toFixed(0)}ms (saved ~${timeSaved.toFixed(0)}ms)`);
+                const blockInfo = blockTag ? ` (block: ${blockTag})` : '';
+                console.log(`⚡ Multicall: ${calls.length} calls in ${timeTaken.toFixed(0)}ms (saved ~${timeSaved.toFixed(0)}ms)${blockInfo}`);
 
                 return results;
 


### PR DESCRIPTION
Fixes the refresh button in the admin panel so it always clears the cache, and does a full reload with fresh data.

- Clear proposal caches (proposalsCache, proposalStates) before refresh
- Force 'latest' blockTag on getAllActions() to bypass ethers.js caching
- Pass blockTag through Multicall to ensure fresh data queries
- Update MulticallService to support blockTag parameter
- Remove selective update optimization during manual refresh