### PR TITLE
Remove arrow indicator from form fields

### DIFF
--- a/css/admin-homepage-theme.css
+++ b/css/admin-homepage-theme.css
@@ -774,17 +774,6 @@ select::after {
     position: relative !important;
 }
 
-.form-group::after {
-    content: '▼' !important;
-    position: absolute !important;
-    right: 16px !important;
-    top: 50% !important;
-    transform: translateY(-50%) !important;
-    pointer-events: none !important;
-    font-size: 12px !important;
-    color: var(--text-secondary) !important;
-}
-
 select option,
 .form-input select option,
 #remove-pair-select option {


### PR DESCRIPTION
Eliminate the arrow indicator that appears inside form fields on the admin page.
<img width="901" height="1159" alt="image" src="https://github.com/user-attachments/assets/ea4ee8de-614d-4a28-8e54-2512dfe5acf1" />
<img width="901" height="1158" alt="image" src="https://github.com/user-attachments/assets/d531f2fb-7dfc-4d27-b7f1-9d40c6965fea" />
