### PR TITLE
Remove state manager references

### DIFF
--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -4875,22 +4875,6 @@ class ContractManager {
 
                 this.log(`🎉 Transaction ${operationName} completed successfully in block ${result.blockNumber}`);
 
-                // Display success notification
-                if (window.stateManager) {
-                    const notifications = window.stateManager.get('ui.notifications') || [];
-                    window.stateManager.set('ui.notifications', [
-                        ...notifications,
-                        {
-                            id: `tx_${Date.now()}`,
-                            type: 'success',
-                            title: 'Transaction Successful',
-                            message: `${operationName} completed successfully`,
-                            timestamp: Date.now(),
-                            metadata: { transactionHash: result.transactionHash }
-                        }
-                    ]);
-                }
-
                 return result;
             } catch (error) {
                 this.log(`❌ Transaction ${operationName} failed:`, error.message);
@@ -4944,22 +4928,6 @@ class ContractManager {
                     if (window.notificationManager) {
                         window.notificationManager.error(userMessage);
                     }
-                }
-
-                // Display user-friendly error notification
-                if (window.stateManager) {
-                    const notifications = window.stateManager.get('ui.notifications') || [];
-                    window.stateManager.set('ui.notifications', [
-                        ...notifications,
-                        {
-                            id: `error_${Date.now()}`,
-                            type: 'error',
-                            title: 'Transaction Failed',
-                            message: userMessage,
-                            timestamp: Date.now(),
-                            metadata: { errorType, operationName, transactionHash: error.transactionHash || null }
-                        }
-                    ]);
                 }
 
                 // Try fallback provider for network errors and RPC errors

--- a/js/core/error-handler.js
+++ b/js/core/error-handler.js
@@ -539,12 +539,6 @@ class ErrorHandler {
                 notification.technicalMessage = processedError.technicalMessage;
             }
 
-            // Add to state manager notifications
-            if (window.stateManager) {
-                const currentNotifications = window.stateManager.get('ui.notifications') || [];
-                window.stateManager.set('ui.notifications', [...currentNotifications, notification]);
-            }
-
             this.log('Error displayed to user:', processedError.id);
             return notification;
         } catch (displayError) {


### PR DESCRIPTION
State manager was deprecated in a previous PR. This removes left over references to it. This functionality is replaced by the notification manager