### PR TITLE
Enhance connect wallet button styling to match admin

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,24 +219,52 @@
         
         /* Connect wallet button */
         .connect-wallet-btn {
-            background: var(--primary-main);
-            color: white;
-            border: none;
-            padding: var(--spacing-1) var(--spacing-3);
-            border-radius: var(--border-radius);
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            height: 38px;
+            padding: 0 16px;
+            min-width: 160px;
+            background: var(--background-paper);
+            border: 1px solid var(--divider);
+            border-radius: 8px;
+            color: var(--text-primary);
+            font-size: 14px;
             font-weight: 600;
             cursor: pointer;
-            transition: all 0.2s;
-            display: flex;
-            align-items: center;
-            gap: var(--spacing-1);
-            font-size: var(--font-size);
+            transition: all 0.2s ease;
+            box-shadow: none;
         }
         
         .connect-wallet-btn:hover {
-            background: var(--primary-hover);
+            background: var(--surface-hover);
+            border-color: rgba(25, 118, 210, 0.25);
             transform: translateY(-1px);
-            box-shadow: var(--shadow-4);
+        }
+
+        .connect-wallet-btn svg {
+            opacity: 0.8;
+            color: var(--primary-main);
+        }
+
+        .connect-wallet-btn .wallet-address-text {
+            font-family: "Monaco", "Courier New", monospace;
+            font-size: 13px;
+            letter-spacing: 0.5px;
+        }
+
+        .connect-wallet-btn .wallet-status-text {
+            font-size: 14px;
+            font-weight: 600;
+        }
+
+        .connect-wallet-btn.connected {
+            border-color: rgba(25, 118, 210, 0.35);
+            background: var(--background-paper);
+        }
+
+        .connect-wallet-btn.connected:hover {
+            background: var(--surface-hover);
         }
         
         /* Main content */
@@ -650,8 +678,10 @@
                     </div>
 
                     <button id="connect-wallet-btn" class="connect-wallet-btn" aria-describedby="wallet-status">
-                        <span class="material-icons" aria-hidden="true">account_balance_wallet</span>
-                        <span>Connect Wallet</span>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M21 18v1c0 1.1-.9 2-2 2H5c-1.1 0-2-.9-2-2V5c0-1.1.9-2 2-2h14c1.1 0 2 .9 2 2v1h-9c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h9zm-9-2h10V8H12v8zm4-2.5c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z" />
+                        </svg>
+                        <span class="wallet-status-text">Connect Wallet</span>
                     </button>
 
 

--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -541,10 +541,10 @@ class MasterInitializer {
 
                 // Update button text and style
                 connectBtn.innerHTML = `
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="margin-right: 8px;">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                         <path d="M21 18v1c0 1.1-.9 2-2 2H5c-1.1 0-2-.9-2-2V5c0-1.1.9-2 2-2h14c1.1 0 2 .9 2 2v1h-9c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h9zm-9-2h10V8H12v8zm4-2.5c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/>
                     </svg>
-                    ${shortAddress}
+                    <span class="wallet-address-text">${shortAddress}</span>
                 `;
                 connectBtn.classList.add('connected');
                 connectBtn.title = `Connected: ${address}`;
@@ -552,10 +552,10 @@ class MasterInitializer {
             } else {
                 // Update button for disconnected state
                 connectBtn.innerHTML = `
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="margin-right: 8px;">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                         <path d="M21 18v1c0 1.1-.9 2-2 2H5c-1.1 0-2-.9-2-2V5c0-1.1.9-2 2-2h14c1.1 0 2 .9 2 2v1h-9c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h9zm-9-2h10V8H12v8zm4-2.5c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/>
                     </svg>
-                    Connect Wallet
+                    <span class="wallet-status-text">Connect Wallet</span>
                 `;
                 connectBtn.classList.remove('connected');
                 connectBtn.title = 'Connect your wallet';


### PR DESCRIPTION
 Matching Admin Wallet Styling

- Align home `connect-wallet-btn` styling with admin header: neutral card background, 38 px height, shared border radius, and monospace address text for visual parity.
- Swap material icon/span markup with shared SVG + status span so runtime updates and default render use consistent structure.
- Update status-rendering logic in `js/master-initializer.js` to wrap connected/disconnected labels in `.wallet-address-text` / `.wallet-status-text`, keeping typography consistent across states.
<img width="559" height="73" alt="image" src="https://github.com/user-attachments/assets/8893798f-6de2-46ff-a48b-ac1e607f7d9a" />

<img width="559" height="73" alt="image" src="https://github.com/user-attachments/assets/2871b7c8-2820-4fdb-8d61-8d58139badc6" />
