### PR TITLE
Remove extra pair name

### DIFF
--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -979,7 +979,6 @@ class HomePage {
                             <line x1="10" y1="14" x2="21" y2="3"></line>
                         </svg>
                     </a>
-                    <span style="font-size: 11px; color: var(--text-secondary); font-family: monospace;">${pairName}</span>
                 </div>
             `;
         }


### PR DESCRIPTION
Removes the extra pair name on the staking page pair rows.

<img width="1482" height="613" alt="image" src="https://github.com/user-attachments/assets/20d1d6c4-7f51-46ef-ba03-5a9e401ed785" />
