### PR TITLE
Remove governance config fallbacks

### DIFF
--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -88,17 +88,6 @@ window.CONFIG = {
         31337: '0xcA11bde05977b3631167028862bE2a173976CA11'   // Local Hardhat
     },
 
-    // Governance Configuration
-    GOVERNANCE: {
-        SIGNERS: [
-            '0x9249cFE964C49Cf2d2D0DBBbB33E99235707aa61',
-            '0xea7bb30fbcCBB2646B0eFeB31382D3A4da07a3cC',
-            '0x2fBe1cd4BC1718B7625932f35e3cb03E6847289F',
-            '0xd3ac493dc0dA16077CC589A838ac473bC010324F'
-        ],
-        REQUIRED_APPROVALS: 3
-    },
-
     // Application Settings
     APP: {
         NAME: 'Liberdus LP Staking',
@@ -174,7 +163,7 @@ window.CONFIG = {
 
     // Development Configuration
     DEV: {
-        DEBUG: false
+        DEBUG: true
     },
 
     // Default Values for Contract Stats

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -1589,11 +1589,17 @@ class ContractManager {
      * Get signers (like React version) with RPC failover
      */
     async getSigners() {
-        return await this.safeContractCall(
+        const signers = await this.safeContractCall(
             () => this.stakingContract.getSigners(),
-            window.CONFIG?.GOVERNANCE?.SIGNERS || [], // Fallback signers from config
+            null,
             'getSigners'
         );
+
+        if (!Array.isArray(signers)) {
+            throw new Error('Failed to retrieve signers from staking contract');
+        }
+
+        return signers;
     }
 
     /**
@@ -1635,7 +1641,7 @@ class ContractManager {
      * Get required approvals for multi-signature actions with RPC failover
      */
     async getRequiredApprovals() {
-        return await this.safeContractCall(
+        const requiredApprovals = await this.safeContractCall(
             async () => {
                 if (!this.stakingContract) {
                     throw new Error('Staking contract not initialized');
@@ -1643,16 +1649,21 @@ class ContractManager {
 
                 // Check if function exists first
                 if (typeof this.stakingContract.REQUIRED_APPROVALS !== 'function') {
-                    console.log('⚠️ REQUIRED_APPROVALS function not available in contract');
-                    return 3; // Default fallback value (updated to match config)
+                    throw new Error('REQUIRED_APPROVALS function not available in contract');
                 }
 
                 const result = await this.stakingContract.REQUIRED_APPROVALS();
                 return result.toNumber();
             },
-            window.CONFIG?.GOVERNANCE?.REQUIRED_APPROVALS || 3, // Fallback from config
+            null,
             'getRequiredApprovals'
         );
+
+        if (!Number.isFinite(requiredApprovals)) {
+            throw new Error('Failed to retrieve required approvals from staking contract');
+        }
+
+        return requiredApprovals;
     }
 
     /**

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -1589,17 +1589,11 @@ class ContractManager {
      * Get signers (like React version) with RPC failover
      */
     async getSigners() {
-        const signers = await this.safeContractCall(
+        return await this.safeContractCall(
             () => this.stakingContract.getSigners(),
-            null,
+            [],
             'getSigners'
         );
-
-        if (!Array.isArray(signers)) {
-            throw new Error('Failed to retrieve signers from staking contract');
-        }
-
-        return signers;
     }
 
     /**


### PR DESCRIPTION
Removes the governance config approvals required and list of signers. Eliminates the use of them as fallbacks in the contract manager.

- throws an error if it cannot get approvals required count
- returns empty array if it gets no signers since no signers is valid when the contract is first created