### PR TITLE
Increase default proposals to 50 and update stats on load more

### DIFF
--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -1504,9 +1504,9 @@ class AdminPage {
                                 Hide executed transactions
                             </label>
                             <div class="panel-stats">
-                                <span class="stat-chip">Total Proposals: ${proposals.length}</span>
-                                <span class="stat-chip">Showing: ${filteredProposals.length}</span>
-                                <span class="stat-chip">Required Approvals: ${this.contractStats.requiredApprovals || 2}</span>
+                                <span class="stat-chip" data-stat="total-proposals">Total Proposals: ${this.totalProposalCount}</span>
+                                <span class="stat-chip" data-stat="showing-proposals">Showing: ${filteredProposals.length}</span>
+                                <span class="stat-chip" data-stat="required-approvals">Required Approvals: ${this.contractStats?.requiredApprovals ?? 3}</span>
                             </div>
                         </div>
                     </div>
@@ -1531,6 +1531,12 @@ class AdminPage {
                     </div>
                 </div>
             `;
+
+            this.updateProposalStatsUI({
+                total: this.totalProposalCount,
+                showing: filteredProposals.length,
+                required: this.contractStats?.requiredApprovals ?? 3
+            });
 
             // Proposals are ready, enable actions now that data exists
             this.setProposalButtonsEnabled(true);
@@ -2281,6 +2287,19 @@ class AdminPage {
 
                 console.log(`📊 Added ${formattedBatch.length} proposals to cache, ${visibleBatch.length} visible`);
 
+                const allCachedProposals = this.proposalsCache
+                    ? Array.from(this.proposalsCache.values())
+                    : [];
+                const currentVisibleCount = hideExecuted
+                    ? allCachedProposals.filter(proposal => !proposal.executed).length
+                    : allCachedProposals.length;
+
+                this.updateProposalStatsUI({
+                    total: this.totalProposalCount,
+                    showing: currentVisibleCount,
+                    required: this.contractStats?.requiredApprovals ?? 2
+                });
+
                 // Update Load More button
                 this.updateLoadMoreButton();
 
@@ -2348,6 +2367,33 @@ class AdminPage {
             this.isLoadingMore = false;
             loadMoreContainer.outerHTML = this.renderLoadMoreButton([]);
         }
+    }
+
+    updateProposalStatsUI(stats = {}) {
+        const statsContainer = document.querySelector('.panel-stats');
+        if (!statsContainer) {
+            return;
+        }
+
+        const updateChip = (selector, label, value) => {
+            if (value === undefined || value === null) {
+                return;
+            }
+
+            const numericValue = Number(value);
+            if (!Number.isFinite(numericValue)) {
+                return;
+            }
+
+            const chip = statsContainer.querySelector(selector);
+            if (chip) {
+                chip.textContent = `${label}: ${numericValue}`;
+            }
+        };
+
+        updateChip('[data-stat="total-proposals"]', 'Total Proposals', stats.total);
+        updateChip('[data-stat="showing-proposals"]', 'Showing', stats.showing);
+        updateChip('[data-stat="required-approvals"]', 'Required Approvals', stats.required);
     }
 
     /**
@@ -3065,11 +3111,8 @@ class AdminPage {
         // Update the table
         proposalsTbody.innerHTML = this.renderProposalsRows(filteredProposals);
 
-        // Update stats
-        const showingChip = document.querySelector('.stat-chip:nth-child(2)');
-        if (showingChip) {
-            showingChip.textContent = `Showing: ${filteredProposals.length}`;
-        }
+        // Update stats to reflect filtered count
+        this.updateProposalStatsUI({ showing: filteredProposals.length });
     }
 
     renderProposalsRows(proposals) {

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -1692,9 +1692,9 @@ class ContractManager {
                 return [];
             }
 
-            // Load recent 25 actions for better UX
+            // Load recent 50 actions for better UX
             const startIndex = actionCount;
-            const endIndex = Math.max(actionCount - 25, 1);
+            const endIndex = Math.max(actionCount - 50, 1);
             const actionIds = [];
             for (let i = startIndex; i >= endIndex; i--) {
                 actionIds.push(i);


### PR DESCRIPTION
- now loads 50 proposals at a time instead of 25
- fixes Total proposals stat at top of admin panel to show actual total proposals instead of just the count of loaded proposals
- fixes proposal stats to be updated when more proposals are loaded