### PR TITLE
Update RPC URL and fallback RPCs for Polygon Mainnet in app configuration

### DIFF
--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -31,10 +31,10 @@ window.CONFIG = {
         POLYGON_MAINNET: {
             CHAIN_ID: 137,
             NAME: 'Polygon Mainnet',
-            RPC_URL: 'https://rpc.ankr.com/polygon',
+            RPC_URL: ' https://polygon-rpc.com',
             FALLBACK_RPCS: [
-                'https://polygon-rpc.com',
-                'https://polygon-mainnet.g.alchemy.com/v2/CjcioLVYYWW0tsHWorEfC'
+                'https://polygon-mainnet.g.alchemy.com/v2/CjcioLVYYWW0tsHWorEfC',
+                'https://rpc.ankr.com/polygon'
             ],
             BLOCK_EXPLORER: 'https://polygonscan.com',
             NATIVE_CURRENCY: { name: 'Polygon', symbol: 'POL', decimals: 18 },

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -31,7 +31,7 @@ window.CONFIG = {
         POLYGON_MAINNET: {
             CHAIN_ID: 137,
             NAME: 'Polygon Mainnet',
-            RPC_URL: ' https://polygon-rpc.com',
+            RPC_URL: 'https://polygon-rpc.com',
             FALLBACK_RPCS: [
                 'https://polygon-mainnet.g.alchemy.com/v2/CjcioLVYYWW0tsHWorEfC'
             ],

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -33,8 +33,7 @@ window.CONFIG = {
             NAME: 'Polygon Mainnet',
             RPC_URL: ' https://polygon-rpc.com',
             FALLBACK_RPCS: [
-                'https://polygon-mainnet.g.alchemy.com/v2/CjcioLVYYWW0tsHWorEfC',
-                'https://rpc.ankr.com/polygon'
+                'https://polygon-mainnet.g.alchemy.com/v2/CjcioLVYYWW0tsHWorEfC'
             ],
             BLOCK_EXPLORER: 'https://polygonscan.com',
             NATIVE_CURRENCY: { name: 'Polygon', symbol: 'POL', decimals: 18 },

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -33,7 +33,9 @@ window.CONFIG = {
             NAME: 'Polygon Mainnet',
             RPC_URL: 'https://polygon-rpc.com',
             FALLBACK_RPCS: [
-                'https://polygon-mainnet.g.alchemy.com/v2/CjcioLVYYWW0tsHWorEfC'
+                'https://polygon-mainnet.infura.io/',
+                'https://polygon.drpc.org',
+                'https://polygon-bor-rpc.publicnode.com'
             ],
             BLOCK_EXPLORER: 'https://polygonscan.com',
             NATIVE_CURRENCY: { name: 'Polygon', symbol: 'POL', decimals: 18 },


### PR DESCRIPTION
Update fixes issue where user can't add Polygon Mainnet to metamask wallet since configured default RPC causes problem with adding network to wallet.