### PR TITLE
Refactor network configuration: remove getters from CONFIG and add NetworkSelector convenience methods

### DIFF
--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -223,7 +223,7 @@ class AdminPage {
             }
 
             const healthChecker = new window.NetworkHealthCheck();
-            const contractAddress = window.CONFIG?.CONTRACTS?.STAKING_CONTRACT;
+            const contractAddress = window.networkSelector?.getStakingContractAddress();
 
             // Perform comprehensive health check
             const isReady = await healthChecker.waitForNetworkReady(contractAddress, 20000); // 20 second timeout

--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -360,9 +360,9 @@ class AdminPage {
 
     showUnauthorizedAccess() {
         const container = document.getElementById('admin-content') || document.body;
-        const currentNetwork = window.CONFIG?.NETWORK?.NAME || 'Unknown Network';
-        const currentChainId = window.CONFIG?.NETWORK?.CHAIN_ID || 'Unknown';
-        const currentContract = window.CONFIG?.CONTRACTS?.STAKING_CONTRACT || 'Not configured';
+        const currentNetwork = window.networkSelector?.getCurrentNetworkName();
+        const currentChainId = window.networkSelector?.getCurrentChainId();
+        const currentContract = window.networkSelector?.getStakingContractAddress();
         
         container.innerHTML = `
             <div class="admin-unauthorized">

--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -1086,15 +1086,13 @@ class AdminPage {
         // Update network indicator when chain changes
         const indicator = document.getElementById('network-indicator-home');
         if (indicator) {
-            const chainIdDecimal = parseInt(chainId, 16);
-            const expectedChainId = window.CONFIG.NETWORK.CHAIN_ID;
-
             // Check permission asynchronously and update
             if (window.networkManager) {
                 window.networkManager.hasRequiredNetworkPermission().then(hasPermission => {
                     window.NetworkIndicator?.update('network-indicator-home', 'admin-network-selector', 'admin');
                 }).catch(error => {
-                    console.error('Error checking permission after chain change:', error);
+                    const networkName = window.networkSelector?.getCurrentNetworkName();
+                    console.error(`Error checking permission after chain change: ${networkName}`, error);
                 });
             }
         }
@@ -3886,7 +3884,7 @@ class AdminPage {
             }
 
             const chainId = await window.ethereum.request({ method: 'eth_chainId' });
-            const expectedChainId = window.networkManager?.getChainIdHex() || ('0x' + window.CONFIG.NETWORK.CHAIN_ID.toString(16));
+            const expectedChainId = window.networkManager?.getChainIdHex();
             return chainId === expectedChainId;
         } catch (error) {
             console.error('❌ Network status check failed:', error);

--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -563,8 +563,8 @@ class HomePage {
         }
 
         // Check if there are valid contracts for the current network
-        const contracts = window.CONFIG.CONTRACTS;
-        if (!contracts.STAKING_CONTRACT || contracts.STAKING_CONTRACT.trim() === '') {
+        const contract = window.networkSelector?.getStakingContractAddress();
+        if (!contract || contract.trim() === '') {
             console.log('⚠️ No contracts deployed on current network - loading empty data');
             this.loadEmptyData();
             return;

--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -430,7 +430,7 @@ class HomePage {
                     
                     // Check if wallet is on configured network
                     if (!(window.networkManager?.isOnRequiredNetwork() || false)) {
-                        const networkName = window.CONFIG?.NETWORK?.NAME || 'configured network';
+                        const networkName = window.networkSelector?.getCurrentNetworkName();
                         if (window.notificationManager) {
                             window.notificationManager.warning(
                                 `Please switch to ${networkName} network to make transactions`
@@ -669,7 +669,7 @@ class HomePage {
                     const isOnCorrectNetwork = window.networkManager?.isOnRequiredNetwork() || false;
                     
                     if (!isOnCorrectNetwork) {
-                        const networkName = window.CONFIG?.NETWORK?.NAME || 'configured network';
+                        const networkName = window.networkSelector?.getCurrentNetworkName();
                         const currentChainId = window.walletManager?.getChainId();
                         const currentNetworkName = window.networkManager?.getNetworkName(currentChainId) || 'Unknown';
                         console.log(`📊 Read-only mode: Wallet on ${currentNetworkName}, viewing ${networkName} data`);

--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -563,8 +563,8 @@ class HomePage {
         }
 
         // Check if there are valid contracts for the current network
-        const contract = window.networkSelector?.getStakingContractAddress();
-        if (!contract || contract.trim() === '') {
+        const contractAddress = window.networkSelector?.getStakingContractAddress();
+        if (!contractAddress || contractAddress.trim() === '') {
             console.log('⚠️ No contracts deployed on current network - loading empty data');
             this.loadEmptyData();
             return;

--- a/js/components/network-indicator-selector.js
+++ b/js/components/network-indicator-selector.js
@@ -174,9 +174,6 @@ class NetworkSelector {
                 return;
             }
 
-            // Update the network name display immediately
-            this.updateNetworkNameDisplay(networkKey, context);
-
             // Switch contract manager to new network
             if (window.contractManager?.switchNetwork) {
                 try {
@@ -232,16 +229,6 @@ class NetworkSelector {
         if (selector) {
             selector.value = this.getSelectedNetworkKey();
         }
-    }
-
-    /**
-     * Update the network name display immediately
-     * @param {string} networkKey - The selected network key
-     * @param {string} context - Context ('home' or 'admin')
-     */
-    updateNetworkNameDisplay(networkKey, context) {
-        const networkName = window.CONFIG.NETWORKS[networkKey]?.NAME || networkKey;        
-        console.log(`📝 Updated network name display to: ${networkName}`);
     }
 
     /**

--- a/js/components/network-indicator-selector.js
+++ b/js/components/network-indicator-selector.js
@@ -245,35 +245,45 @@ class NetworkSelector {
     }
 
     /**
-     * Get available networks for display
+     * Get current network configuration (replaces CONFIG.NETWORK getter)
+     * @returns {object|undefined} Network configuration object or undefined
      */
-    getAvailableNetworks() {
-        return Object.entries(window.CONFIG.NETWORKS).map(([key, network]) => ({
-            key,
-            name: network.NAME,
-            chainId: network.CHAIN_ID
-        }));
+    getCurrentNetworkConfig() {
+        const selectedNetwork = this.getSelectedNetworkKey();
+        return window.CONFIG?.NETWORKS[selectedNetwork] ?? undefined;
     }
 
     /**
-     * Check if a network is available
-     * @param {string} networkKey - Network key to check
+     * Get current network contracts (replaces CONFIG.CONTRACTS getter)
+     * @returns {object|undefined} Contracts object or undefined
      */
-    isNetworkAvailable(networkKey) {
-        return !!window.CONFIG.NETWORKS[networkKey];
+    getCurrentContracts() {
+        const selectedNetwork = this.getSelectedNetworkKey();
+        return window.CONFIG?.NETWORKS[selectedNetwork]?.CONTRACTS;
     }
 
     /**
-     * Get current selected network info
+     * Get current network name
+     * @returns {string|undefined} Network name or undefined
      */
-    getCurrentNetwork() {
-        const selectedKey = this.getSelectedNetworkKey();
-        const network = selectedKey && window.CONFIG?.NETWORKS[selectedKey] ? window.CONFIG.NETWORKS[selectedKey] : null;
-        return {
-            key: selectedKey,
-            name: network?.NAME || 'Unknown',
-            chainId: network?.CHAIN_ID || null
-        };
+    getCurrentNetworkName() {
+        return this.getCurrentNetworkConfig()?.NAME;
+    }
+
+    /**
+     * Get current network chain ID
+     * @returns {number|undefined} Chain ID or undefined
+     */
+    getCurrentChainId() {
+        return this.getCurrentNetworkConfig()?.CHAIN_ID;
+    }
+
+    /**
+     * Get staking contract address for current network
+     * @returns {string|undefined} Staking contract address or undefined
+     */
+    getStakingContractAddress() {
+        return this.getCurrentContracts()?.STAKING_CONTRACT;
     }
 
     /**
@@ -374,7 +384,6 @@ class NetworkIndicator {
         indicator.className = `network-indicator-home loading`;
 
         const isWalletConnected = window.walletManager && window.walletManager.isConnected();
-        const expectedNetworkName = window.CONFIG?.NETWORK?.NAME || 'Unknown';
 
         // Check permission asynchronously if wallet is connected
         if (isWalletConnected && window.networkManager) {

--- a/js/components/network-indicator-selector.js
+++ b/js/components/network-indicator-selector.js
@@ -287,6 +287,14 @@ class NetworkSelector {
     }
 
     /**
+     * Get native currency for current network
+     * @returns {object|undefined} Native currency object or undefined
+     */
+    getCurrentNativeCurrency() {
+        return this.getCurrentNetworkConfig()?.NATIVE_CURRENCY;
+    }
+
+    /**
      * Check if network is currently switching
      * @returns {boolean} True if network is switching
      */

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -407,9 +407,7 @@ class StakingModalNew {
             const userAddress = window.walletManager.address;
 
             // Get staking contract address (try multiple config paths)
-            const stakingAddress = window.CONFIG?.CONTRACTS?.STAKING_CONTRACT ||
-                                   window.CONFIG?.CONTRACTS?.STAKING ||
-                                   '0xDB7100D6f037fc36A51c38E76c910626A2d755f4'; // Fallback
+            const stakingAddress = window.networkSelector?.getStakingContractAddress();
 
             console.log(`🔍 Checking approval for:`, {
                 lpToken: lpTokenAddress,

--- a/js/components/wallet-popup.js
+++ b/js/components/wallet-popup.js
@@ -140,7 +140,8 @@ class WalletPopup {
 
     createPopupHTML(walletData) {
         const shortAddress = this.formatAddress(walletData.address);
-        const nativeCurrency = window.CONFIG?.NETWORK?.NATIVE_CURRENCY;
+        const networkConfig = window.networkSelector?.getCurrentNetworkConfig();
+        const nativeCurrency = networkConfig?.NATIVE_CURRENCY;
         const labelToken = nativeCurrency?.name || nativeCurrency?.symbol;
         const balanceLabel = labelToken ? `${labelToken} Balance` : 'Balance';
 
@@ -305,8 +306,8 @@ class WalletPopup {
             return;
         }
 
-        const network = window.CONFIG?.NETWORK;
-        const nativeCurrency = network?.NATIVE_CURRENCY || {};
+        const networkConfig = window.networkSelector?.getCurrentNetworkConfig();
+        const nativeCurrency = networkConfig?.NATIVE_CURRENCY || {};
         const decimals = typeof nativeCurrency.decimals === 'number' ? nativeCurrency.decimals : 18;
         const displaySymbol = nativeCurrency.symbol || 'Native';
         const displayName = nativeCurrency.name || displaySymbol;
@@ -323,7 +324,7 @@ class WalletPopup {
         try {
             const balance = await this.fetchNativeBalance(
                 walletData.address,
-                network?.CHAIN_ID,
+                networkConfig?.CHAIN_ID,
                 walletData.chainId
             );
 

--- a/js/components/wallet-popup.js
+++ b/js/components/wallet-popup.js
@@ -140,8 +140,7 @@ class WalletPopup {
 
     createPopupHTML(walletData) {
         const shortAddress = this.formatAddress(walletData.address);
-        const networkConfig = window.networkSelector?.getCurrentNetworkConfig();
-        const nativeCurrency = networkConfig?.NATIVE_CURRENCY;
+        const nativeCurrency = window.networkSelector?.getCurrentNativeCurrency();
         const labelToken = nativeCurrency?.name || nativeCurrency?.symbol;
         const balanceLabel = labelToken ? `${labelToken} Balance` : 'Balance';
 
@@ -306,8 +305,7 @@ class WalletPopup {
             return;
         }
 
-        const networkConfig = window.networkSelector?.getCurrentNetworkConfig();
-        const nativeCurrency = networkConfig?.NATIVE_CURRENCY || {};
+        const nativeCurrency = window.networkSelector?.getCurrentNativeCurrency();
         const decimals = typeof nativeCurrency.decimals === 'number' ? nativeCurrency.decimals : 18;
         const displaySymbol = nativeCurrency.symbol || 'Native';
         const displayName = nativeCurrency.name || displaySymbol;
@@ -324,7 +322,7 @@ class WalletPopup {
         try {
             const balance = await this.fetchNativeBalance(
                 walletData.address,
-                networkConfig?.CHAIN_ID,
+                window.networkSelector?.getCurrentChainId(),
                 walletData.chainId
             );
 

--- a/js/components/wallet-popup.js
+++ b/js/components/wallet-popup.js
@@ -306,9 +306,9 @@ class WalletPopup {
         }
 
         const nativeCurrency = window.networkSelector?.getCurrentNativeCurrency();
-        const decimals = typeof nativeCurrency.decimals === 'number' ? nativeCurrency.decimals : 18;
-        const displaySymbol = nativeCurrency.symbol || 'Native';
-        const displayName = nativeCurrency.name || displaySymbol;
+        const decimals = typeof nativeCurrency?.decimals === 'number' ? nativeCurrency.decimals : 18;
+        const displaySymbol = nativeCurrency?.symbol || 'Native';
+        const displayName = nativeCurrency?.name || displaySymbol;
 
         const labelElement = this.popupElement.querySelector('[data-wallet-balance-label]');
         if (labelElement) {

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -45,18 +45,6 @@ window.CONFIG = {
         }
     },
 
-    // Backward compatibility - these reference the selected network
-    get NETWORK() {
-        const selectedNetwork = window?.networkSelector?.getSelectedNetworkKey();
-        return this.NETWORKS[selectedNetwork] ?? undefined;
-    },
-
-    get CONTRACTS() {
-        const selectedNetwork = window?.networkSelector?.getSelectedNetworkKey();
-        return this.NETWORKS[selectedNetwork]?.CONTRACTS;
-    },
-
-
     // Multicall2 addresses (canonical deployment for batch loading optimization)
     MULTICALL2: {
         1: '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696',      // Ethereum Mainnet

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -4646,13 +4646,6 @@ class ContractManager {
             return errorFallback;
         }
 
-        // Check if contract is deployed on current network
-        const contract = window.networkSelector?.getStakingContractAddress();
-        if (!contract || contract.trim() === '') {
-            console.log(`⚠️ No staking contract deployed on current network - ${functionName} skipped gracefully`);
-            return errorFallback;
-        }
-
         for (let attempt = 0; attempt < maxRetries; attempt++) {
             try {
                 return await contractFunction();

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -105,8 +105,6 @@ class ContractManager {
                 throw new Error('CONFIG not loaded');
             }
 
-            console.log('✅ CONFIG available:', window.CONFIG.CONTRACTS);
-
             // Check if ethers is available
             if (!window.ethers) {
                 console.error('❌ Ethers.js not available - cannot initialize contracts');
@@ -677,7 +675,7 @@ class ContractManager {
                 throw new Error('Configuration not available');
             }
 
-            const stakingAddress = config.CONTRACTS?.STAKING_CONTRACT || null;
+            const stakingAddress = window.networkSelector?.getStakingContractAddress();
             console.log('   - Staking contract (config):', stakingAddress);
 
             if (stakingAddress && this.isValidContractAddress(stakingAddress)) {
@@ -1147,9 +1145,10 @@ class ContractManager {
             }
 
             // Check if the new network has valid contract addresses
-            const contracts = window.CONFIG.CONTRACTS;
-            if (!contracts.STAKING_CONTRACT || contracts.STAKING_CONTRACT.trim() === '') {
-                console.log(`⚠️ No contracts deployed on ${network.NAME} - skipping initialization`);
+            const contract = window.CONFIG.NETWORKS[networkKey]?.CONTRACTS?.STAKING_CONTRACT || null;
+            if (!contract || contract.trim() === '') {
+                const networkName = network?.NAME || networkKey || 'current network';
+                console.log(`⚠️ No contracts deployed on ${networkName} - skipping initialization`);
                 this.isInitialized = true; // Mark as initialized but with no contracts
                 return true;
             }
@@ -4648,8 +4647,8 @@ class ContractManager {
         }
 
         // Check if contract is deployed on current network
-        const contracts = window.CONFIG.CONTRACTS;
-        if (!contracts.STAKING_CONTRACT || contracts.STAKING_CONTRACT.trim() === '') {
+        const contract = window.networkSelector?.getStakingContractAddress();
+        if (!contract || contract.trim() === '') {
             console.log(`⚠️ No staking contract deployed on current network - ${functionName} skipped gracefully`);
             return errorFallback;
         }

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -1145,9 +1145,9 @@ class ContractManager {
             }
 
             // Check if the new network has valid contract addresses
-            const contract = window.CONFIG.NETWORKS[networkKey]?.CONTRACTS?.STAKING_CONTRACT || null;
-            if (!contract || contract.trim() === '') {
-                const networkName = network?.NAME || networkKey || 'current network';
+            const contractAddress = window.networkSelector?.getStakingContractAddress();
+            if (!contractAddress || contractAddress.trim() === '') {
+                const networkName = window.networkSelector?.getCurrentNetworkName() || networkKey || 'current network';
                 console.log(`⚠️ No contracts deployed on ${networkName} - skipping initialization`);
                 this.isInitialized = true; // Mark as initialized but with no contracts
                 return true;

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -4640,12 +4640,6 @@ class ContractManager {
     async safeContractCall(contractFunction, errorFallback = null, functionName = 'unknown') {
         const maxRetries = 2;
 
-        // Check if contracts are initialized before attempting calls
-        if (!this.stakingContract && functionName.includes('staking')) {
-            console.error(`❌ Staking contract not initialized for ${functionName}`);
-            return errorFallback;
-        }
-
         for (let attempt = 0; attempt < maxRetries; attempt++) {
             try {
                 return await contractFunction();

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -422,7 +422,7 @@ class ContractManager {
                 const network = await Promise.race([networkPromise, timeoutPromise]);
 
                 // Verify correct network (using centralized config)
-                const expectedChainId = window.CONFIG?.NETWORK?.CHAIN_ID || 80002;
+                const expectedChainId = window.networkSelector?.getCurrentChainId();
                 if (network.chainId !== expectedChainId) {
                     throw new Error(`Wrong network: expected ${expectedChainId}, got ${network.chainId}`);
                 }
@@ -459,7 +459,7 @@ class ContractManager {
      */
     getAllRPCUrls() {
         const rpcUrls = [];
-        const networkConfig = window.CONFIG?.NETWORK;
+        const networkConfig = window.networkSelector?.getCurrentNetworkConfig();
 
         if (networkConfig?.RPC_URL) {
             rpcUrls.push(networkConfig.RPC_URL);
@@ -515,7 +515,7 @@ class ContractManager {
                     const network = await Promise.race([networkPromise, timeoutPromise]);
 
                     // Verify correct network (using centralized config when available)
-                    const expectedChainId = window.CONFIG?.NETWORK?.CHAIN_ID;
+                    const expectedChainId = window.networkSelector?.getCurrentChainId();
                     if (expectedChainId != null && network.chainId !== expectedChainId) {
                         throw new Error(`Wrong network: expected ${expectedChainId}, got ${network.chainId}`);
                     }
@@ -2901,11 +2901,11 @@ class ContractManager {
 
             // Ensure we're on the correct network (using centralized config)
             const network = await web3Provider.getNetwork();
-            const expectedChainId = window.CONFIG?.NETWORK?.CHAIN_ID || 80002;
+            const expectedChainId = window.networkSelector?.getCurrentChainId();
             
             // Check permissions for the selected network regardless of current network
-            const selectedNetwork = window.CONFIG?.NETWORK?.CHAIN_ID || 80002;
-            const networkName = window.CONFIG?.NETWORK?.NAME || 'the selected network';
+            const selectedNetwork = window.networkSelector?.getCurrentChainId();
+            const networkName = window.networkSelector?.getCurrentNetworkName();
             
             if (selectedNetwork === expectedChainId) {
                 console.log(`🌐 ${networkName} selected in UI, checking permissions...`);

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -1340,7 +1340,7 @@ class ContractManager {
             );
 
             // Get balance of staking contract (total LP tokens staked)
-            const stakingContractAddress = window.CONFIG?.CONTRACTS?.STAKING_CONTRACT;
+            const stakingContractAddress = window.networkSelector?.getStakingContractAddress();
             if (!stakingContractAddress) {
                 throw new Error('Staking contract address not configured');
             }
@@ -1361,7 +1361,7 @@ class ContractManager {
                 throw new Error(`Unable to resolve LP token for identifier: ${pairIdentifier}`);
             }
 
-            const stakingAddress = this.contractAddresses.get('STAKING') || window.CONFIG?.CONTRACTS?.STAKING_CONTRACT;
+            const stakingAddress = this.contractAddresses.get('STAKING') || window.networkSelector?.getStakingContractAddress();
             if (!stakingAddress || !this.isValidContractAddress(stakingAddress)) {
                 throw new Error('Staking contract address not available');
             }

--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -687,7 +687,7 @@ class MasterInitializer {
 
                 if (!hasPermission) {
                     // Wallet is connected but missing permission - show as disconnected
-                    const networkName = window.CONFIG?.NETWORK?.NAME || 'network';
+                    const networkName = window.networkSelector?.getCurrentNetworkName();
                     this.renderConnectButton(connectBtn, {
                         text: 'Connect Wallet',
                         title: `Grant permission for ${networkName}`,
@@ -826,7 +826,7 @@ class MasterInitializer {
                     : false;
                 
                 if (!isOnRequiredNetwork) {
-                    const networkName = window.CONFIG?.NETWORK?.NAME || 'configured network';
+                    const networkName = window.networkSelector?.getCurrentNetworkName();
                     console.log(`📊 Wallet connected but not on ${networkName} - staying in read-only mode`);
                     console.log(`💡 ContractManager will upgrade when switched to ${networkName}`);
                     // Don't upgrade yet - stay in read-only mode

--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -86,7 +86,6 @@ class MasterInitializer {
         }
 
         console.log('✅ Configuration loaded successfully');
-        console.log('📄 Staking Contract:', window.CONFIG.CONTRACTS.STAKING_CONTRACT);
     }
 
     async loadEthersLibrary() {

--- a/js/wallet/network-manager.js
+++ b/js/wallet/network-manager.js
@@ -642,7 +642,7 @@ class NetworkManager {
                 
                 // Only show notification for explicit permission requests, not background checks
                 if (window.notificationManager && this._showPermissionNotification) {
-                    window.notificationManager.success(`${network.NAME} permission confirmed. You can now make transactions.`);
+                    window.notificationManager.success(`${network?.NAME} permission confirmed. You can now make transactions.`);
                 }
             } else {
                 // No permission or wrong network

--- a/js/wallet/network-manager.js
+++ b/js/wallet/network-manager.js
@@ -117,21 +117,15 @@ class NetworkManager {
             throw new Error('Wallet not connected');
         }
 
-        const network = window.networkSelector?.getCurrentNetworkConfig();
-        const chainId = network?.CHAIN_ID;
+        const chainId = window.networkSelector?.getCurrentChainId();
         if (!chainId) {
             throw new Error('Network configuration not found');
         }
 
         try {
-            this.log('Switching to network:', network.NAME);
-
             // Try to switch to the network
             await this.requestNetworkSwitch(chainId);
-            
-            this.log('Network switch successful');
             return true;
-
         } catch (error) {
             // If the network doesn't exist in wallet, try to add it
             if (error.code === 4902 || error.message.includes('Unrecognized chain ID')) {
@@ -177,7 +171,7 @@ class NetworkManager {
         }
 
         const networkConfig = this.buildNetworkConfig();
-        const networkName = window.networkSelector?.getCurrentNetworkName() || 'configured network';
+        const networkName = window.networkSelector?.getCurrentNetworkName();
 
         try {
             await window.ethereum.request({
@@ -239,7 +233,7 @@ class NetworkManager {
 
         const chainId = this.getCurrentChainId();
         const isCorrect = this.isOnRequiredNetwork(chainId);
-        const network = window.networkSelector?.getCurrentNetworkConfig();
+        const networkName = window.networkSelector?.getCurrentNetworkName();
 
         if (!chainId || !isCorrect) {
             // Show warning
@@ -250,7 +244,7 @@ class NetworkManager {
                 if (!chainId) {
                     messageElement.textContent = 'Please connect your wallet';
                 } else {
-                    messageElement.textContent = `Please switch to ${network?.NAME || 'the configured network'}`;
+                    messageElement.textContent = `Please switch to ${networkName}`;
                 }
             }
         } else {
@@ -438,7 +432,7 @@ class NetworkManager {
 
             throw new Error(`Unsupported wallet type: ${walletType}`);
         } catch (error) {
-            const networkName = window.networkSelector?.getCurrentNetworkName() || 'configured network';
+            const networkName = window.networkSelector?.getCurrentNetworkName();
             console.error(`Failed to request ${networkName} permission:`, error);
             throw error;
         }
@@ -455,7 +449,7 @@ class NetworkManager {
         }
 
         try {
-            const networkName = window.networkSelector?.getCurrentNetworkName() || 'configured network';
+            const networkName = window.networkSelector?.getCurrentNetworkName();
             console.log(`🔐 Requesting ${networkName} network permission...`);
 
             // First, ensure we have account permissions
@@ -492,7 +486,7 @@ class NetworkManager {
         // Set flag for background permission checks
         this._showPermissionNotification = showNotification;
         try {
-            const networkName = window.networkSelector?.getCurrentNetworkName() || 'configured network';
+            const networkName = window.networkSelector?.getCurrentNetworkName();
 
             // Request permission using modern approach
             await this.requestNetworkPermission('metamask');
@@ -517,7 +511,7 @@ class NetworkManager {
             return true;
         } catch (error) {
             console.error('❌ Failed to get network permission:', error);
-            const networkName = window.networkSelector?.getCurrentNetworkName() || 'configured network';
+            const networkName = window.networkSelector?.getCurrentNetworkName();
             const errorMessage = `Failed to get network permission. Please grant permission for ${networkName} network in MetaMask.`;
             
             if (context === 'admin') {
@@ -648,8 +642,7 @@ class NetworkManager {
                 
                 // Only show notification for explicit permission requests, not background checks
                 if (window.notificationManager && this._showPermissionNotification) {
-                    const networkName = network?.NAME || 'the selected network';
-                    window.notificationManager.success(`${networkName} permission confirmed. You can now make transactions.`);
+                    window.notificationManager.success(`${network.NAME} permission confirmed. You can now make transactions.`);
                 }
             } else {
                 // No permission or wrong network

--- a/js/wallet/network-manager.js
+++ b/js/wallet/network-manager.js
@@ -27,14 +27,6 @@ class NetworkManager {
     }
 
     /**
-     * Check if current network is supported
-     */
-    isNetworkSupported(chainId = null) {
-        const targetChainId = chainId || this.getCurrentChainId();
-        return targetChainId === window.CONFIG?.NETWORK?.CHAIN_ID;
-    }
-
-    /**
      * Check if wallet is on the required network (synchronous chainId comparison)
      * ⚠️ NETWORK CHECK ONLY - Does NOT verify MetaMask permissions
      * Only compares chainId values, not wallet_getPermissions
@@ -44,7 +36,8 @@ class NetworkManager {
      */
     isOnRequiredNetwork(chainId = null) {
         const targetChainId = chainId || this.getCurrentChainId();
-        return targetChainId === window.CONFIG?.NETWORK?.CHAIN_ID;
+        const currentChainId = window.networkSelector?.getCurrentChainId();
+        return targetChainId === currentChainId;
     }
 
     /**
@@ -95,13 +88,14 @@ class NetworkManager {
      * Returns network info if chainId matches configured network, null otherwise
      */
     getNetworkInfo(chainId) {
-        if (chainId === window.CONFIG?.NETWORK?.CHAIN_ID) {
+        const network = window.networkSelector?.getCurrentNetworkConfig();
+        if (chainId === network?.CHAIN_ID) {
             return {
-                chainId: window.CONFIG.NETWORK.CHAIN_ID,
-                name: window.CONFIG.NETWORK.NAME,
-                rpcUrl: window.CONFIG.NETWORK.RPC_URL,
-                blockExplorer: window.CONFIG.NETWORK.BLOCK_EXPLORER,
-                nativeCurrency: window.CONFIG.NETWORK.NATIVE_CURRENCY
+                chainId: network.CHAIN_ID,
+                name: network.NAME,
+                rpcUrl: network.RPC_URL,
+                blockExplorer: network.BLOCK_EXPLORER,
+                nativeCurrency: network.NATIVE_CURRENCY
             };
         }
         return null;
@@ -123,13 +117,14 @@ class NetworkManager {
             throw new Error('Wallet not connected');
         }
 
-        const chainId = window.CONFIG?.NETWORK?.CHAIN_ID;
+        const network = window.networkSelector?.getCurrentNetworkConfig();
+        const chainId = network?.CHAIN_ID;
         if (!chainId) {
             throw new Error('Network configuration not found');
         }
 
         try {
-            this.log('Switching to network:', window.CONFIG.NETWORK.NAME);
+            this.log('Switching to network:', network.NAME);
 
             // Try to switch to the network
             await this.requestNetworkSwitch(chainId);
@@ -182,8 +177,8 @@ class NetworkManager {
         }
 
         const networkConfig = this.buildNetworkConfig();
-        const networkName = window.CONFIG?.NETWORK?.NAME || 'configured network';
-        
+        const networkName = window.networkSelector?.getCurrentNetworkName() || 'configured network';
+
         try {
             await window.ethereum.request({
                 method: 'wallet_addEthereumChain',
@@ -227,7 +222,6 @@ class NetworkManager {
         this.notifyListeners('networkChanged', {
             chainId,
             networkInfo: this.getNetworkInfo(chainId),
-            isSupported: this.isNetworkSupported(chainId),
             isCorrect: this.isOnRequiredNetwork(chainId),
             previousNetwork
         });
@@ -245,7 +239,7 @@ class NetworkManager {
 
         const chainId = this.getCurrentChainId();
         const isCorrect = this.isOnRequiredNetwork(chainId);
-        const isSupported = this.isNetworkSupported(chainId);
+        const network = window.networkSelector?.getCurrentNetworkConfig();
 
         if (!chainId || !isCorrect) {
             // Show warning
@@ -255,10 +249,8 @@ class NetworkManager {
             if (messageElement) {
                 if (!chainId) {
                     messageElement.textContent = 'Please connect your wallet';
-                } else if (!isSupported) {
-                    messageElement.textContent = 'Unsupported network detected';
                 } else {
-                    messageElement.textContent = `Please switch to ${window.CONFIG?.NETWORK?.NAME || 'the configured network'}`;
+                    messageElement.textContent = `Please switch to ${network?.NAME || 'the configured network'}`;
                 }
             }
         } else {
@@ -273,14 +265,13 @@ class NetworkManager {
     getNetworkStatus() {
         const chainId = this.getCurrentChainId();
         const networkInfo = this.getNetworkInfo(chainId);
-        
+
         return {
             chainId,
             networkInfo,
             isConnected: !!chainId,
-            isSupported: this.isNetworkSupported(chainId),
             isCorrect: this.isOnRequiredNetwork(chainId),
-            configuredNetwork: this.getNetworkInfo(window.CONFIG?.NETWORK?.CHAIN_ID)
+            configuredNetwork: this.getNetworkInfo(window.networkSelector?.getCurrentChainId())
         };
     }
 
@@ -348,10 +339,10 @@ class NetworkManager {
      */
     validateNetworkConfig() {
         const errors = [];
-        const network = window.CONFIG?.NETWORK;
+        const network = window.networkSelector?.getCurrentNetworkConfig();
         
         if (!network) {
-            errors.push('No network configuration found (CONFIG.NETWORK is missing)');
+            errors.push('No network configuration found (network not selected)');
         } else {
             if (!network.CHAIN_ID) {
                 errors.push('Missing CHAIN_ID in network configuration');
@@ -383,7 +374,7 @@ class NetworkManager {
      * @returns {string} Chain ID in hex (e.g., '0x13882')
      */
     getChainIdHex() {
-        const chainId = window.CONFIG?.NETWORK?.CHAIN_ID;
+        const chainId = window.networkSelector?.getCurrentChainId();
         return chainId ? '0x' + chainId.toString(16) : null;
     }
 
@@ -393,9 +384,9 @@ class NetworkManager {
      * @returns {object} Network configuration for wallet_addEthereumChain
      */
     buildNetworkConfig() {
-        const network = window.CONFIG?.NETWORK;
+        const network = window.networkSelector?.getCurrentNetworkConfig();
         if (!network) {
-            throw new Error('Network configuration not found in CONFIG.NETWORK');
+            throw new Error('Network configuration not found');
         }
         
         const hexChainId = '0x' + network.CHAIN_ID.toString(16);
@@ -447,7 +438,7 @@ class NetworkManager {
 
             throw new Error(`Unsupported wallet type: ${walletType}`);
         } catch (error) {
-            const networkName = window.CONFIG?.NETWORK?.NAME || 'configured network';
+            const networkName = window.networkSelector?.getCurrentNetworkName() || 'configured network';
             console.error(`Failed to request ${networkName} permission:`, error);
             throw error;
         }
@@ -464,7 +455,7 @@ class NetworkManager {
         }
 
         try {
-            const networkName = window.CONFIG?.NETWORK?.NAME || 'configured network';
+            const networkName = window.networkSelector?.getCurrentNetworkName() || 'configured network';
             console.log(`🔐 Requesting ${networkName} network permission...`);
 
             // First, ensure we have account permissions
@@ -501,8 +492,7 @@ class NetworkManager {
         // Set flag for background permission checks
         this._showPermissionNotification = showNotification;
         try {
-            const expectedChainId = window.CONFIG?.NETWORK?.CHAIN_ID;
-            const networkName = this.getNetworkName(expectedChainId);
+            const networkName = window.networkSelector?.getCurrentNetworkName() || 'configured network';
 
             // Request permission using modern approach
             await this.requestNetworkPermission('metamask');
@@ -527,7 +517,7 @@ class NetworkManager {
             return true;
         } catch (error) {
             console.error('❌ Failed to get network permission:', error);
-            const networkName = window.CONFIG?.NETWORK?.NAME || 'the configured network';
+            const networkName = window.networkSelector?.getCurrentNetworkName() || 'configured network';
             const errorMessage = `Failed to get network permission. Please grant permission for ${networkName} network in MetaMask.`;
             
             if (context === 'admin') {
@@ -640,7 +630,8 @@ class NetworkManager {
             // Check if we have permission for the selected network
             const hasPermission = await this.hasRequiredNetworkPermission();
             const currentChainId = window.ethereum ? parseInt(await window.ethereum.request({ method: 'eth_chainId' }), 16) : null;
-            const expectedChainId = window.CONFIG?.NETWORK?.CHAIN_ID || 80002;
+            const network = window.networkSelector?.getCurrentNetworkConfig();
+            const expectedChainId = network?.CHAIN_ID;
             
             console.log('Permission state:', { hasPermission, currentChainId, expectedChainId });
             
@@ -657,7 +648,7 @@ class NetworkManager {
                 
                 // Only show notification for explicit permission requests, not background checks
                 if (window.notificationManager && this._showPermissionNotification) {
-                    const networkName = window.CONFIG?.NETWORK?.NAME || 'the selected network';
+                    const networkName = network?.NAME || 'the selected network';
                     window.notificationManager.success(`${networkName} permission confirmed. You can now make transactions.`);
                 }
             } else {


### PR DESCRIPTION
**Reason:**
- Remove getters from static config to improve separation of concerns
- Reduce duplication and chained property accesses
- Centralize network state access through NetworkSelector

**Changes:**
- Removed `CONFIG.NETWORK` and `CONFIG.CONTRACTS` getters from app-config.js
- Added convenience methods to NetworkSelector: `getCurrentNetworkConfig()`, `getCurrentContracts()`, `getCurrentNetworkName()`, `getCurrentChainId()`, `getStakingContractAddress()`, `getCurrentNativeCurrency()`
- Replaced all `CONFIG.NETWORK` and `CONFIG.CONTRACTS` usages with NetworkSelector methods across 8 files
- Removed duplicate `isNetworkSupported()` function (identical to `isOnRequiredNetwork()`)
- Removed unused functions: `getAvailableNetworks()`, `isNetworkAvailable()`, `getCurrentNetwork()`
- Fixed unsafe `network.NAME` access in contract-manager.js switchNetwork method
- Removed redundant `isSupported` property from network event/status objects
- Cleaned up unused variables, debug console.logs, and hardcoded fallback values

**Impact:**
- 20+ chained property accesses replaced with convenience methods
- Config is now truly static (no dynamic getters)
- Single source of truth for network state through NetworkSelector