### PR TITLE
Add claimRewards parameter to unstake ABI

### DIFF
--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -178,7 +178,7 @@ window.CONFIG.ABIS = {
     STAKING_CONTRACT: [
         // Core staking functions
         'function stake(address lpToken, uint256 amount) external',
-        'function unstake(address lpToken, uint256 amount) external',
+        'function unstake(address lpToken, uint256 amount, bool claimRewards) external',
         'function claimRewards(address lpToken) external',
 
         // View functions - User info


### PR DESCRIPTION
Introduce a new parameter to the unstake function in the ABI to allow for optional reward claims during the unstaking process.