### PR TITLE
Refactor stake information retrieval in ContractManager, was using wrong property name

### DIFF
--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -4242,7 +4242,7 @@ class ContractManager {
             userData.set(pairAddress, {
                 balance: balanceResult?.success ? this.multicallService.decodeResult(erc20Interface, 'balanceOf', balanceResult.returnData) || ethers.BigNumber.from(0) : ethers.BigNumber.from(0),
                 allowance: allowanceResult?.success ? this.multicallService.decodeResult(erc20Interface, 'allowance', allowanceResult.returnData) || ethers.BigNumber.from(0) : ethers.BigNumber.from(0),
-                stake: decodedStakeInfo?.stakedAmount || ethers.BigNumber.from(0),
+                stake: decodedStakeInfo?.amount || ethers.BigNumber.from(0),
                 pendingRewards: decodedStakeInfo?.pendingRewards || ethers.BigNumber.from(0)
             });
         });


### PR DESCRIPTION
- Updated the stake property in user data to use 'amount' instead of incorrect 'stakedAmount'.

Was causing table to show 0.00 for shares and 0.00 caused the unstake button to be disabled