### PR TITLE
Refactor homepage styles by extracting inline CSS to external stylesheet

### DIFF
--- a/css/home-page/home-page.css
+++ b/css/home-page/home-page.css
@@ -1,0 +1,933 @@
+/**
+ * Homepage styles extracted from inline styles in index.html
+ * Maintains existing look and feel while moving presentation to external CSS.
+ */
+
+:root {
+
+    --primary-main: #1976d2;
+    --primary-hover: #1565c0;
+    --primary-light: #e3f2fd;
+    --secondary-main: #dc004e;
+    --secondary-hover: #c5003e;
+
+    /* Status colors */
+    --success-main: #4caf50;
+    --error-main: #f44336;
+    --warning-main: #ff9800;
+    --info-main: #2196f3;
+
+    /* Theme-specific variables are defined in [data-theme] selectors below */
+
+    /* Shadows */
+    --shadow-1: 0px 2px 1px -1px rgba(0,0,0,0.2), 0px 1px 1px 0px rgba(0,0,0,0.14), 0px 1px 3px 0px rgba(0,0,0,0.12);
+    --shadow-4: 0px 2px 4px -1px rgba(0,0,0,0.2), 0px 4px 5px 0px rgba(0,0,0,0.14), 0px 1px 10px 0px rgba(0,0,0,0.12);
+    --shadow-8: 0px 5px 5px -3px rgba(0,0,0,0.2), 0px 8px 10px 1px rgba(0,0,0,0.14), 0px 3px 14px 2px rgba(0,0,0,0.12);
+
+    
+    /* Typography */
+    --font-family: "Exo", "Helvetica", "Arial", sans-serif;
+    --font-size: 15px;
+    
+    /* Spacing */
+    --spacing-1: 8px;
+    --spacing-2: 16px;
+    --spacing-3: 24px;
+    --spacing-4: 32px;
+    --spacing-6: 48px;
+    
+    /* Border radius */
+    --border-radius: 4px;
+    --border-radius-lg: 8px;
+}
+
+/* Light theme - Higher specificity to override external CSS */
+html[data-theme="light"] {
+    --background-default: #ffffff !important;
+    --background-paper: #ffffff !important;
+    --surface-hover: rgba(0, 0, 0, 0.04) !important;
+    --action-selected: rgba(25, 118, 210, 0.08) !important;
+    --action-hover: rgba(0, 0, 0, 0.04) !important;
+    
+    --text-primary: rgba(0, 0, 0, 0.87) !important;
+    --text-secondary: rgba(0, 0, 0, 0.6) !important;
+    --text-disabled: rgba(0, 0, 0, 0.38) !important;
+    
+    --divider: rgba(0, 0, 0, 0.12) !important;
+}
+
+/* Dark theme - Higher specificity to override external CSS */
+html[data-theme="dark"] {
+    --background-default: #121212 !important;
+    --background-paper: #1e1e1e !important;
+    --surface-hover: rgba(255, 255, 255, 0.08) !important;
+    --action-selected: rgba(144, 202, 249, 0.16) !important;
+    --action-hover: rgba(255, 255, 255, 0.08) !important;
+    
+    --text-primary: #ffffff !important;
+    --text-secondary: rgba(255, 255, 255, 0.7) !important;
+    --text-disabled: rgba(255, 255, 255, 0.5) !important;
+    
+    --divider: rgba(255, 255, 255, 0.12) !important;
+}
+
+/* Reset and base styles */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: var(--font-family);
+    font-size: var(--font-size);
+    line-height: 1.5;
+    color: var(--text-primary);
+    background-color: var(--background-default);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+/* Main content */
+.main-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: var(--spacing-6) var(--spacing-3);
+}
+
+/* Page title */
+.page-title {
+    text-align: center;
+    margin-bottom: var(--spacing-4);
+}
+
+.page-title h1 {
+    font-size: 48px;
+    font-weight: 700;
+    margin-bottom: 0;
+    color: var(--text-primary);
+}
+
+.page-title-header {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-2);
+    margin-bottom: var(--spacing-2);
+}
+
+/* Refresh button */
+.refresh-button {
+    background: transparent;
+    border: none;
+    color: var(--primary-main);
+    cursor: pointer;
+    width: 40px;
+    height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    transition: background 0.2s, transform 0.2s;
+    transform-origin: center;
+}
+
+.refresh-button:hover {
+    background: var(--action-hover);
+    transform: rotate(180deg);
+}
+
+/* Table container */
+.table-container {
+    width: 100%;
+    background: var(--background-paper);
+    border-radius: 12px;
+    box-shadow: var(--shadow-4);
+    overflow: hidden;
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.table th,
+.table td {
+    padding: var(--spacing-2);
+    text-align: left;
+    border-bottom: 1px solid var(--divider);
+}
+
+.table th {
+    background: var(--background-default);
+    font-weight: 600;
+    color: var(--text-primary);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.table th .material-icons {
+    vertical-align: middle;
+    margin-right: var(--spacing-1);
+    color: var(--primary-main);
+}
+
+.table tbody tr:hover {
+    background: var(--surface-hover);
+}
+
+.table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+/* Button styles matching MUI */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-1);
+    padding: var(--spacing-1) var(--spacing-2);
+    border: none;
+    border-radius: var(--border-radius);
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    transition: all 0.2s;
+    font-size: 14px;
+    min-width: 64px;
+    justify-content: center;
+}
+
+.btn-primary {
+    background: var(--primary-main);
+    color: white;
+}
+
+.btn-primary:hover {
+    background: var(--primary-hover);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-4);
+}
+
+.btn-secondary {
+    background: var(--secondary-main);
+    color: white;
+}
+
+.btn-secondary:hover {
+    background: var(--secondary-hover);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-4);
+}
+
+.btn-text {
+    background: transparent;
+    color: var(--primary-main);
+    font-weight: bold;
+}
+
+.btn-text:hover {
+    background: var(--action-hover);
+}
+
+.btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none !important;
+    box-shadow: none !important;
+}
+
+/* Small button variant */
+.btn-small {
+    padding: 6px 12px;
+    font-size: 13px;
+    min-width: 80px;
+}
+
+/* Share and Earnings buttons in table */
+.btn-share,
+.btn-earnings {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.btn-share .material-icons,
+.btn-earnings .material-icons {
+    font-size: 16px;
+}
+
+/* Chip styles matching MUI */
+.chip {
+    align-items: center;
+    padding: 4px 12px;
+    border-radius: 16px;
+    font-size: 12px;
+    font-weight: 600;
+    border: 1px solid;
+}
+
+.chip-primary {
+    background: var(--primary-light);
+    color: var(--primary-main);
+    border-color: var(--primary-main);
+}
+
+.chip-secondary {
+    background: rgba(220, 0, 78, 0.1);
+    color: var(--secondary-main);
+    border-color: var(--secondary-main);
+}
+
+/* Success color for APR */
+.success-text {
+    color: var(--success-main);
+    font-weight: bold;
+}
+
+/* Loading skeleton */
+.skeleton {
+    background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+    background-size: 200% 100%;
+    animation: loading 1.5s infinite;
+    border-radius: var(--border-radius);
+}
+
+.skeleton-line {
+    height: 20px;
+}
+
+.skeleton-width-60 { width: 60px; }
+.skeleton-width-80 { width: 80px; }
+.skeleton-width-100 { width: 100px; }
+.skeleton-width-120 { width: 120px; }
+
+@keyframes loading {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+}
+
+[data-theme="dark"] .skeleton {
+    background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+    background-size: 200% 100%;
+}
+
+/* Footer */
+.footer {
+    margin-top: auto;
+    padding: var(--spacing-3) 0;
+    border-top: 1px solid var(--divider);
+    background: var(--background-paper) !important;
+    backdrop-filter: blur(8px);
+}
+
+.footer-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--spacing-2);
+}
+
+.footer-text {
+    color: var(--text-secondary);
+    font-weight: 500;
+    letter-spacing: 0.5px;
+}
+
+.social-links {
+    display: flex;
+    gap: var(--spacing-2);
+}
+
+.social-link {
+    color: var(--text-secondary);
+    text-decoration: none;
+    transition: transform 0.2s;
+}
+
+.social-link:hover {
+    transform: translateY(-2px);
+    color: var(--primary-main);
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .logo-text {
+        display: none;
+    }
+    
+    .version-badge {
+        font-size: 10px;
+        margin-left: 8px;
+        padding: 2px 6px;
+    }
+
+    .nav-section {
+        gap: var(--spacing-1);
+    }
+
+    .nav-button span:not(.material-icons) {
+        display: none;
+    }
+
+    .page-title h1 {
+        font-size: 32px;
+    }
+
+    .page-title-header {
+        flex-direction: column;
+        gap: var(--spacing-1);
+    }
+
+    .table th,
+    .table td {
+        padding: 12px 8px;
+        font-size: 14px;
+    }
+
+    .footer-content {
+        flex-direction: column;
+        text-align: center;
+    }
+}
+
+@media (max-width: 480px) {
+    .container-lg,
+    .container-xl {
+        padding: 0 var(--spacing-2);
+    }
+
+    .main-content {
+        padding: var(--spacing-3) var(--spacing-2);
+    }
+
+    .table-container {
+        overflow-x: auto;
+    }
+
+    .table {
+        min-width: 600px;
+    }
+}
+
+/* Utility Classes */
+.hidden {
+    display: none !important;
+}
+
+.loading {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.text-center {
+    text-align: center;
+}
+
+.mb-4 {
+    margin-bottom: var(--spacing-4);
+}
+
+.mt-4 {
+    margin-top: var(--spacing-4);
+}
+
+.flex {
+    display: flex;
+}
+
+.items-center {
+    align-items: center;
+}
+
+.justify-center {
+    justify-content: center;
+}
+
+.gap-2 {
+    gap: var(--spacing-2);
+}
+
+.network-indicator-home.has-permission {
+    background: rgba(76, 175, 80, 0.1);
+    border: 1px solid rgba(76, 175, 80, 0.3);
+}
+
+.network-indicator-home.missing-permission {
+    background: rgba(244, 67, 54, 0.1);
+    border: 1px solid rgba(244, 67, 54, 0.3);
+}
+
+.network-status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.network-status-dot.green {
+    background-color: #4caf50;
+    box-shadow: 0 0 8px rgba(76, 175, 80, 0.6);
+}
+
+.network-status-dot.red {
+    background-color: #f44336;
+    box-shadow: 0 0 8px rgba(244, 67, 54, 0.6);
+    animation: pulse-red 2s infinite;
+}
+
+@keyframes pulse-red {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+}
+
+/**
+ * Home page specific styles
+ * Consolidated from inline rules in index.html and component templates
+ */
+
+body.homepage {
+    font-family: var(--font-family, "Exo", "Helvetica", "Arial", sans-serif);
+    font-size: var(--font-size, 15px);
+    line-height: 1.5;
+    color: var(--text-primary, rgba(0, 0, 0, 0.87));
+    background-color: var(--background-default, #ffffff);
+    background-image: none;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+.homepage .hidden {
+    display: none !important;
+}
+
+.homepage-main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: var(--spacing-6, 48px) var(--spacing-3, 24px);
+    width: 100%;
+}
+
+.homepage-main .container-xl {
+    width: 100%;
+}
+
+#content-container {
+    width: 100%;
+    max-width: 908px;
+    margin: 0 auto;
+}
+
+.homepage-main .page-title {
+    text-align: center;
+    margin-bottom: var(--spacing-4, 32px);
+}
+
+.homepage-main .page-title h1 {
+    font-size: 3rem;
+    font-weight: 700;
+    margin: 0;
+    color: var(--text-primary, rgba(0, 0, 0, 0.87));
+}
+
+.page-title-header {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-2, 16px);
+    margin-bottom: var(--spacing-2, 16px);
+}
+
+.refresh-button {
+    background: transparent;
+    border: none;
+    color: var(--primary-main, #1976d2);
+    cursor: pointer;
+    width: 40px;
+    height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    transition: background 0.2s ease, transform 0.2s ease;
+    transform-origin: center;
+}
+
+.refresh-button:hover {
+    background: var(--action-hover, rgba(0, 0, 0, 0.04));
+    transform: rotate(180deg);
+}
+
+.refresh-button:disabled {
+    color: var(--text-disabled, rgba(0, 0, 0, 0.38));
+    cursor: not-allowed;
+    transform: none;
+}
+
+.homepage-main .table-container {
+    width: 100%;
+    max-width: 1200px;
+    background: var(--background-paper, #ffffff);
+    border-radius: 12px;
+    box-shadow: var(--shadow-4, 0px 2px 4px -1px rgba(0,0,0,0.2), 0px 4px 5px 0px rgba(0,0,0,0.14), 0px 1px 10px 0px rgba(0,0,0,0.12));
+    overflow: hidden;
+    margin: 0 auto;
+}
+
+.homepage-main .table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.homepage-main .table th,
+.homepage-main .table td {
+    padding: var(--spacing-2, 16px);
+    text-align: left;
+    border-bottom: 1px solid var(--divider, rgba(0, 0, 0, 0.12));
+}
+
+.homepage-main .table th {
+    background: var(--background-default, #ffffff);
+    font-weight: 600;
+    color: var(--text-primary, rgba(0, 0, 0, 0.87));
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.homepage-main .table th .material-icons {
+    vertical-align: middle;
+    margin-right: var(--spacing-1, 8px);
+    color: var(--primary-main, #1976d2);
+    font-size: 20px;
+}
+
+.homepage-main .table tbody tr:hover {
+    background: var(--surface-hover, rgba(0, 0, 0, 0.04));
+}
+
+.homepage-main .table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.pair-row {
+    cursor: pointer;
+}
+
+.pair-row .platform-label {
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+
+.pair-row .apr-value {
+    color: var(--success-main, #4caf50);
+    font-weight: 700;
+}
+
+.pair-row .weight-value,
+.pair-row .tvl-value {
+    font-weight: 600;
+    color: var(--text-primary, rgba(0, 0, 0, 0.87));
+}
+
+.btn-small {
+    padding: 6px 12px;
+    font-size: 13px;
+    min-width: 80px;
+}
+
+.btn-share,
+.btn-earnings {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.btn-share {
+    min-width: 100px;
+}
+
+.btn-earnings {
+    min-width: 120px;
+}
+
+.btn-share .material-icons,
+.btn-earnings .material-icons {
+    font-size: 16px;
+}
+
+.chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 12px;
+    border-radius: 16px;
+    font-size: 12px;
+    font-weight: 600;
+    border: 1px solid currentColor;
+}
+
+.chip-primary {
+    background: var(--primary-light, #e3f2fd);
+    color: var(--primary-main, #1976d2);
+}
+
+.chip-secondary {
+    background: rgba(220, 0, 78, 0.1);
+    color: var(--secondary-main, #dc004e);
+    border-color: var(--secondary-main, #dc004e);
+}
+
+.skeleton {
+    background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+    background-size: 200% 100%;
+    animation: homepage-loading 1.5s infinite;
+    border-radius: var(--border-radius, 4px);
+}
+
+[data-theme="dark"] .skeleton {
+    background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+}
+
+.skeleton-line {
+    height: 20px;
+}
+
+.skeleton-width-60 { width: 60px; }
+.skeleton-width-80 { width: 80px; }
+.skeleton-width-100 { width: 100px; }
+.skeleton-width-120 { width: 120px; }
+
+.data-error {
+    text-align: center;
+    padding: 48px;
+    color: var(--error-main, #f44336);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-2, 16px);
+}
+
+.data-error__icon {
+    font-size: 48px;
+}
+
+.data-error__message {
+    color: var(--text-secondary, rgba(0, 0, 0, 0.6));
+    margin: 0;
+}
+
+.table-empty {
+    text-align: center;
+    padding: 48px 24px;
+    color: var(--text-secondary, rgba(0, 0, 0, 0.6));
+}
+
+.table-empty__content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+}
+
+.table-empty__icon {
+    font-size: 48px;
+    color: var(--text-secondary, rgba(0, 0, 0, 0.6));
+    opacity: 0.5;
+}
+
+.table-empty__title {
+    font-size: 16px;
+    font-weight: 500;
+    margin: 0;
+    color: var(--text-primary, rgba(0, 0, 0, 0.87));
+}
+
+.table-empty__description {
+    font-size: 14px;
+    margin: 0;
+    color: var(--text-secondary, rgba(0, 0, 0, 0.6));
+}
+
+.homepage .footer {
+    margin-top: auto;
+    padding: 6px 0;
+    border-top: 1px solid var(--divider, rgba(0, 0, 0, 0.12));
+    background: var(--background-paper, #ffffff);
+}
+
+.homepage .footer-inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 0 16px;
+}
+
+.homepage .footer-text {
+    color: var(--text-secondary, rgba(0, 0, 0, 0.6));
+    font-weight: 500;
+    letter-spacing: 0.4px;
+    font-size: 12px;
+}
+
+.homepage .footer-links {
+    display: flex;
+    gap: 8px;
+}
+
+.homepage .footer-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    color: var(--text-secondary, rgba(0, 0, 0, 0.6));
+    transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.homepage .footer-icon .material-icons {
+    font-size: 18px;
+    line-height: 1;
+}
+
+.homepage .footer-icon:hover {
+    transform: translateY(-1px);
+    color: var(--primary-main, #1976d2);
+}
+
+.nav-button--hidden {
+    display: none;
+}
+
+.homepage .loading {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.network-indicator-home.has-permission {
+    background: rgba(76, 175, 80, 0.1);
+    border: 1px solid rgba(76, 175, 80, 0.3);
+}
+
+.network-indicator-home.missing-permission {
+    background: rgba(244, 67, 54, 0.1);
+    border: 1px solid rgba(244, 67, 54, 0.3);
+}
+
+.network-status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.network-status-dot.green {
+    background-color: #4caf50;
+    box-shadow: 0 0 8px rgba(76, 175, 80, 0.6);
+}
+
+.network-status-dot.red {
+    background-color: #f44336;
+    box-shadow: 0 0 8px rgba(244, 67, 54, 0.6);
+    animation: homepage-pulse-red 2s infinite;
+}
+
+@keyframes homepage-loading {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+}
+
+@keyframes homepage-pulse-red {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+}
+
+@media (max-width: 768px) {
+    .logo-text {
+        display: none;
+    }
+
+    .version-badge {
+        font-size: 10px;
+        margin-left: 8px;
+        padding: 2px 6px;
+    }
+
+    .nav-section {
+        gap: var(--spacing-1, 8px);
+    }
+
+    .nav-button span:not(.material-icons) {
+        display: none;
+    }
+
+    .homepage-main {
+        padding: var(--spacing-4, 32px) var(--spacing-2, 16px);
+    }
+
+    .homepage-main .page-title h1 {
+        font-size: 2rem;
+    }
+
+    .page-title-header {
+        flex-direction: column;
+        gap: var(--spacing-1, 8px);
+    }
+
+    .homepage-main .table th,
+    .homepage-main .table td {
+        padding: 12px 8px;
+        font-size: 14px;
+    }
+
+    .homepage .footer-content {
+        flex-direction: column;
+        text-align: center;
+    }
+}
+
+@media (max-width: 480px) {
+    .container-lg,
+    .container-xl {
+        padding: 0 var(--spacing-2, 16px);
+    }
+
+    .homepage-main {
+        padding: var(--spacing-3, 24px) var(--spacing-2, 16px);
+    }
+
+    .homepage-main .table-container {
+        overflow-x: auto;
+    }
+
+    .homepage-main .table {
+        min-width: 600px;
+    }
+}
+
+@media (max-width: 320px) {
+    .homepage-main .page-title h1 {
+        font-size: 1.75rem;
+    }
+}
+

--- a/index.html
+++ b/index.html
@@ -20,487 +20,7 @@
     <link rel="stylesheet" href="css/day10-enhancements.css">
     <link rel="stylesheet" href="css/network-indicator-selector.css">
     <link rel="stylesheet" href="css/theme-toggle.css">
-    <style>
-        :root {
-
-            --primary-main: #1976d2;
-            --primary-hover: #1565c0;
-            --primary-light: #e3f2fd;
-            --secondary-main: #dc004e;
-            --secondary-hover: #c5003e;
-
-            /* Status colors */
-            --success-main: #4caf50;
-            --error-main: #f44336;
-            --warning-main: #ff9800;
-            --info-main: #2196f3;
-
-            /* Theme-specific variables are defined in [data-theme] selectors below */
-
-            /* Shadows */
-            --shadow-1: 0px 2px 1px -1px rgba(0,0,0,0.2), 0px 1px 1px 0px rgba(0,0,0,0.14), 0px 1px 3px 0px rgba(0,0,0,0.12);
-            --shadow-4: 0px 2px 4px -1px rgba(0,0,0,0.2), 0px 4px 5px 0px rgba(0,0,0,0.14), 0px 1px 10px 0px rgba(0,0,0,0.12);
-            --shadow-8: 0px 5px 5px -3px rgba(0,0,0,0.2), 0px 8px 10px 1px rgba(0,0,0,0.14), 0px 3px 14px 2px rgba(0,0,0,0.12);
-
-            
-            /* Typography */
-            --font-family: "Exo", "Helvetica", "Arial", sans-serif;
-            --font-size: 15px;
-            
-            /* Spacing */
-            --spacing-1: 8px;
-            --spacing-2: 16px;
-            --spacing-3: 24px;
-            --spacing-4: 32px;
-            --spacing-6: 48px;
-            
-            /* Border radius */
-            --border-radius: 4px;
-            --border-radius-lg: 8px;
-        }
-        
-        /* Light theme - Higher specificity to override external CSS */
-        html[data-theme="light"] {
-            --background-default: #ffffff !important;
-            --background-paper: #ffffff !important;
-            --surface-hover: rgba(0, 0, 0, 0.04) !important;
-            --action-selected: rgba(25, 118, 210, 0.08) !important;
-            --action-hover: rgba(0, 0, 0, 0.04) !important;
-            
-            --text-primary: rgba(0, 0, 0, 0.87) !important;
-            --text-secondary: rgba(0, 0, 0, 0.6) !important;
-            --text-disabled: rgba(0, 0, 0, 0.38) !important;
-            
-            --divider: rgba(0, 0, 0, 0.12) !important;
-        }
-
-        /* Dark theme - Higher specificity to override external CSS */
-        html[data-theme="dark"] {
-            --background-default: #121212 !important;
-            --background-paper: #1e1e1e !important;
-            --surface-hover: rgba(255, 255, 255, 0.08) !important;
-            --action-selected: rgba(144, 202, 249, 0.16) !important;
-            --action-hover: rgba(255, 255, 255, 0.08) !important;
-            
-            --text-primary: #ffffff !important;
-            --text-secondary: rgba(255, 255, 255, 0.7) !important;
-            --text-disabled: rgba(255, 255, 255, 0.5) !important;
-            
-            --divider: rgba(255, 255, 255, 0.12) !important;
-        }
-        
-        /* Reset and base styles */
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
-        body {
-            font-family: var(--font-family);
-            font-size: var(--font-size);
-            line-height: 1.5;
-            color: var(--text-primary);
-            background-color: var(--background-default);
-            min-height: 100vh;
-            display: flex;
-            flex-direction: column;
-            font-synthesis: none;
-            text-rendering: optimizeLegibility;
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
-        }
-        
-        /* Main content */
-        .main-content {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            padding: var(--spacing-6) var(--spacing-3);
-        }
-        
-        /* Page title */
-        .page-title {
-            text-align: center;
-            margin-bottom: var(--spacing-4);
-        }
-        
-        .page-title h1 {
-            font-size: 48px;
-            font-weight: 700;
-            margin-bottom: 0;
-            color: var(--text-primary);
-        }
-
-        .page-title-header {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            gap: var(--spacing-2);
-            margin-bottom: var(--spacing-2);
-        }
-        
-        /* Refresh button */
-        .refresh-button {
-            background: transparent;
-            border: none;
-            color: var(--primary-main);
-            cursor: pointer;
-            width: 40px;
-            height: 40px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            border-radius: 50%;
-            transition: background 0.2s, transform 0.2s;
-            transform-origin: center;
-        }
-        
-        .refresh-button:hover {
-            background: var(--action-hover);
-            transform: rotate(180deg);
-        }
-        
-        /* Table container */
-        .table-container {
-            width: 100%;
-            background: var(--background-paper);
-            border-radius: 12px;
-            box-shadow: var(--shadow-4);
-            overflow: hidden;
-        }
-        
-        .table {
-            width: 100%;
-            border-collapse: collapse;
-        }
-        
-        .table th,
-        .table td {
-            padding: var(--spacing-2);
-            text-align: left;
-            border-bottom: 1px solid var(--divider);
-        }
-        
-        .table th {
-            background: var(--background-default);
-            font-weight: 600;
-            color: var(--text-primary);
-            position: sticky;
-            top: 0;
-            z-index: 10;
-        }
-        
-        .table th .material-icons {
-            vertical-align: middle;
-            margin-right: var(--spacing-1);
-            color: var(--primary-main);
-        }
-        
-        .table tbody tr:hover {
-            background: var(--surface-hover);
-        }
-        
-        .table tbody tr:last-child td {
-            border-bottom: none;
-        }
-
-        /* Button styles matching MUI */
-        .btn {
-            display: inline-flex;
-            align-items: center;
-            gap: var(--spacing-1);
-            padding: var(--spacing-1) var(--spacing-2);
-            border: none;
-            border-radius: var(--border-radius);
-            font-weight: 600;
-            text-decoration: none;
-            cursor: pointer;
-            transition: all 0.2s;
-            font-size: 14px;
-            min-width: 64px;
-            justify-content: center;
-        }
-
-        .btn-primary {
-            background: var(--primary-main);
-            color: white;
-        }
-
-        .btn-primary:hover {
-            background: var(--primary-hover);
-            transform: translateY(-1px);
-            box-shadow: var(--shadow-4);
-        }
-
-        .btn-secondary {
-            background: var(--secondary-main);
-            color: white;
-        }
-
-        .btn-secondary:hover {
-            background: var(--secondary-hover);
-            transform: translateY(-1px);
-            box-shadow: var(--shadow-4);
-        }
-
-        .btn-text {
-            background: transparent;
-            color: var(--primary-main);
-            font-weight: bold;
-        }
-
-        .btn-text:hover {
-            background: var(--action-hover);
-        }
-
-        .btn:disabled {
-            opacity: 0.6;
-            cursor: not-allowed;
-            transform: none !important;
-            box-shadow: none !important;
-        }
-
-        /* Small button variant */
-        .btn-small {
-            padding: 6px 12px;
-            font-size: 13px;
-            min-width: 80px;
-        }
-
-        /* Share and Earnings buttons in table */
-        .btn-share,
-        .btn-earnings {
-            display: inline-flex;
-            align-items: center;
-            gap: 6px;
-            font-weight: 600;
-            white-space: nowrap;
-        }
-
-        .btn-share .material-icons,
-        .btn-earnings .material-icons {
-            font-size: 16px;
-        }
-
-        /* Chip styles matching MUI */
-        .chip {
-            align-items: center;
-            padding: 4px 12px;
-            border-radius: 16px;
-            font-size: 12px;
-            font-weight: 600;
-            border: 1px solid;
-        }
-
-        .chip-primary {
-            background: var(--primary-light);
-            color: var(--primary-main);
-            border-color: var(--primary-main);
-        }
-
-        .chip-secondary {
-            background: rgba(220, 0, 78, 0.1);
-            color: var(--secondary-main);
-            border-color: var(--secondary-main);
-        }
-
-        /* Success color for APR */
-        .success-text {
-            color: var(--success-main);
-            font-weight: bold;
-        }
-
-        /* Loading skeleton */
-        .skeleton {
-            background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
-            background-size: 200% 100%;
-            animation: loading 1.5s infinite;
-            border-radius: var(--border-radius);
-        }
-
-        @keyframes loading {
-            0% { background-position: 200% 0; }
-            100% { background-position: -200% 0; }
-        }
-
-        [data-theme="dark"] .skeleton {
-            background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
-            background-size: 200% 100%;
-        }
-
-        /* Footer */
-        .footer {
-            margin-top: auto;
-            padding: var(--spacing-3) 0;
-            border-top: 1px solid var(--divider);
-            background: var(--background-paper) !important;
-            backdrop-filter: blur(8px);
-        }
-
-        .footer-content {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            flex-wrap: wrap;
-            gap: var(--spacing-2);
-        }
-
-        .footer-text {
-            color: var(--text-secondary);
-            font-weight: 500;
-            letter-spacing: 0.5px;
-        }
-
-        .social-links {
-            display: flex;
-            gap: var(--spacing-2);
-        }
-
-        .social-link {
-            color: var(--text-secondary);
-            text-decoration: none;
-            transition: transform 0.2s;
-        }
-
-        .social-link:hover {
-            transform: translateY(-2px);
-            color: var(--primary-main);
-        }
-
-        /* Responsive Design */
-        @media (max-width: 768px) {
-            .logo-text {
-                display: none;
-            }
-            
-            .version-badge {
-                font-size: 10px;
-                margin-left: 8px;
-                padding: 2px 6px;
-            }
-
-            .nav-section {
-                gap: var(--spacing-1);
-            }
-
-            .nav-button span:not(.material-icons) {
-                display: none;
-            }
-
-            .page-title h1 {
-                font-size: 32px;
-            }
-
-            .page-title-header {
-                flex-direction: column;
-                gap: var(--spacing-1);
-            }
-
-            .table th,
-            .table td {
-                padding: 12px 8px;
-                font-size: 14px;
-            }
-
-            .footer-content {
-                flex-direction: column;
-                text-align: center;
-            }
-        }
-
-        @media (max-width: 480px) {
-            .container-lg,
-            .container-xl {
-                padding: 0 var(--spacing-2);
-            }
-
-            .main-content {
-                padding: var(--spacing-3) var(--spacing-2);
-            }
-
-            .table-container {
-                overflow-x: auto;
-            }
-
-            .table {
-                min-width: 600px;
-            }
-        }
-
-        /* Utility Classes */
-        .hidden {
-            display: none !important;
-        }
-
-        .loading {
-            opacity: 0.6;
-            pointer-events: none;
-        }
-
-        .text-center {
-            text-align: center;
-        }
-
-        .mb-4 {
-            margin-bottom: var(--spacing-4);
-        }
-
-        .mt-4 {
-            margin-top: var(--spacing-4);
-        }
-
-        .flex {
-            display: flex;
-        }
-
-        .items-center {
-            align-items: center;
-        }
-
-        .justify-center {
-            justify-content: center;
-        }
-
-        .gap-2 {
-            gap: var(--spacing-2);
-        }
-
-        .network-indicator-home.has-permission {
-            background: rgba(76, 175, 80, 0.1);
-            border: 1px solid rgba(76, 175, 80, 0.3);
-        }
-
-        .network-indicator-home.missing-permission {
-            background: rgba(244, 67, 54, 0.1);
-            border: 1px solid rgba(244, 67, 54, 0.3);
-        }
-
-        .network-status-dot {
-            width: 8px;
-            height: 8px;
-            border-radius: 50%;
-            display: inline-block;
-        }
-
-        .network-status-dot.green {
-            background-color: #4caf50;
-            box-shadow: 0 0 8px rgba(76, 175, 80, 0.6);
-        }
-
-        .network-status-dot.red {
-            background-color: #f44336;
-            box-shadow: 0 0 8px rgba(244, 67, 54, 0.6);
-            animation: pulse-red 2s infinite;
-        }
-
-        @keyframes pulse-red {
-            0%, 100% { opacity: 1; }
-            50% { opacity: 0.5; }
-        }
-
-    </style>
+    <link rel="stylesheet" href="css/home-page/home-page.css">
 </head>
 <body>
 
@@ -516,13 +36,13 @@
 
 
                 <nav class="nav-section" role="navigation" aria-label="Main navigation">
-                    <a href="admin/" id="admin-panel-link" class="nav-button" style="display: none;">
+                    <a href="admin/" id="admin-panel-link" class="nav-button hidden">
                         <span class="material-icons" aria-hidden="true">admin_panel_settings</span>
                         <span>Admin Panel</span>
                     </a>
 
                     <!-- Network indicator -->
-                    <div id="network-indicator-home" class="network-indicator-home" style="display:none;">
+                    <div id="network-indicator-home" class="network-indicator-home hidden">
                         <!-- Populated by JavaScript -->
                     </div>
 
@@ -577,9 +97,33 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <tr><td><div class="skeleton" style="height: 20px; width: 120px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 60px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 100px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 120px;"></div></td></tr>
-                            <tr><td><div class="skeleton" style="height: 20px; width: 120px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 60px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 100px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 120px;"></div></td></tr>
-                            <tr><td><div class="skeleton" style="height: 20px; width: 120px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 60px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 100px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 120px;"></div></td></tr>
+                            <tr>
+                                <td><div class="skeleton skeleton-line skeleton-width-120"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-80"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-60"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-80"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-100"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-80"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-120"></div></td>
+                            </tr>
+                            <tr>
+                                <td><div class="skeleton skeleton-line skeleton-width-120"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-80"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-60"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-80"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-100"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-80"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-120"></div></td>
+                            </tr>
+                            <tr>
+                                <td><div class="skeleton skeleton-line skeleton-width-120"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-80"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-60"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-80"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-100"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-80"></div></td>
+                                <td><div class="skeleton skeleton-line skeleton-width-120"></div></td>
+                            </tr>
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
- Moved all inline styles from index.html to a new home-page.css file for better maintainability and separation of concerns.
- Updated index.html to link the new stylesheet and removed deprecated inline styles.
- Enhanced skeleton loading styles for improved visual consistency across the homepage.