### PR TITLE
Propagate error message on approval failure

### DIFF
--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -650,6 +650,7 @@ class StakingModalNew {
 
         } catch (error) {
             console.error('❌ Approval failed:', error);
+            window.notificationManager?.error('Token approval failed. ' + error.message);
             this.isApproving = false;
             this.isApproved = false;
             this.updateStakeButton();

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -1291,11 +1291,6 @@ class ContractManager {
     getLPTokenContract(pairName) {
         const contract = this.lpTokenContracts.get(pairName);
         if (!contract) {
-            // In fallback mode, return null instead of throwing error
-            if (this.lpTokenContracts.size === 0) {
-                this.log(`No LP token contracts available - running in fallback mode for pair: ${pairName}`);
-                return null;
-            }
             throw new Error(`LP token contract not found for pair: ${pairName}`);
         }
         return contract;
@@ -4453,19 +4448,6 @@ class ContractManager {
 
         // Check if we're in fallback mode
         const lpContract = this.getLPTokenContract(pairName);
-        if (!lpContract) {
-            // Fallback mode - simulate transaction
-            this.log(`Fallback mode: Simulating approveLPToken for ${pairName}, amount: ${amount}`);
-            return {
-                hash: '0x' + Math.random().toString(16).substr(2, 64),
-                wait: async () => ({
-                    status: 1,
-                    transactionHash: '0x' + Math.random().toString(16).substr(2, 64),
-                    blockNumber: Math.floor(Math.random() * 1000000) + 1000000,
-                    gasUsed: ethers.BigNumber.from('21000')
-                })
-            };
-        }
 
         return await this.executeTransactionWithRetry(async () => {
             const stakingAddress = this.contractAddresses.get('STAKING');


### PR DESCRIPTION
When approval flow fails because it cannot get the contract it will now throw an error instead of mock fallback and show an error toast