### PR TITLE
Clear proposal caches on network change

### DIFF
--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -563,8 +563,7 @@ class AdminPage {
             if (window.contractManager) {
                 try {
                     await window.contractManager.initialize();
-                    await this.loadContractStats();
-                    await this.loadMultiSignPanel();
+                    await this.refreshData();
                 } catch (error) {
                     console.error('❌ Error refreshing contract data:', error);
                 }


### PR DESCRIPTION
Refreshes all data when network is changed, which first clears the caches before loading contract stats and the multisign panel