### PR TITLE
Refactor network selection to use localStorage instead of CONFIG.SELECTED_NETWORK

### DIFF
--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -391,8 +391,8 @@ class AdminPage {
                         <p>Or try switching to a network where you have admin permissions:</p>
                         <div class="network-selector-container">
                             <select id="unauthorized-network-select" class="network-select">
-                                <option value="AMOY" ${(localStorage.getItem('liberdus-selected-network') || '') === 'AMOY' ? 'selected' : ''}>Amoy Testnet</option>
-                                <option value="POLYGON_MAINNET" ${(localStorage.getItem('liberdus-selected-network') || '') === 'POLYGON_MAINNET' ? 'selected' : ''}>Polygon Mainnet</option>
+                                <option value="AMOY" ${(window.networkSelector.getSelectedNetworkKey() || '') === 'AMOY' ? 'selected' : ''}>Amoy Testnet</option>
+                                <option value="POLYGON_MAINNET" ${(window.networkSelector.getSelectedNetworkKey() || '') === 'POLYGON_MAINNET' ? 'selected' : ''}>Polygon Mainnet</option>
                             </select>
                         </div>
                     </div>

--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -391,8 +391,8 @@ class AdminPage {
                         <p>Or try switching to a network where you have admin permissions:</p>
                         <div class="network-selector-container">
                             <select id="unauthorized-network-select" class="network-select">
-                                <option value="AMOY" ${window.CONFIG?.SELECTED_NETWORK === 'AMOY' ? 'selected' : ''}>Amoy Testnet</option>
-                                <option value="POLYGON_MAINNET" ${window.CONFIG?.SELECTED_NETWORK === 'POLYGON_MAINNET' ? 'selected' : ''}>Polygon Mainnet</option>
+                                <option value="AMOY" ${(localStorage.getItem('liberdus-selected-network') || '') === 'AMOY' ? 'selected' : ''}>Amoy Testnet</option>
+                                <option value="POLYGON_MAINNET" ${(localStorage.getItem('liberdus-selected-network') || '') === 'POLYGON_MAINNET' ? 'selected' : ''}>Polygon Mainnet</option>
                             </select>
                         </div>
                     </div>

--- a/js/components/network-indicator-selector.js
+++ b/js/components/network-indicator-selector.js
@@ -18,23 +18,27 @@ class NetworkSelector {
         this.defaultNetwork = 'AMOY';
     }
 
+    getSelectedNetworkKey() {
+        const selectedNetworkKey = localStorage.getItem('liberdus-selected-network')
+        if (!selectedNetworkKey) {
+            localStorage.setItem('liberdus-selected-network', this.defaultNetwork);
+            return this.defaultNetwork;
+        }
+        return selectedNetworkKey;
+    }
+
     /**
      * Load selected network from localStorage and initialize if needed
      * @param {string} defaultNetwork - The default network key to use if no network is selected
      * @returns {string|null} Active network key
      */
     loadSelectedNetwork() {
-        const stored = localStorage.getItem('liberdus-selected-network');
-        if (stored && window.CONFIG?.NETWORKS[stored]) {
-            console.log(`🔄 Loaded network from storage: ${window.CONFIG.NETWORKS[stored].NAME}`);
-            return stored;
+        const selectedNetworkKey = this.getSelectedNetworkKey();
+        if (selectedNetworkKey && window.CONFIG?.NETWORKS[selectedNetworkKey]) {
+            console.log(`🔄 Loaded network from storage: ${window.CONFIG.NETWORKS[selectedNetworkKey].NAME}`);
+            return selectedNetworkKey;
         }
 
-        if (this.defaultNetwork && window.CONFIG?.NETWORKS[this.defaultNetwork]) {
-            localStorage.setItem('liberdus-selected-network', this.defaultNetwork);
-            console.log(`🔄 Initialized network storage with default: ${window.CONFIG.NETWORKS[this.defaultNetwork].NAME}`);
-            return this.defaultNetwork;
-        }
 
         console.error('❌ No valid default network configured');
         return null;
@@ -98,7 +102,7 @@ class NetworkSelector {
      */
     getSelectorHTML() {
         const networks = Object.entries(window.CONFIG.NETWORKS);
-        const selectedNetwork = localStorage.getItem('liberdus-selected-network') || Object.keys(window.CONFIG.NETWORKS)[0];
+        const selectedNetwork = this.getSelectedNetworkKey();
         
         return `
             <div class="network-select-wrapper">
@@ -226,7 +230,7 @@ class NetworkSelector {
         // Update the selector value if it exists
         const selector = document.getElementById('network-select');
         if (selector) {
-            selector.value = localStorage.getItem('liberdus-selected-network') || Object.keys(window.CONFIG.NETWORKS)[0];
+            selector.value = this.getSelectedNetworkKey();
         }
     }
 
@@ -263,7 +267,7 @@ class NetworkSelector {
      * Get current selected network info
      */
     getCurrentNetwork() {
-        const selectedKey = localStorage.getItem('liberdus-selected-network') || Object.keys(window.CONFIG.NETWORKS)[0];
+        const selectedKey = this.getSelectedNetworkKey();
         const network = selectedKey && window.CONFIG?.NETWORKS[selectedKey] ? window.CONFIG.NETWORKS[selectedKey] : null;
         return {
             key: selectedKey,

--- a/js/components/network-indicator-selector.js
+++ b/js/components/network-indicator-selector.js
@@ -15,6 +15,7 @@ class NetworkSelector {
         this.isInitialized = false;
         this.eventListeners = new Map(); // Store event listeners for cleanup
         this._networkSwitching = false; // Track network switching state
+        this.defaultNetwork = 'AMOY';
     }
 
     /**
@@ -22,17 +23,17 @@ class NetworkSelector {
      * @param {string} defaultNetwork - The default network key to use if no network is selected
      * @returns {string|null} Active network key
      */
-    loadSelectedNetwork(defaultNetwork) {
+    loadSelectedNetwork() {
         const stored = localStorage.getItem('liberdus-selected-network');
         if (stored && window.CONFIG?.NETWORKS[stored]) {
             console.log(`🔄 Loaded network from storage: ${window.CONFIG.NETWORKS[stored].NAME}`);
             return stored;
         }
 
-        if (defaultNetwork && window.CONFIG?.NETWORKS[defaultNetwork]) {
-            localStorage.setItem('liberdus-selected-network', defaultNetwork);
-            console.log(`🔄 Initialized network storage with default: ${window.CONFIG.NETWORKS[defaultNetwork].NAME}`);
-            return defaultNetwork;
+        if (this.defaultNetwork && window.CONFIG?.NETWORKS[this.defaultNetwork]) {
+            localStorage.setItem('liberdus-selected-network', this.defaultNetwork);
+            console.log(`🔄 Initialized network storage with default: ${window.CONFIG.NETWORKS[this.defaultNetwork].NAME}`);
+            return this.defaultNetwork;
         }
 
         console.error('❌ No valid default network configured');

--- a/js/components/network-indicator-selector.js
+++ b/js/components/network-indicator-selector.js
@@ -305,7 +305,7 @@ class NetworkSelector {
             // If the network is not added to MetaMask, try to add it
             if (error.code === 4902) {
                 console.log(`🔗 Network ${networkKey} not found in MetaMask, attempting to add it...`);
-                return await this.addNetworkToMetaMask(window.CONFIG.NETWORKS[networkKey]);
+                return await this.addNetworkToMetaMask(networkKey);
             }
             
             return false;
@@ -315,26 +315,12 @@ class NetworkSelector {
     /**
      * Add network to MetaMask and switch to it
      * Delegates to NetworkManager.addNetwork()
-     * @param {string|Object} networkKeyOrObject - The network key or network object
+     * @param {string} networkKey - The network key to add
      */
-    async addNetworkToMetaMask(networkKeyOrObject) {
+    async addNetworkToMetaMask(networkKey) {
         try {
-            let networkKey;
-            
-            // Handle both network key string and network object
-            if (typeof networkKeyOrObject === 'string') {
-                networkKey = networkKeyOrObject;
-            } else {
-                // Find the network key from the network object
-                networkKey = Object.keys(window.CONFIG.NETWORKS).find(
-                    key => window.CONFIG.NETWORKS[key] === networkKeyOrObject
-                );
-            }
-            
             // Switch localStorage to target network for NetworkManager
-            if (networkKey) {
-                localStorage.setItem('liberdus-selected-network', networkKey);
-            }
+            localStorage.setItem('liberdus-selected-network', networkKey);
             
             // Use NetworkManager's addNetwork method
             await window.networkManager.addNetwork();

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -47,12 +47,12 @@ window.CONFIG = {
 
     // Backward compatibility - these reference the selected network
     get NETWORK() {
-        const selectedNetwork = localStorage.getItem('liberdus-selected-network') || Object.keys(this.NETWORKS)[0];
+        const selectedNetwork = localStorage.getItem('liberdus-selected-network');
         return this.NETWORKS[selectedNetwork];
     },
 
     get CONTRACTS() {
-        const selectedNetwork = localStorage.getItem('liberdus-selected-network') || Object.keys(this.NETWORKS)[0];
+        const selectedNetwork = localStorage.getItem('liberdus-selected-network');
         return this.NETWORKS[selectedNetwork]?.CONTRACTS;
     },
 

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -47,12 +47,12 @@ window.CONFIG = {
 
     // Backward compatibility - these reference the selected network
     get NETWORK() {
-        const selectedNetwork = localStorage.getItem('liberdus-selected-network');
+        const selectedNetwork = window?.networkSelector?.getSelectedNetworkKey();
         return this.NETWORKS[selectedNetwork];
     },
 
     get CONTRACTS() {
-        const selectedNetwork = localStorage.getItem('liberdus-selected-network');
+        const selectedNetwork = window?.networkSelector?.getSelectedNetworkKey();
         return this.NETWORKS[selectedNetwork]?.CONTRACTS;
     },
 

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -45,38 +45,15 @@ window.CONFIG = {
         }
     },
 
-    // Selected Network (defaults to AMOY, can be changed via dropdown)
-    SELECTED_NETWORK: 'AMOY',
-
     // Backward compatibility - these reference the selected network
     get NETWORK() {
-        return this.NETWORKS[this.SELECTED_NETWORK];
+        const selectedNetwork = localStorage.getItem('liberdus-selected-network') || Object.keys(this.NETWORKS)[0];
+        return this.NETWORKS[selectedNetwork];
     },
 
     get CONTRACTS() {
-        return this.NETWORKS[this.SELECTED_NETWORK].CONTRACTS;
-    },
-
-    // Network switching functionality
-    switchNetwork(networkKey) {
-        if (this.NETWORKS[networkKey]) {
-            this.SELECTED_NETWORK = networkKey;
-            // Store in localStorage for persistence
-            localStorage.setItem('liberdus-selected-network', networkKey);
-            console.log(`🌐 Switched to ${this.NETWORK.NAME} network`);
-            return true;
-        }
-        console.error(`❌ Network ${networkKey} not found`);
-        return false;
-    },
-
-    // Load selected network from localStorage
-    loadSelectedNetwork() {
-        const stored = localStorage.getItem('liberdus-selected-network');
-        if (stored && this.NETWORKS[stored]) {
-            this.SELECTED_NETWORK = stored;
-            console.log(`🔄 Loaded network from storage: ${this.NETWORK.NAME}`);
-        }
+        const selectedNetwork = localStorage.getItem('liberdus-selected-network') || Object.keys(this.NETWORKS)[0];
+        return this.NETWORKS[selectedNetwork]?.CONTRACTS;
     },
 
 
@@ -269,21 +246,3 @@ window.CONFIG.ABIS = {
         'function name() external view returns (string)'
     ]
 };
-
-// Initialize network selection
-window.CONFIG.loadSelectedNetwork();
-
-// Make SELECTED_NETWORK writable
-Object.defineProperty(window.CONFIG, 'SELECTED_NETWORK', {
-    value: window.CONFIG.SELECTED_NETWORK,
-    writable: true,
-    enumerable: true,
-    configurable: true
-});
-
-// Note: Not freezing CONFIG to allow SELECTED_NETWORK to be writable for network switching
-
-console.log('✅ Application configuration loaded successfully');
-console.log('🌐 Network:', window.CONFIG.NETWORK.NAME);
-console.log('📄 Staking Contract:', window.CONFIG.CONTRACTS.STAKING_CONTRACT);
-console.log('🎨 Default Theme:', window.CONFIG.UI.THEME.DEFAULT);

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -48,7 +48,7 @@ window.CONFIG = {
     // Backward compatibility - these reference the selected network
     get NETWORK() {
         const selectedNetwork = window?.networkSelector?.getSelectedNetworkKey();
-        return this.NETWORKS[selectedNetwork];
+        return this.NETWORKS[selectedNetwork] ?? undefined;
     },
 
     get CONTRACTS() {

--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -55,6 +55,9 @@ class MasterInitializer {
         // Load SES-safe handler
         await this.loadScript('js/utils/ses-safe-handler.js');
 
+        // Load network selector (contains network config utilities)
+        await this.loadScript('js/components/network-indicator-selector.js');
+
         // Load main configuration
         await this.loadScript('js/config/app-config.js');
 
@@ -62,6 +65,12 @@ class MasterInitializer {
         if (!window.CONFIG) {
             throw new Error('Failed to load application configuration');
         }
+
+        // Initialize network selection (validate localStorage)
+        window.networkSelector.loadSelectedNetwork(Object.keys(window.CONFIG.NETWORKS)[0]);
+
+        // Freeze CONFIG to make it immutable - network state is only in localStorage
+        Object.freeze(window.CONFIG);
 
         // Disable console output if not in debug mode
         if (!window.CONFIG?.DEV?.DEBUG) {
@@ -77,6 +86,7 @@ class MasterInitializer {
         }
 
         console.log('✅ Configuration loaded successfully');
+        console.log('📄 Staking Contract:', window.CONFIG.CONTRACTS.STAKING_CONTRACT);
     }
 
     async loadEthersLibrary() {
@@ -99,7 +109,6 @@ class MasterInitializer {
         const coreScripts = [
             'js/utils/multicall-service.js',    // Multicall2 for batch loading (90% RPC reduction)
             'js/utils/formatter.js',            // Formatter utilities (needed before UI components)
-            'js/components/network-indicator-selector.js',
             'js/core/error-handler.js',        // Error handling system
             'js/core/unified-theme-manager.js', // Unified theme manager
             'js/core/notification-manager-new.js'

--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -67,7 +67,7 @@ class MasterInitializer {
         }
 
         // Initialize network selection (validate localStorage)
-        window.networkSelector.loadSelectedNetwork(Object.keys(window.CONFIG.NETWORKS)[0]);
+        window.networkSelector.loadSelectedNetwork();
 
         // Freeze CONFIG to make it immutable - network state is only in localStorage
         Object.freeze(window.CONFIG);

--- a/types.d.ts
+++ b/types.d.ts
@@ -7,7 +7,7 @@ declare global {
         networkSelector: {
             init: (onNetworkChange?: Function) => void;
             createSelector: (containerId: string, context?: string) => void;
-            addNetworkToMetaMask: (networkKeyOrObject: string | Object) => Promise<boolean>;
+            addNetworkToMetaMask: (networkKey: string) => Promise<boolean>;
             addNetworkToMetaMaskAndReload: (networkKey: string) => Promise<void>;
         };
     }


### PR DESCRIPTION
**Summary:**

- Removed `CONFIG.SELECTED_NETWORK`; selection now stored in `localStorage.getItem('liberdus-selected-network')`.
- Updated `CONFIG.NETWORK` and `CONFIG.CONTRACTS` getters to read from localStorage directly.
- Moved network management functions into `NetworkSelector`:
  - `loadSelectedNetwork()` — initializes/loads selected network
  - `switchNetwork()` — switches networks and persists to localStorage
- Updated references across components to use localStorage instead of `CONFIG.SELECTED_NETWORK`:
  - `admin-page.js` — network selector options
  - `network-indicator-selector.js` — all network selection logic
- Removed network management from `CONFIG` object:
  - Deleted `switchNetwork()` and `loadSelectedNetwork()` methods
  - Removed initialization code at bottom of `app-config.js`
- Updated initialization order in `master-initializer.js`:
  - Load `network-indicator-selector.js` before `app-config.js`
  - Initialize network selection after CONFIG loads
  - Freeze CONFIG object after network initialization

This makes the network state persist in localStorage and removes the need for a mutable `SELECTED_NETWORK` property on CONFIG.