### PR TITLE
Update CSS styles for connect and unauthorized cards on admin pages

### DIFF
--- a/css/admin-homepage-theme.css
+++ b/css/admin-homepage-theme.css
@@ -48,7 +48,9 @@ body {
 .info-card .card-header h3,
 .info-card .card-header h5,
 .admin-grid-sidebar h3,
-.recent-activity h3 {
+.recent-activity h3,
+.connect-card h2,
+.unauthorized-card h2 {
     color: var(--text-primary) !important;
 }
 
@@ -56,7 +58,9 @@ body {
     color: var(--text-primary) !important;
 }
 
-.info-label {
+.info-label,
+.connect-card p,
+.unauthorized-card p {
     color: var(--text-secondary) !important;
 }
 

--- a/css/admin-homepage-theme.css
+++ b/css/admin-homepage-theme.css
@@ -48,9 +48,7 @@ body {
 .info-card .card-header h3,
 .info-card .card-header h5,
 .admin-grid-sidebar h3,
-.recent-activity h3,
-.connect-card h2,
-.unauthorized-card h2 {
+.recent-activity h3 {
     color: var(--text-primary) !important;
 }
 
@@ -58,9 +56,7 @@ body {
     color: var(--text-primary) !important;
 }
 
-.info-label,
-.connect-card p,
-.unauthorized-card p {
+.info-label {
     color: var(--text-secondary) !important;
 }
 

--- a/css/admin.css
+++ b/css/admin.css
@@ -542,13 +542,11 @@
     margin: 0 0 20px 0;
     font-size: 24px;
     font-weight: 600;
-    color: #ffffff;
 }
 
 .connect-card p,
 .unauthorized-card p {
     margin: 0 0 25px 0;
-    color: #a0a0a0;
     line-height: 1.6;
 }
 
@@ -2529,7 +2527,6 @@ table td:last-child {
 }
 
 .unauthorized-card h2 {
-    color: #ef4444;
     margin-bottom: 16px;
     font-size: 1.5rem;
     text-align: center;

--- a/css/admin.css
+++ b/css/admin.css
@@ -542,11 +542,13 @@
     margin: 0 0 20px 0;
     font-size: 24px;
     font-weight: 600;
+    color: var(--text-primary);
 }
 
 .connect-card p,
 .unauthorized-card p {
     margin: 0 0 25px 0;
+    color: var(--text-secondary);
     line-height: 1.6;
 }
 

--- a/css/admin.css
+++ b/css/admin.css
@@ -539,17 +539,18 @@
 
 .connect-card h2,
 .unauthorized-card h2 {
-    margin: 0 0 20px 0;
-    font-size: 24px;
-    font-weight: 600;
+    margin: 0 0 var(--space-4) 0;
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-semibold);
     color: var(--text-primary);
 }
 
 .connect-card p,
 .unauthorized-card p {
-    margin: 0 0 25px 0;
+    margin: 0 0 var(--space-4) 0;
+    font-size: var(--font-size-base);
     color: var(--text-secondary);
-    line-height: 1.6;
+    line-height: var(--line-height-normal);
 }
 
 .access-details {

--- a/css/admin.css
+++ b/css/admin.css
@@ -539,16 +539,16 @@
 
 .connect-card h2,
 .unauthorized-card h2 {
-    margin: 0 0 var(--space-4) 0;
-    font-size: var(--font-size-lg);
-    font-weight: var(--font-weight-semibold);
+    margin: 0 0 20px 0;
+    font-size: 24px;
+    font-weight: 600;
     color: var(--text-primary);
 }
 
 .connect-card p,
 .unauthorized-card p {
-    margin: 0 0 var(--space-4) 0;
-    font-size: var(--font-size-base);
+    margin: 0 0 25px 0;
+    font-size: 1rem;
     color: var(--text-secondary);
     line-height: var(--line-height-normal);
 }

--- a/css/admin.css
+++ b/css/admin.css
@@ -540,9 +540,10 @@
 .connect-card h2,
 .unauthorized-card h2 {
     margin: 0 0 20px 0;
-    font-size: 24px;
+    font-size: 1.5rem;
     font-weight: 600;
     color: var(--text-primary);
+    text-align: center;
 }
 
 .connect-card p,
@@ -2527,12 +2528,6 @@ table td:last-child {
     max-width: 600px;
     width: 100%;
     box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
-}
-
-.unauthorized-card h2 {
-    margin-bottom: 16px;
-    font-size: 1.5rem;
-    text-align: center;
 }
 
 .unauthorized-card h3 {

--- a/css/components.css
+++ b/css/components.css
@@ -1638,12 +1638,10 @@
 .connect-card h2 {
     font-size: 1.75rem;
     font-weight: var(--liberdus-font-semibold);
-    color: var(--liberdus-text-primary);
     margin: 0 0 1rem 0;
 }
 
 .connect-card p {
-    color: var(--liberdus-text-secondary);
     margin: 0 0 2rem 0;
     font-size: 1rem;
     line-height: 1.5;

--- a/css/components.css
+++ b/css/components.css
@@ -1635,18 +1635,6 @@
     margin-bottom: 1.5rem;
 }
 
-.connect-card h2 {
-    font-size: 1.75rem;
-    font-weight: var(--liberdus-font-semibold);
-    margin: 0 0 1rem 0;
-}
-
-.connect-card p {
-    margin: 0 0 2rem 0;
-    font-size: 1rem;
-    line-height: 1.5;
-}
-
 .connect-cta-btn {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
Main issue: not able to see h1 text when in light mode

- Added color styles for headings and paragraphs in connect-card and unauthorized-card components.
- Removed hardcoded colors in favor of CSS variables for better maintainability.
- Enhanced overall consistency in text styling across admin homepage and components.

<img width="557" height="283" alt="image" src="https://github.com/user-attachments/assets/80b7a1e3-f5e7-432a-879c-d0c11748f633" />
