### PR TITLE
Change proposals header color based on theme

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -748,7 +748,7 @@
 
 .panel-header h2 {
     margin: 0;
-    color: #00d4ff;
+    color: var(--text-primary);
     font-size: 1.5rem;
     font-weight: 600;
 }


### PR DESCRIPTION
Update the proposals header color to adapt to the current theme, using black or white instead of blue.
<img width="1221" height="566" alt="image" src="https://github.com/user-attachments/assets/401ea44b-d237-48e6-aec2-5671801b945a" />
