### PR TITLE
Remove unsupported uniswap v3

### DIFF
--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -156,7 +156,6 @@ window.CONFIG = {
     PLATFORMS: {
         // Available platforms for dropdown (matches contract values)
         OPTIONS: [
-            'Uniswap V3',
             'Uniswap V2',
             'SushiSwap',
             'Curve Finance',
@@ -165,7 +164,6 @@ window.CONFIG = {
         ],
         // Base URLs for each platform (address will be inserted where {address} appears)
         BASE_URLS: {
-            'Uniswap V3': 'https://app.uniswap.org/explore/pools/polygon/{address}',
             'Uniswap V2': 'https://app.uniswap.org/explore/pools/polygon/{address}',
             'SushiSwap': 'https://www.sushi.com/analytics/pools/polygon/{address}',
             'Curve Finance': 'https://curve.fi/polygon/pools/{address}',


### PR DESCRIPTION
We don't support uniswap v3 so this PR removes it as an option when creating new pairs