### PR TITLE
Add standard dropdown arrow style to network select

### DIFF
--- a/css/network-indicator-selector.css
+++ b/css/network-indicator-selector.css
@@ -50,9 +50,6 @@
     border-radius: 8px !important;
     cursor: pointer;
     transition: all 0.2s ease !important;
-    appearance: none;
-    -webkit-appearance: none;
-    -moz-appearance: none;
 }
 
 .network-select:hover {
@@ -79,21 +76,6 @@
     display: inline-flex;
     align-items: center;
     height: 38px;
-}
-
-.network-select-chevron {
-    position: absolute;
-    right: 16px;
-    top: 50%;
-    transform: translateY(-50%);
-    font-size: 12px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    pointer-events: none;
-    z-index: 1;
-    line-height: 1;
-    color: var(--text-primary);
 }
 
 /* Layout specific */

--- a/js/components/network-indicator-selector.js
+++ b/js/components/network-indicator-selector.js
@@ -117,7 +117,6 @@ class NetworkSelector {
                         </option>
                     `).join('')}
                 </select>
-                <span class="network-select-chevron">▼</span>
             </div>
         `;
     }


### PR DESCRIPTION
Implement a standard dropdown arrow style for the network select component.
Remove custom chevron icon from dropdown.
<img width="648" height="804" alt="image" src="https://github.com/user-attachments/assets/5d2c973a-a6df-4b19-a6a4-b4a78e7b599a" />
<img width="1183" height="324" alt="image" src="https://github.com/user-attachments/assets/caa565a3-897c-4e2e-8a08-a62d251ff7e0" />

