### PR TITLE
Refactor Pair Name Display and Formatting

### DIFF
--- a/css/day10-enhancements.css
+++ b/css/day10-enhancements.css
@@ -447,3 +447,37 @@
 .space-x-4 > * + * { margin-left: 1rem; }
 .space-x-6 > * + * { margin-left: 1.5rem; }
 .space-x-8 > * + * { margin-left: 2rem; }
+
+/* Pair Name Link Component */
+.pair-name-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    text-decoration: none;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    padding: 4px 0;
+}
+
+.pair-name-link:hover {
+    opacity: 0.8;
+}
+
+.pair-name-link-text {
+    font-weight: 700;
+    color: var(--text-primary);
+    font-size: 14px;
+}
+
+.pair-name-link-icon {
+    flex-shrink: 0;
+    transition: all 0.2s ease;
+    min-width: 20px;
+    width: 20px;
+    height: 20px;
+    stroke: var(--primary-main);
+    stroke-width: 2.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    fill: none;
+}

--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -3340,54 +3340,6 @@ class AdminPage {
         }
     }
 
-    /**
-     * Format pair name for better display
-     * Converts "LPLIBETH" to "LIB/ETH LP"
-     * Converts "LPLIBUSDC" to "LIB/USDC LP"
-     */
-    formatPairName(pairName) {
-        if (!pairName) return pairName;
-
-        // If already formatted (contains /), return as is
-        if (pairName.includes('/')) {
-            return pairName;
-        }
-
-        // Handle LP prefix format: "LPLIBETH" -> "LIB/ETH LP"
-        if (pairName.startsWith('LP') && pairName.length > 4) {
-            const tokens = pairName.substring(2); // Remove "LP"
-
-            // Try to split into two tokens
-            // Common patterns: LIBETH, LIBUSDC, LIBUSDT, ETHUSDC, etc.
-            const commonTokens = ['USDC', 'USDT', 'DAI', 'WETH', 'ETH', 'WBTC', 'BTC', 'LIB', 'MATIC'];
-
-            for (const token of commonTokens) {
-                if (tokens.endsWith(token)) {
-                    const token1 = tokens.substring(0, tokens.length - token.length);
-                    const token2 = token;
-                    if (token1.length > 0) {
-                        return `${token1}/${token2} LP`;
-                    }
-                }
-                if (tokens.startsWith(token)) {
-                    const token1 = token;
-                    const token2 = tokens.substring(token.length);
-                    if (token2.length > 0) {
-                        return `${token1}/${token2} LP`;
-                    }
-                }
-            }
-
-            // Fallback: split in half
-            const mid = Math.floor(tokens.length / 2);
-            const token1 = tokens.substring(0, mid);
-            const token2 = tokens.substring(mid);
-            return `${token1}/${token2} LP`;
-        }
-
-        // Return original if no pattern matched
-        return pairName;
-    }
 
     /**
      * Get pair name by address from existing pairs or contract data
@@ -3400,7 +3352,7 @@ class AdminPage {
                     p.address && p.address.toLowerCase() === address.toLowerCase()
                 );
                 if (pair && pair.name) {
-                    return this.formatPairName(pair.name);
+                    return pair.name;
                 }
             }
 
@@ -3437,8 +3389,7 @@ class AdminPage {
             }
             
             return {
-                name: pair?.name ? this.formatPairName(pair.name) 
-                    : (pair?.address ? this.getPairNameByAddress(pair.address) : null) || 'Unknown Pair',
+                name: pair?.name || (pair?.address ? this.getPairNameByAddress(pair.address) : null) || 'Unknown Pair',
                 address: pair?.address || 'Unknown',
                 weight: weight,
                 displayWeight: displayWeight

--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -3408,7 +3408,7 @@ class AdminPage {
                 <div class="pair-item-card">
                     <div class="pair-header-section">
                         <div class="pair-name-section">
-                            <h6 class="pair-name">${pair.name}</h6>
+                            <h6 class="pair-name">${window.Formatter?.formatPairName(pair.name, pair.address) || pair.name}</h6>
                             <div class="pair-address-wrapper">
                                 <span class="address-label">Address:</span>
                                 <code class="pair-address">${pair.address}</code>

--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -335,7 +335,7 @@ class HomePage {
         return `
             <tr class="pair-row" data-pair-id="${pair.id}" style="cursor: pointer;">
                 <td>
-                    ${this.formatPairName(pair.name, pair.address)}
+                    ${window.Formatter?.formatPairName(pair.name, pair.address) || pair.name}
                 </td>
                 <td>
                     <span class="chip chip-primary">${pair.platform || 'Uniswap V2'}</span>
@@ -845,33 +845,6 @@ class HomePage {
     }
 
 
-    /**
-     * Format pair name for display with Uniswap link
-     * Simply displays the raw pair name from the contract as a clickable link
-     */
-    formatPairName(pairName, lpTokenAddress = '') {
-        if (!pairName) return pairName;
-
-        const uniswapUrl = lpTokenAddress ? 
-            `https://app.uniswap.org/explore/pools/polygon/${lpTokenAddress}` : 
-            `https://app.uniswap.org/explore/pools`;
-        
-        return `
-            <a href="${uniswapUrl}" target="_blank" rel="noopener noreferrer" 
-               class="pair-name-link"
-               style="display: inline-flex; align-items: center; gap: 8px; text-decoration: none; cursor: pointer; transition: all 0.2s ease; padding: 4px 0;"
-               onmouseover="this.style.opacity='0.8'"
-               onmouseout="this.style.opacity='1'"
-               title="View pool on Uniswap">
-                <span style="font-weight: 700; color: var(--primary-main); font-size: 14px;">${pairName}</span>
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--primary-main)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink: 0; transition: all 0.2s ease; min-width: 20px;">
-                    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-                    <polyline points="15 3 21 3 21 9"></polyline>
-                    <line x1="10" y1="14" x2="21" y2="3"></line>
-                </svg>
-            </a>
-        `;
-    }
 
 
     /**

--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -335,7 +335,7 @@ class HomePage {
         return `
             <tr class="pair-row" data-pair-id="${pair.id}" style="cursor: pointer;">
                 <td>
-                    ${this.formatPairName(`${pair.token0Symbol}/${pair.token1Symbol}`, pair.address)}
+                    ${this.formatPairName(pair.name, pair.address)}
                 </td>
                 <td>
                     <span class="chip chip-primary">${pair.platform || 'Uniswap V2'}</span>
@@ -621,8 +621,6 @@ class HomePage {
                 this.pairs = [{
                     id: '1',
                     address: '0x0000000000000000000000000000000000000000',
-                    token0Symbol: 'LIB',
-                    token1Symbol: 'USDC',
                     name: 'No Pairs Configured',
                     platform: 'Waiting for Setup',
                     apr: '0.00',
@@ -648,8 +646,6 @@ class HomePage {
                     return {
                         id: pairInfo.id || (i + 1).toString(),
                         address: pairInfo.address,
-                        token0Symbol: 'LIB',
-                        token1Symbol: this.extractTokenSymbol(pairInfo.name) || 'TOKEN',
                         name: pairInfo.name || `LP Token ${i + 1}`,
                         platform: pairInfo.platform || 'Unknown',
                         apr: pairInfo.apr || '0.00',
@@ -848,185 +844,43 @@ class HomePage {
         }
     }
 
-    /**
-     * Get token color for avatar
-     */
-    getTokenColor(tokenSymbol) {
-        const colors = {
-            'LIB': '#3B82F6',      // Blue
-            'USDT': '#26A17B',     // Tether Green
-            'USDC': '#2775CA',     // USDC Blue
-            'DAI': '#F5AC37',      // DAI Gold
-            'WETH': '#627EEA',     // Ethereum Purple
-            'ETH': '#627EEA',      // Ethereum Purple
-            'WBTC': '#F7931A',     // Bitcoin Orange
-            'BTC': '#F7931A',      // Bitcoin Orange
-            'MATIC': '#8247E5',    // Polygon Purple
-            'TOKEN': '#FF9800'     // Default Orange
-        };
-        return colors[tokenSymbol.toUpperCase()] || '#6B7280';
-    }
 
     /**
-     * Create token avatar HTML
-     */
-    createTokenAvatar(tokenSymbol) {
-        const symbol = tokenSymbol.toUpperCase();
-        const color = this.getTokenColor(symbol);
-        const initial = symbol.substring(0, 3);
-        
-        return `
-            <div class="token-avatar" style="
-                width: 32px;
-                height: 32px;
-                border-radius: 50%;
-                background: ${color};
-                color: white;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                font-size: 10px;
-                font-weight: 700;
-                letter-spacing: -0.5px;
-                box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-            ">${initial}</div>
-        `;
-    }
-
-    /**
-     * Format pair name for display with token avatars and Uniswap link
+     * Format pair name for display with Uniswap link
+     * Simply displays the raw pair name from the contract as a clickable link
      */
     formatPairName(pairName, lpTokenAddress = '') {
         if (!pairName) return pairName;
 
-        let token1 = '';
-        let token2 = '';
-        let formattedName = pairName;
-
-        // If already formatted (contains /), extract tokens
-        if (pairName.includes('/')) {
-            const parts = pairName.split('/');
-            token1 = parts[0].trim();
-            token2 = parts[1].replace('LP', '').trim();
-            formattedName = `${token1}/${token2}`;
-        }
-        // Handle "LIB-USDT" format
-        else if (pairName.includes('-')) {
-            const parts = pairName.split('-');
-            token1 = parts[0].trim();
-            token2 = parts[1].trim();
-            formattedName = `${token1}/${token2}`;
-        }
-        // Handle LP prefix format: "LPLIBETH" -> "LIB/ETH"
-        else if (pairName.startsWith('LP') && pairName.length > 4) {
-            const tokens = pairName.substring(2); // Remove "LP"
-
-            // Try to split into two tokens
-            const commonTokens = ['USDC', 'USDT', 'DAI', 'WETH', 'ETH', 'WBTC', 'BTC', 'LIB', 'MATIC'];
-
-            for (const token of commonTokens) {
-                if (tokens.endsWith(token)) {
-                    token1 = tokens.substring(0, tokens.length - token.length);
-                    token2 = token;
-                    if (token1.length > 0) {
-                        formattedName = `${token1}/${token2}`;
-                        break;
-                    }
-                }
-                if (tokens.startsWith(token)) {
-                    token1 = token;
-                    token2 = tokens.substring(token.length);
-                    if (token2.length > 0) {
-                        formattedName = `${token1}/${token2}`;
-                        break;
-                    }
-                }
-            }
-
-            // Fallback: split in half if tokens not found
-            if (!token1 || !token2) {
-                const mid = Math.floor(tokens.length / 2);
-                token1 = tokens.substring(0, mid);
-                token2 = tokens.substring(mid);
-                formattedName = `${token1}/${token2}`;
-            }
-        }
-
-        // Create pair display with avatars and Uniswap link
-        if (token1 && token2) {
-            const avatar1 = this.createTokenAvatar(token1);
-            const avatar2 = this.createTokenAvatar(token2);
-            const uniswapUrl = lpTokenAddress ? 
-                `https://app.uniswap.org/explore/pools/polygon/${lpTokenAddress}` : 
-                `https://app.uniswap.org/explore/pools`;
-            
-            return `
-                <div style="display: flex; align-items: center; gap: 8px;">
-                    <div style="display: flex; align-items: center;">
-                        ${avatar1}
-                        <div style="margin-left: -8px; z-index: 1;">${avatar2}</div>
-                    </div>
-                    <a href="${uniswapUrl}" target="_blank" rel="noopener noreferrer" 
-                       class="pair-name-link"
-                       style="display: inline-flex; align-items: center; gap: 8px; text-decoration: none; cursor: pointer; transition: all 0.2s ease; padding: 4px 0;"
-                       onmouseover="this.style.opacity='0.8'"
-                       onmouseout="this.style.opacity='1'"
-                       title="View pool on Uniswap">
-                        <span style="font-weight: 700; color: var(--primary-main); font-size: 14px;">${formattedName}</span>
-                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--primary-main)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink: 0; transition: all 0.2s ease; min-width: 20px;">
-                            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-                            <polyline points="15 3 21 3 21 9"></polyline>
-                            <line x1="10" y1="14" x2="21" y2="3"></line>
-                        </svg>
-                    </a>
-                    <span style="font-size: 11px; color: var(--text-secondary); font-family: monospace;">${pairName}</span>
-                </div>
-            `;
-        }
-
-        // Return original if no pattern matched
-        return formattedName;
+        const uniswapUrl = lpTokenAddress ? 
+            `https://app.uniswap.org/explore/pools/polygon/${lpTokenAddress}` : 
+            `https://app.uniswap.org/explore/pools`;
+        
+        return `
+            <a href="${uniswapUrl}" target="_blank" rel="noopener noreferrer" 
+               class="pair-name-link"
+               style="display: inline-flex; align-items: center; gap: 8px; text-decoration: none; cursor: pointer; transition: all 0.2s ease; padding: 4px 0;"
+               onmouseover="this.style.opacity='0.8'"
+               onmouseout="this.style.opacity='1'"
+               title="View pool on Uniswap">
+                <span style="font-weight: 700; color: var(--primary-main); font-size: 14px;">${pairName}</span>
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--primary-main)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink: 0; transition: all 0.2s ease; min-width: 20px;">
+                    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                    <polyline points="15 3 21 3 21 9"></polyline>
+                    <line x1="10" y1="14" x2="21" y2="3"></line>
+                </svg>
+            </a>
+        `;
     }
 
-    /**
-     * Extract token symbol from pair name
-     */
-    extractTokenSymbol(pairName) {
-        if (!pairName) return 'USDT';
-
-        // Try to extract the second token from patterns like "LIB/USDC" or "LIB-USDC"
-        const match = pairName.match(/LIB[\/\-](\w+)/i);
-        if (match) {
-            return match[1].toUpperCase();
-        }
-
-        // Fallback patterns
-        if (pairName.toLowerCase().includes('usdc')) return 'USDC';
-        if (pairName.toLowerCase().includes('usdt')) return 'USDT';
-        if (pairName.toLowerCase().includes('eth')) return 'ETH';
-        if (pairName.toLowerCase().includes('btc')) return 'BTC';
-        if (pairName.toLowerCase().includes('dai')) return 'DAI';
-        if (pairName.toLowerCase().includes('matic')) return 'MATIC';
-
-        // Default to USDT instead of TOKEN
-        return 'USDT';
-    }
 
     /**
      * Build real pair data from contract information
      */
     async buildRealPairData(pairInfo, index) {
         try {
-            // Extract pair name from platform or use address
-            const pairName = this.extractPairName(pairInfo.address, pairInfo.platform);
-            
-            // Use existing token symbols if available, otherwise extract from pair name
-            let tokens;
-            if (pairInfo.token0Symbol && pairInfo.token1Symbol) {
-                tokens = { token0: pairInfo.token0Symbol, token1: pairInfo.token1Symbol };
-            } else {
-                tokens = this.extractTokenSymbols(pairName);
-            }
+            // Use the raw pair name from contract (contract manager ensures this is always set)
+            const pairName = pairInfo.name || 'Unknown Pair';
 
             // Get additional data if available
             let tvl = 0;
@@ -1109,9 +963,7 @@ class HomePage {
 
             return {
                 id: index.toString(),
-                token0Symbol: tokens.token0,
-                token1Symbol: tokens.token1,
-                name: `${tokens.token0}/${tokens.token1} LP`,
+                name: pairName,
                 platform: pairInfo.platform || 'Unknown',
                 apr: apr.toFixed(2),
                 tvl: tvl,
@@ -1119,7 +971,8 @@ class HomePage {
                 userEarnings: userEarnings,
                 totalStaked: totalStaked.toString(),
                 rewardRate: rewardRate.toFixed(3),
-                stakingEnabled: pairInfo.isActive
+                stakingEnabled: pairInfo.isActive,
+                address: pairInfo.address
             };
         } catch (error) {
             console.error('Failed to build real pair data:', error);
@@ -1127,78 +980,7 @@ class HomePage {
         }
     }
 
-    /**
-     * Extract pair name from address or platform
-     */
-    extractPairName(address, platform) {
-        // Try to find a known pair name from config
-        const lpTokens = window.CONFIG?.CONTRACTS?.LP_TOKENS || {};
-        for (const [pairName, pairAddress] of Object.entries(lpTokens)) {
-            if (pairAddress.toLowerCase() === address.toLowerCase()) {
-                return pairName;
-            }
-        }
 
-        // Use platform if available
-        if (platform && platform !== 'Unknown') {
-            return platform;
-        }
-
-        // Fallback to shortened address
-        return `${address.slice(0, 6)}...${address.slice(-4)}`;
-    }
-
-    /**
-     * Extract token symbols from pair name
-     */
-    extractTokenSymbols(pairName) {
-        // Handle common pair name formats
-        if (pairName.includes('/')) {
-            const parts = pairName.split('/');
-            return { token0: parts[0].trim(), token1: parts[1].trim() };
-        } else if (pairName.includes('-')) {
-            const parts = pairName.split('-');
-            return { token0: parts[0].trim(), token1: parts[1].trim() };
-        } else if (pairName.includes('_')) {
-            const parts = pairName.split('_');
-            return { token0: parts[0].trim(), token1: parts[1].trim() };
-        }
-
-        // Handle LP prefix format: "LPLIBUSDT" -> "LIB/USDT"
-        if (pairName.startsWith('LP') && pairName.length > 4) {
-            const tokens = pairName.substring(2); // Remove "LP"
-            
-            // Try to split into two tokens using common token patterns
-            const commonTokens = ['USDC', 'USDT', 'DAI', 'WETH', 'ETH', 'WBTC', 'BTC', 'LIB', 'MATIC'];
-            
-            for (const token of commonTokens) {
-                if (tokens.endsWith(token)) {
-                    const token1 = tokens.substring(0, tokens.length - token.length);
-                    const token2 = token;
-                    if (token1.length > 0) {
-                        return { token0: token1, token1: token2 };
-                    }
-                }
-                if (tokens.startsWith(token)) {
-                    const token1 = token;
-                    const token2 = tokens.substring(token.length);
-                    if (token2.length > 0) {
-                        return { token0: token1, token1: token2 };
-                    }
-                }
-            }
-            
-            // Fallback: split in half
-            const mid = Math.floor(tokens.length / 2);
-            const token1 = tokens.substring(0, mid);
-            const token2 = tokens.substring(mid);
-            return { token0: token1, token1: token2 };
-        }
-
-        // Fallback for unknown formats - try to extract from address or use LIB/USDT as default
-        console.warn(`Could not parse pair name: ${pairName}, using LIB/USDT as fallback`);
-        return { token0: 'LIB', token1: 'USDT' };
-    }
 
     openStakingModal(pairId, tab = 'stake') {
         const pair = this.pairs.find(p => p.id === pairId);

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -808,7 +808,7 @@ class StakingModalNew {
 
         pairInfoElement.innerHTML = `
             <span class="material-icons" style="font-size: 16px;">swap_horiz</span>
-            ${this.currentPair.token0Symbol}/${this.currentPair.token1Symbol}
+            ${this.currentPair.name || 'Unknown Pair'}
             <span class="chip chip-primary" style="margin-left: 8px;">${this.currentPair.platform}</span>
         `;
     }

--- a/js/utils/formatter.js
+++ b/js/utils/formatter.js
@@ -64,5 +64,33 @@ window.Formatter = {
         const limited = parseFloat(`${integerPart}.${decimalPart}`).toFixed(6).replace(/\.?0+$/, '');
         return prefix + limited;
     },
+
+    /**
+     * Format pair name for display with Uniswap link
+     * Simply displays the raw pair name from the contract as a clickable link
+     * @param {string} pairName - The pair name from the contract
+     * @param {string} lpTokenAddress - The LP token address for the Uniswap link
+     * @returns {string} HTML string with clickable link to Uniswap
+     */
+    formatPairName(pairName, lpTokenAddress = '') {
+        if (!pairName) return pairName;
+
+        const uniswapUrl = lpTokenAddress ? 
+            `https://app.uniswap.org/explore/pools/polygon/${lpTokenAddress}` : 
+            `https://app.uniswap.org/explore/pools`;
+        
+        return `
+            <a href="${uniswapUrl}" target="_blank" rel="noopener noreferrer" 
+               class="pair-name-link"
+               title="View pool on Uniswap">
+                <span class="pair-name-link-text">${pairName}</span>
+                <svg class="pair-name-link-icon" viewBox="0 0 24 24">
+                    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                    <polyline points="15 3 21 3 21 9"></polyline>
+                    <line x1="10" y1="14" x2="21" y2="3"></line>
+                </svg>
+            </a>
+        `;
+    },
 };
 


### PR DESCRIPTION
### Overview
Consolidates pair name formatting into a shared utility, removes duplicate logic, and centralizes CSS styles. Simplifies codebase by displaying raw contract pair names instead of parsing/extracting tokens.

### Key Changes

- **Centralized formatting** (`js/utils/formatter.js`): Added `formatPairName()` to `window.Formatter` utility that displays raw pair names as clickable Uniswap links
- **Refactored HomePage** (`js/components/home-page.js`): Removed 8 deprecated functions (`formatPairName`, `createTokenAvatar`, `getTokenColor`, `extractTokenSymbol`, etc.) and simplified to use raw `pairInfo.name`
- **Refactored AdminPage** (`js/components/admin-page.js`): Removed duplicate `formatPairName()` logic, now uses shared utility
- **CSS consolidation** (`css/day10-enhancements.css`): Moved inline styles to shared stylesheet (`.pair-name-link`, `.pair-name-link-text`, `.pair-name-link-icon`)

### Benefits

- Single source of truth for pair name formatting
- Easier maintenance and updates
- Consistent styling across home and admin pages
- Cleaner, more maintainable codebase