### PR TITLE
Streamline Wallet Popup UI/UX

### DIFF
--- a/css/wallet-popup.css
+++ b/css/wallet-popup.css
@@ -4,42 +4,43 @@
 
 .wallet-popup {
     position: absolute;
-    background: #2a2a2a;
-    border: 1px solid #404040;
-    border-radius: 16px;
-    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
+    background: var(--background-paper);
+    border: 1px solid var(--divider);
+    border-radius: var(--border-radius-lg);
+    box-shadow: var(--shadow-8);
     width: 280px;
     z-index: 10001;
-    backdrop-filter: blur(20px);
+    /* backdrop-filter: blur(20px); */
     overflow: hidden;
-    color: white;
-    font-family: "Exo", "Helvetica", "Arial", sans-serif;
+    color: var(--text-primary);
+    font-family: var(--font-family);
 }
 
 .wallet-popup-content {
-    padding: 24px;
+    padding: var(--spacing-3);
     text-align: center;
     position: relative;
+    background: var(--background-paper);
 }
 
 /* Close Button */
 .wallet-popup-close {
     position: absolute;
-    top: 12px;
-    right: 12px;
+    top: var(--spacing-2);
+    right: var(--spacing-2);
     background: none;
     border: none;
-    color: #888;
+    color: var(--text-secondary);
     cursor: pointer;
     padding: 4px;
-    border-radius: 4px;
+    border-radius: var(--border-radius);
     transition: all 0.2s ease;
     z-index: 1;
 }
 
 .wallet-popup-close:hover {
-    color: white;
-    background: rgba(255, 255, 255, 0.1);
+    color: var(--text-primary);
+    background: var(--surface-hover);
 }
 
 .wallet-popup-close .material-icons {
@@ -48,7 +49,7 @@
 
 /* Wallet Avatar */
 .wallet-avatar {
-    margin-bottom: 16px;
+    margin-bottom: var(--spacing-2);
 }
 
 .avatar-circle {
@@ -77,50 +78,57 @@
     position: relative;
     z-index: 1;
     color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
 }
 
 .avatar-icon .material-icons {
     font-size: 28px;
+    line-height: 1;
 }
 
 /* Wallet Address */
 .wallet-address {
-    margin-bottom: 8px;
+    margin-bottom: var(--spacing-1);
 }
 
 .address-text {
     font-family: 'Courier New', monospace;
     font-size: 16px;
     font-weight: 600;
-    color: white;
+    color: var(--text-primary);
     letter-spacing: 0.5px;
 }
 
 /* Wallet Balance */
 .wallet-balance {
-    margin-bottom: 24px;
+    margin-bottom: var(--spacing-3);
 }
 
 .balance-amount {
-    font-size: 14px;
-    color: #888;
+    font-size: 0.875rem;
+    color: var(--text-secondary);
     font-weight: 500;
 }
 
 /* Action Buttons */
 .wallet-actions {
-    display: flex;
-    gap: 12px;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--spacing-2);
 }
 
 .action-button {
     flex: 1;
-    background: #404040;
-    color: white;
-    border: 1px solid #555;
-    padding: 12px 16px;
-    border-radius: 8px;
-    font-size: 13px;
+    background: var(--surface-hover);
+    color: var(--text-primary);
+    border: 1px solid var(--divider);
+    padding: var(--spacing-2);
+    border-radius: var(--border-radius);
+    font-size: 0.875rem;
     font-weight: 500;
     cursor: pointer;
     display: flex;
@@ -132,8 +140,8 @@
 }
 
 .action-button:hover {
-    background: #4a4a4a;
-    border-color: #666;
+    background: var(--action-hover);
+    border-color: var(--divider);
     transform: translateY(-1px);
 }
 
@@ -141,22 +149,14 @@
     font-size: 16px;
 }
 
-.copy-button {
-    border-color: #555;
-}
-
 .copy-button:hover {
-    border-color: #3b82f6;
-    background: rgba(59, 130, 246, 0.1);
-}
-
-.disconnect-button {
-    border-color: #555;
+    border-color: var(--primary-main);
+    background: color-mix(in srgb, var(--primary-main) 15%, transparent);
 }
 
 .disconnect-button:hover {
-    border-color: #ef4444;
-    background: rgba(239, 68, 68, 0.1);
+    border-color: var(--error-main);
+    background: color-mix(in srgb, var(--error-main) 12%, transparent);
 }
 
 /* Mobile Responsive */
@@ -167,7 +167,7 @@
     }
 
     .wallet-popup-content {
-        padding: 20px;
+        padding: var(--spacing-2);
     }
 
     .avatar-circle {
@@ -180,12 +180,12 @@
     }
 
     .address-text {
-        font-size: 14px;
+        font-size: 0.875rem;
     }
 
     .action-button {
-        padding: 10px 12px;
-        font-size: 12px;
+        padding: var(--spacing-1) var(--spacing-2);
+        font-size: 0.75rem;
     }
 }
 
@@ -215,14 +215,14 @@
 /* Focus States for Accessibility */
 .action-button:focus,
 .wallet-popup-close:focus {
-    outline: 2px solid #3b82f6;
+    outline: 2px solid var(--primary-main);
     outline-offset: 2px;
 }
 
 /* Success State for Copy */
 .copy-button.success {
-    border-color: #10b981;
-    background: rgba(16, 185, 129, 0.1);
+    border-color: var(--success-main);
+    background: color-mix(in srgb, var(--success-main) 15%, transparent);
 }
 
 .copy-button.success .material-icons {

--- a/css/wallet-popup.css
+++ b/css/wallet-popup.css
@@ -49,8 +49,8 @@
 
 /* Wallet Address */
 .wallet-address {
-    margin-top: var(--spacing-1);
-    margin-bottom: var(--spacing-2);
+    margin-top: var(--spacing-2);
+    margin-bottom: 0;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -88,21 +88,11 @@
     font-size: 18px;
 }
 
-/* Wallet Balance */
-.wallet-balance {
-    margin-bottom: var(--spacing-2);
-}
-
-.balance-amount {
-    font-size: 0.875rem;
-    color: var(--text-secondary);
-    font-weight: 500;
-}
-
 /* Action Buttons */
 .wallet-actions {
     display: flex;
     justify-content: center;
+    margin-top: var(--spacing-2);
 }
 
 .disconnect-button {

--- a/css/wallet-popup.css
+++ b/css/wallet-popup.css
@@ -47,52 +47,14 @@
     font-size: 18px;
 }
 
-/* Wallet Avatar */
-.wallet-avatar {
-    margin-bottom: var(--spacing-2);
-}
-
-.avatar-circle {
-    width: 64px;
-    height: 64px;
-    border-radius: 50%;
-    margin: 0 auto;
-    position: relative;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.avatar-gradient {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    border-radius: 50%;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-}
-
-.avatar-icon {
-    position: relative;
-    z-index: 1;
-    color: white;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-}
-
-.avatar-icon .material-icons {
-    font-size: 28px;
-    line-height: 1;
-}
-
 /* Wallet Address */
 .wallet-address {
-    margin-bottom: var(--spacing-1);
+    margin-top: var(--spacing-1);
+    margin-bottom: var(--spacing-2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-1);
 }
 
 .address-text {
@@ -103,9 +65,32 @@
     letter-spacing: 0.5px;
 }
 
+.copy-icon-button {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: var(--border-radius);
+    transition: all 0.2s ease;
+    min-width: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.copy-icon-button:hover {
+    color: var(--text-primary);
+    background: var(--surface-hover);
+}
+
+.copy-icon-button .material-icons {
+    font-size: 18px;
+}
+
 /* Wallet Balance */
 .wallet-balance {
-    margin-bottom: var(--spacing-3);
+    margin-bottom: var(--spacing-2);
 }
 
 .balance-amount {
@@ -116,22 +101,21 @@
 
 /* Action Buttons */
 .wallet-actions {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: var(--spacing-2);
+    display: flex;
+    justify-content: center;
 }
 
-.action-button {
-    flex: 1;
-    background: var(--surface-hover);
-    color: var(--text-primary);
+.disconnect-button {
+    min-width: 120px;
+    padding: calc(var(--spacing-2) - 4px) var(--spacing-3);
+    background: color-mix(in srgb, var(--error-main) 8%, transparent);
+    color: var(--error-main);
     border: 1px solid var(--divider);
-    padding: var(--spacing-2);
     border-radius: var(--border-radius);
     font-size: 0.875rem;
     font-weight: 500;
     cursor: pointer;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: 6px;
@@ -139,24 +123,14 @@
     font-family: inherit;
 }
 
-.action-button:hover {
-    background: var(--action-hover);
-    border-color: var(--divider);
+.disconnect-button:hover {
+    border-color: var(--error-main);
+    background: color-mix(in srgb, var(--error-main) 18%, transparent);
     transform: translateY(-1px);
 }
 
-.action-button .material-icons {
+.disconnect-button .material-icons {
     font-size: 16px;
-}
-
-.copy-button:hover {
-    border-color: var(--primary-main);
-    background: color-mix(in srgb, var(--primary-main) 15%, transparent);
-}
-
-.disconnect-button:hover {
-    border-color: var(--error-main);
-    background: color-mix(in srgb, var(--error-main) 12%, transparent);
 }
 
 /* Mobile Responsive */
@@ -220,12 +194,12 @@
 }
 
 /* Success State for Copy */
-.copy-button.success {
-    border-color: var(--success-main);
+.copy-icon-button.success {
+    color: var(--success-main);
     background: color-mix(in srgb, var(--success-main) 15%, transparent);
 }
 
-.copy-button.success .material-icons {
+.copy-icon-button.success .material-icons {
     animation: checkmark 0.3s ease;
 }
 

--- a/js/components/wallet-popup.js
+++ b/js/components/wallet-popup.js
@@ -141,32 +141,21 @@ class WalletPopup {
                         <span class="material-icons">close</span>
                     </button>
 
-                    <!-- Wallet Avatar -->
-                    <div class="wallet-avatar">
-                        <div class="avatar-circle">
-                            <div class="avatar-gradient"></div>
-                            <div class="avatar-icon">
-                                <span class="material-icons">account_balance_wallet</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Wallet Address -->
-                    <div class="wallet-address">
-                        <span class="address-text">${shortAddress}</span>
-                    </div>
-
                     <!-- Wallet Balance -->
                     <div class="wallet-balance">
                         <span class="balance-amount">${balance}</span>
                     </div>
 
+                    <!-- Wallet Address -->
+                    <div class="wallet-address">
+                        <span class="address-text">${shortAddress}</span>
+                        <button class="copy-icon-button" data-address="${walletData.address}" title="Copy address">
+                            <span class="material-icons">content_copy</span>
+                        </button>
+                    </div>
+
                     <!-- Action Buttons -->
                     <div class="wallet-actions">
-                        <button class="action-button copy-button" data-address="${walletData.address}">
-                            <span class="material-icons">content_copy</span>
-                            <span>Copy Address</span>
-                        </button>
                         <button class="action-button disconnect-button">
                             <span class="material-icons">logout</span>
                             <span>Disconnect</span>
@@ -214,10 +203,10 @@ class WalletPopup {
         });
 
         // Copy button
-        const copyButton = this.popupElement.querySelector('.copy-button');
+        const copyButton = this.popupElement.querySelector('.copy-icon-button');
         copyButton?.addEventListener('click', (e) => {
             e.stopPropagation();
-            this.copyAddress(e.target.closest('.copy-button').dataset.address);
+            this.copyAddress(e.currentTarget.dataset.address);
         });
 
         // Disconnect button
@@ -270,19 +259,21 @@ class WalletPopup {
     }
 
     showCopyFeedback() {
-        const copyButton = this.popupElement?.querySelector('.copy-button');
-        if (copyButton) {
-            const icon = copyButton.querySelector('.material-icons');
-            const originalText = icon.textContent;
-            
-            icon.textContent = 'check';
-            copyButton.style.color = 'var(--success-main)';
-            
-            setTimeout(() => {
-                icon.textContent = originalText;
-                copyButton.style.color = '';
-            }, 1500);
-        }
+        const copyButton = this.popupElement?.querySelector('.copy-icon-button');
+        if (!copyButton) return;
+
+        const icon = copyButton.querySelector('.material-icons');
+        if (!icon) return;
+
+        const originalText = icon.textContent;
+
+        icon.textContent = 'check';
+        copyButton.classList.add('success');
+
+        setTimeout(() => {
+            icon.textContent = originalText;
+            copyButton.classList.remove('success');
+        }, 1500);
     }
 
     async disconnectWallet() {

--- a/js/components/wallet-popup.js
+++ b/js/components/wallet-popup.js
@@ -131,7 +131,6 @@ class WalletPopup {
 
     createPopupHTML(walletData) {
         const shortAddress = this.formatAddress(walletData.address);
-        const balance = this.getWalletBalance();
 
         return `
             <div class="wallet-popup">
@@ -140,11 +139,6 @@ class WalletPopup {
                     <button class="wallet-popup-close" title="Close">
                         <span class="material-icons">close</span>
                     </button>
-
-                    <!-- Wallet Balance -->
-                    <div class="wallet-balance">
-                        <span class="balance-amount">${balance}</span>
-                    </div>
 
                     <!-- Wallet Address -->
                     <div class="wallet-address">
@@ -321,32 +315,6 @@ class WalletPopup {
         this.popupElement.style.transform = 'translateY(-10px) scale(0.95)';
         
         setTimeout(callback, 150);
-    }
-
-    getWalletBalance() {
-        try {
-            // Try to get balance from wallet manager or state manager
-            if (window.walletManager && window.walletManager.getBalance) {
-                const balance = window.walletManager.getBalance();
-                if (balance) {
-                    return `${parseFloat(balance).toFixed(2)} POL`;
-                }
-            }
-
-            // Try to get from state manager
-            if (window.stateManager && window.stateManager.getState) {
-                const state = window.stateManager.getState('wallet.balance');
-                if (state) {
-                    return `${parseFloat(state).toFixed(2)} POL`;
-                }
-            }
-
-            // Default fallback
-            return '4.86 POL';
-        } catch (error) {
-            console.warn('Error getting wallet balance:', error);
-            return '4.86 POL';
-        }
     }
 
     formatAddress(address) {


### PR DESCRIPTION
- Removed the balance display and the unused balance-fetch helper so the popup now focuses purely on address actions.
- Simplified the markup by deleting the avatar block and replacing the full-width copy CTA with a compact icon beside the shortened address, keeping the success check animation.
- Restyled the popup shell and disconnect button to rely on shared design tokens, adding a subtle error-tinted pill CTA with centered layout and consistent spacing.

<img width="348" height="176" alt="image" src="https://github.com/user-attachments/assets/d2320fbb-a86b-4b36-9ccb-400bd3bc9720" />

