### PR TITLE
Bubble up approve lp errors

### DIFF
--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -766,6 +766,10 @@ class StakingModalNew {
                 this.setActionPhase('approve', 'processing');
             }
 
+            if (!approveTx.success) {
+                throw new Error(approveTx.error || 'Approval transaction failed');
+            }
+
             // Update state and UI
             this.isApproved = true;
             this.needsApproval = false;


### PR DESCRIPTION
Fixes a bug with allowance approval transcation where errors would get hidden and it would incorrectly continue to the staking transaction. Now the errors get thrown and displayed as error toasts.