### PR TITLE
Remove reward rate display on staking page

### DIFF
--- a/css/day10-enhancements.css
+++ b/css/day10-enhancements.css
@@ -66,9 +66,9 @@
         margin-bottom: 20px;
     }
 
-    .reward-info {
+    .page-title-header {
         flex-direction: column;
-        align-items: flex-start;
+        align-items: center;
         gap: 8px;
     }
 

--- a/index.html
+++ b/index.html
@@ -257,26 +257,16 @@
         .page-title h1 {
             font-size: 48px;
             font-weight: 700;
-            margin-bottom: var(--spacing-2);
+            margin-bottom: 0;
             color: var(--text-primary);
         }
-        
-        .reward-info {
-            display: flex;
+
+        .page-title-header {
+            display: inline-flex;
             align-items: center;
             justify-content: center;
             gap: var(--spacing-2);
             margin-bottom: var(--spacing-2);
-        }
-        
-        .reward-info .material-icons {
-            color: var(--primary-main);
-        }
-        
-        .reward-rate {
-            font-size: 20px;
-            font-weight: 600;
-            color: var(--text-primary);
         }
         
         /* Refresh button */
@@ -526,7 +516,7 @@
                 font-size: 32px;
             }
 
-            .reward-info {
+            .page-title-header {
                 flex-direction: column;
                 gap: var(--spacing-1);
             }
@@ -678,10 +668,8 @@
         <div class="container-xl">
 
             <div class="page-title">
-                <h1>LP Staking</h1>
-                <div class="reward-info">
-                    <span class="material-icons" aria-hidden="true">access_time</span>
-                    <span class="reward-rate">Hourly Reward Rate: <span id="hourly-rate" aria-live="polite">0.00</span> LIB</span>
+                <div class="page-title-header">
+                    <h1>LP Staking</h1>
                     <button id="refresh-button" class="refresh-button" aria-label="Refresh data">
                         <span class="material-icons" aria-hidden="true">refresh</span>
                     </button>

--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -180,25 +180,11 @@ class HomePage {
             container.innerHTML = this.renderHomepage();
         }
 
-        // Update the hourly rate in the existing HTML header
-        this.updateHourlyRateDisplay();
         this.attachRetryHandler();
     }
 
     renderHomepage() {
         return this.renderTable();
-    }
-
-    /**
-     * Update the hourly rate display in the existing HTML header
-     */
-    updateHourlyRateDisplay() {
-        const hourlyRateElement = document.getElementById('hourly-rate');
-        if (hourlyRateElement) {
-            const formattedRate = parseFloat(this.hourlyRewardRate || '0').toFixed(2);
-            hourlyRateElement.textContent = formattedRate;
-            console.log(`📊 Updated hourly rate display: ${formattedRate} LIB`);
-        }
     }
 
     attachRetryHandler() {
@@ -560,7 +546,6 @@ class HomePage {
         this.loading = false;
         
         // Update display
-        this.updateHourlyRateDisplay(0);
         this.render();
         
         console.log('✅ Empty data loaded successfully');


### PR DESCRIPTION
- Removes the reward rate displayed on the staking page since it could confuse user.
- moved the refresh button to be inline with the page title 
<img width="1317" height="526" alt="image" src="https://github.com/user-attachments/assets/dc71662e-c4fb-4102-932c-09de912a8a61" />
