### PR TITLE
Update CSS styles for `proposal-title` in admin homepage

### DIFF
--- a/css/admin-homepage-theme.css
+++ b/css/admin-homepage-theme.css
@@ -48,7 +48,8 @@ body {
 .info-card .card-header h3,
 .info-card .card-header h5,
 .admin-grid-sidebar h3,
-.recent-activity h3 {
+.recent-activity h3,
+.proposal-title {
     color: var(--text-primary) !important;
 }
 

--- a/css/admin-homepage-theme.css
+++ b/css/admin-homepage-theme.css
@@ -48,8 +48,7 @@ body {
 .info-card .card-header h3,
 .info-card .card-header h5,
 .admin-grid-sidebar h3,
-.recent-activity h3,
-.proposal-title {
+.recent-activity h3 {
     color: var(--text-primary) !important;
 }
 

--- a/css/admin.css
+++ b/css/admin.css
@@ -1443,7 +1443,6 @@ table td:last-child {
     font-size: 1.5rem;
     font-weight: 400;
     margin: 0 0 1rem 0;
-    color: #ffffff;
     line-height: 1.334;
 }
 

--- a/css/admin.css
+++ b/css/admin.css
@@ -1443,6 +1443,7 @@ table td:last-child {
     font-size: 1.5rem;
     font-weight: 400;
     margin: 0 0 1rem 0;
+    color: var(--text-primary);
     line-height: 1.334;
 }
 


### PR DESCRIPTION
Main issue: not able to see title when in light mode

- Added a new style for proposal titles in the admin homepage theme.
- Removed the white color from the last table cell in the general CSS for improved readability.

<img width="355" height="145" alt="image" src="https://github.com/user-attachments/assets/cac54ade-f14b-4c8b-a25c-86705c1b8b00" />
