### PR TITLE
Show weight percentage without chip style

### DIFF
--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -383,8 +383,8 @@ class HomePage {
                     <span style="color: var(--success-main); font-weight: bold;">${pair.apr || '0.00'}%</span>
                 </td>
                 <td>
-                    <span class="chip chip-secondary">
-                        ${window.Formatter?.formatSmallNumberWithSubscript(parseFloat(pair.weight || '0')) || '0'} (${pair.weightPercentage || '0.00'}%)
+                    <span style="font-weight: 600;">
+                        ${pair.weightPercentage || '0.00'}%
                     </span>
                 </td>
                 <td>


### PR DESCRIPTION
Display only the weight percentage in a simplified format, removing the chip style for a cleaner appearance.
<img width="1013" height="413" alt="image" src="https://github.com/user-attachments/assets/d6b06579-c901-4dc9-a7e3-b9bc4b0e1dd1" />
