### PR TITLE
Sort Pairs by Weight on User and Admin Pages

### DIFF
--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -5938,9 +5938,17 @@ class AdminPage {
         // Update LP pairs with real contract data
         const pairsContainer = document.querySelector('[data-info="lp-pairs"]');
         if (pairsContainer) {
-            pairsContainer.innerHTML = (info.pairs && info.pairs.length > 0)
-                ? this.renderPairsList(info.pairs)
-                : '<div class="no-data">No LP pairs configured</div>';
+            if (info.pairs && info.pairs.length > 0) {
+                // Sort pairs by weight (highest first)
+                const sortedPairs = [...info.pairs].sort((a, b) => {
+                    const weightA = parseFloat(a.weight || '0');
+                    const weightB = parseFloat(b.weight || '0');
+                    return weightB - weightA; // Descending order (highest first)
+                });
+                pairsContainer.innerHTML = this.renderPairsList(sortedPairs);
+            } else {
+                pairsContainer.innerHTML = '<div class="no-data">No LP pairs configured</div>';
+            }
         }
 
         // Update signers with real contract data

--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -315,7 +315,11 @@ class HomePage {
                         </tr>
                     </thead>
                     <tbody>
-                        ${this.pairs.map(pair => this.renderPairRow(pair)).join('')}
+                        ${[...this.pairs].sort((a, b) => {
+                            const weightA = parseFloat(a.weight || '0');
+                            const weightB = parseFloat(b.weight || '0');
+                            return weightB - weightA; // Descending order (highest first)
+                        }).map(pair => this.renderPairRow(pair)).join('')}
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
## Summary
Add sorting to display LP pairs ordered by weight (highest first) on both the User page table and Admin page contract information section.

## Changes Made
- **User Page (`home-page.js`)**: Sort pairs by weight before rendering the table rows
- **Admin Page (`admin-page.js`)**: Sort pairs by weight before displaying in the contract information section

## Implementation
- Pairs are sorted in descending order by weight value using `parseFloat()` for numeric comparison
- Sorting is applied at the display layer during rendering to ensure consistent ordering regardless of contract storage order
- Previously, pairs were displayed in insertion order (FIFO) as returned from the smart contract's `activePairs` array