### PR TITLE
Remove wait handled by contract manager

### DIFF
--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -637,7 +637,6 @@ class StakingModalNew {
             // Execute approval and wait for confirmation
             const approveTx = await window.contractManager.approveLPToken(pairName, this.stakeAmount);
             console.log(`✅ Approval transaction sent: ${approveTx.hash}`);
-            const receipt = await approveTx.wait();
 
             console.log(`✅ Approval confirmed in block ${receipt.blockNumber}`);
 


### PR DESCRIPTION
Fixes a small bug in the staking approve tokens flow. The contract manager handles the wait for transaction success and does not return an object with wait on it. The wait was left over from when this function was calling the contract directly.