### PR TITLE
remove extra wallet notification

### DIFF
--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -474,11 +474,6 @@ class MasterInitializer {
                 });
 
                 try {
-                    // Show connecting notification
-                    if (window.notificationManager) {
-                        window.notificationManager.info('Please approve the connection in MetaMask');
-                    }
-
                     // Use safe MetaMask connection with circuit breaker protection
                     await window.walletManager.connectMetaMask();
 


### PR DESCRIPTION
Removes unecessary `Please approve the connection in MetaMask` notification when connecting the wallet