### PR TITLE
Remove admin page load notification

### DIFF
--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -2509,19 +2509,6 @@ class AdminPage {
                     });
                     console.log(`🎯 Cached states for ${formattedProposals.length} proposals`);
 
-                    // Show success notification
-                    if (window.notificationManager) {
-                        if (realProposals.length > 0) {
-                            window.notificationManager.success(
-                                `Successfully loaded ${realProposals.length} proposals from blockchain`
-                            );
-                        } else {
-                            window.notificationManager.info(
-                                'Connected to blockchain - no proposals exist yet'
-                            );
-                        }
-                    }
-
                     return formattedProposals;
                 } else {
                     console.log('⚠️ Invalid response from getAllActions:', realProposals);
@@ -2949,12 +2936,6 @@ class AdminPage {
                 // Update the UI
                 await this.loadMultiSignPanel();
 
-                if (window.notificationManager) {
-                    window.notificationManager.success(
-                        `Successfully loaded ${realProposals.length} proposals from blockchain`
-                    );
-                }
-
                 return formattedProposals;
             } else {
                 throw new Error('No proposals returned from contract');
@@ -3278,12 +3259,6 @@ class AdminPage {
 
                 // Refresh the display
                 await this.loadMultiSignPanel();
-
-                if (window.notificationManager) {
-                    window.notificationManager.success(
-                        `Successfully loaded all ${allProposals.length} proposals from blockchain`
-                    );
-                }
             }
 
         } catch (error) {


### PR DESCRIPTION
**Reason for PR:**
Remove the notification shown when the admin page loads proposals; it's distracting and the proposal count is already visible in the UI stats.

**Changes made:**
- Removed success notification in `loadProposals()` that displayed "Successfully loaded X proposals from blockchain" on initial page load
- Removed success notification in `forceLoadRealProposals()` that showed when manually forcing a reload
- Removed success notification in `forceLoadAllProposals()` that showed when loading all proposals
- Removed info notification that showed "Connected to blockchain - no proposals exist yet" when no proposals were found

The proposal count remains visible in the Multi-Signature Proposals section stats (Total Proposals, Showing, Required Approvals).