### PR TITLE
Show full precision for reward balance

### DIFF
--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -4240,8 +4240,6 @@ class AdminPage {
                 const withdrawAmount = proposal.withdrawAmount
                     ? (typeof proposal.withdrawAmount === 'bigint'
                         ? ethers.utils.formatEther(proposal.withdrawAmount)
-                        : typeof proposal.withdrawAmount === 'number'
-                        ? proposal.withdrawAmount.toString()
                         : proposal.withdrawAmount)
                     : 'Not specified';
 

--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -4982,7 +4982,7 @@ class AdminPage {
                         <form id="withdrawal-form" onsubmit="adminPage.submitWithdrawalProposal(event)">
                             <div class="form-group">
                                 <label for="withdrawal-amount">Amount (${this.contractStats?.rewardTokenSymbol || 'USDC'})</label>
-                                <input type="decimal" id="withdrawal-amount" min="0" required
+                                <input type="number" id="withdrawal-amount" step="any" min="0" inputmode="decimal" required
                                        placeholder="Enter amount to withdraw">
                                 <small class="form-help">Available balance: ${this.contractStats?.rewardBalance ?? 'N/A'}</small>
                             </div>

--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -4240,6 +4240,8 @@ class AdminPage {
                 const withdrawAmount = proposal.withdrawAmount
                     ? (typeof proposal.withdrawAmount === 'bigint'
                         ? ethers.utils.formatEther(proposal.withdrawAmount)
+                        : typeof proposal.withdrawAmount === 'number'
+                        ? proposal.withdrawAmount.toString()
                         : proposal.withdrawAmount)
                     : 'Not specified';
 
@@ -4980,7 +4982,7 @@ class AdminPage {
                         <form id="withdrawal-form" onsubmit="adminPage.submitWithdrawalProposal(event)">
                             <div class="form-group">
                                 <label for="withdrawal-amount">Amount (${this.contractStats?.rewardTokenSymbol || 'USDC'})</label>
-                                <input type="number" id="withdrawal-amount" step="0.01" min="0" required
+                                <input type="decimal" id="withdrawal-amount" min="0" required
                                        placeholder="Enter amount to withdraw">
                                 <small class="form-help">Available balance: ${this.contractStats?.rewardBalance ?? 'N/A'}</small>
                             </div>
@@ -5375,8 +5377,8 @@ class AdminPage {
                         throw new Error('Staking contract address not available');
                     }
                     const balance = await contractManager.rewardTokenContract.balanceOf(stakingContractAddress);
-                    const balanceValue = Number(ethers.utils.formatEther(balance));
-                    return `${balanceValue.toFixed(2)} ${rewardTokenSymbol}`;
+                    const balanceValue = ethers.utils.formatEther(balance);
+                    return `${balanceValue} ${rewardTokenSymbol}`;
                 },
                 null
             );


### PR DESCRIPTION
- In contract info panel show the full precision for Reward Balance
- In create withdraw rewards proposal modal show full precision for Available reward balance, allow fractional withdraw (less than 1)
- In proposal details it now shows the full precision being withdrawn
<img width="858" height="421" alt="image" src="https://github.com/user-attachments/assets/bf0794d8-8d65-4885-88bc-8293fa52aa0b" />
<img width="1213" height="456" alt="image" src="https://github.com/user-attachments/assets/adca2f64-56a9-4b23-9840-1fa055bf4db9" />
<img width="978" height="515" alt="image" src="https://github.com/user-attachments/assets/a6901d2d-9f18-4f00-bdfe-05cc60be5bd9" />
