### PR TITLE
Consolidated duplicate CSS definitions across admin stylesheets

### DIFF
--- a/css/admin-homepage-theme.css
+++ b/css/admin-homepage-theme.css
@@ -512,21 +512,6 @@ textarea::placeholder {
 }
 
 /* ========================================
-   LOADING STATES - HOMEPAGE STYLE
-   ======================================== */
-.loading-spinner,
-.spinner {
-    border-color: rgba(0, 0, 0, 0.1) !important;
-    border-top-color: var(--primary-main) !important;
-}
-
-[data-theme="dark"] .loading-spinner,
-[data-theme="dark"] .spinner {
-    border-color: rgba(255, 255, 255, 0.1) !important;
-    border-top-color: var(--primary-main) !important;
-}
-
-/* ========================================
    CHIPS & BADGES - HOMEPAGE STYLE
    ======================================== */
 .chip,
@@ -845,12 +830,6 @@ select option:disabled,
     animation: spin 0.8s linear infinite !important;
 }
 
-@keyframes spin {
-    to {
-        transform: rotate(360deg);
-    }
-}
-
 .loading-text {
     margin-left: 12px !important;
     font-size: 14px !important;
@@ -999,19 +978,6 @@ button[type="submit"] .btn-text,
     font-size: 13px !important;
     color: var(--error-main) !important;
     min-height: 18px !important;
-}
-
-/* ========================================
-   SPINNER ANIMATION
-   ======================================== */
-.spinner {
-    display: inline-block !important;
-    width: 16px !important;
-    height: 16px !important;
-    border: 2px solid rgba(255, 255, 255, 0.3) !important;
-    border-top-color: white !important;
-    border-radius: 50% !important;
-    animation: spin 0.6s linear infinite !important;
 }
 
 /* ========================================

--- a/css/admin-loading.css
+++ b/css/admin-loading.css
@@ -20,7 +20,7 @@
     height: 50px;
     border: 3px solid rgba(0, 0, 0, 0.1);
     border-radius: 50%;
-    border-top-color: var(--primary-main, #00d4ff);
+    border-top-color: var(#00d4ff);
     animation: spin 1s ease-in-out infinite;
     margin: 0 auto 20px;
 }

--- a/css/admin-loading.css
+++ b/css/admin-loading.css
@@ -18,11 +18,29 @@
 .loading-spinner {
     width: 50px;
     height: 50px;
-    border: 3px solid rgba(255, 255, 255, 0.3);
+    border: 3px solid rgba(0, 0, 0, 0.1);
     border-radius: 50%;
-    border-top-color: #00d4ff;
+    border-top-color: var(--primary-main, #00d4ff);
     animation: spin 1s ease-in-out infinite;
     margin: 0 auto 20px;
+}
+
+/* Dark theme override for loading-spinner (from removed admin-homepage-theme.css) */
+[data-theme="dark"] .loading-spinner {
+    border-color: rgba(255, 255, 255, 0.1) !important;
+    border-top-color: var(--primary-main, #00d4ff) !important;
+}
+
+/* Small inline variant for text/button use (from removed admin.css definition) */
+.loading-spinner.inline,
+.loading-spinner-small {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border: 2px solid currentColor;
+    border-top-color: transparent;
+    margin: 0 0 0 5px;
+    vertical-align: middle;
 }
 
 .loading-container h2 {
@@ -63,8 +81,30 @@
     line-height: 1.6;
 }
 
-@keyframes spin {
-    to { transform: rotate(360deg); }
+/* Spinner */
+.spinner {
+    display: inline-block;
+    width: 40px;
+    height: 40px;
+    border: 4px solid rgba(0, 0, 0, 0.1);
+    border-top-color: var(--primary-main, #1976d2);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+
+/* Small inline variant */
+.spinner.inline,
+.spinner-small {
+    width: 16px;
+    height: 16px;
+    border: 2px solid transparent;
+    border-top: 2px solid currentColor;
+}
+
+/* Theme color overrides */
+[data-theme="dark"] .spinner {
+    border-color: rgba(255, 255, 255, 0.1);
+    border-top-color: var(--primary-main, #1976d2);
 }
 
 #error-boundary {

--- a/css/admin-loading.css
+++ b/css/admin-loading.css
@@ -20,7 +20,7 @@
     height: 50px;
     border: 3px solid rgba(0, 0, 0, 0.1);
     border-radius: 50%;
-    border-top-color: var(#00d4ff);
+    border-top-color: var(--primary-main, #00d4ff);
     animation: spin 1s ease-in-out infinite;
     margin: 0 auto 20px;
 }

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -363,19 +363,6 @@ table tbody tr:last-child td {
 /* ========================================
    LOADING STATES - MATCHING HOMEPAGE
    ======================================== */
-.loading-spinner,
-.spinner {
-    width: 40px;
-    height: 40px;
-    border: 4px solid rgba(0, 0, 0, 0.1);
-    border-top-color: var(--primary-main);
-    border-radius: 50%;
-    animation: spin 0.8s linear infinite;
-}
-
-@keyframes spin {
-    to { transform: rotate(360deg); }
-}
 
 /* Loading skeleton - MATCHING HOMEPAGE */
 .skeleton {

--- a/css/admin.css
+++ b/css/admin.css
@@ -1,13 +1,3 @@
-.loading-spinner {
-    display: inline-block;
-    width: 12px;
-    height: 12px;
-    border: 2px solid #ffffff;
-    border-radius: 50%;
-    border-top-color: transparent;
-    animation: spin 1s linear infinite;
-    margin-right: 5px;
-}
 
 /* Keyframe Animations */
 @keyframes statusPulse {
@@ -17,11 +7,6 @@
 @keyframes loadingShimmer {
     0% { transform: translateX(-100%); }
     100% { transform: translateX(100%); }
-}
-
-@keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
 }
 
 /* Demo Data Indicator */
@@ -590,10 +575,6 @@
     border-top-color: #00d4ff;
     animation: spin 1s ease-in-out infinite;
     margin-left: 10px;
-}
-
-@keyframes spin {
-    to { transform: rotate(360deg); }
 }
 
 /* Responsive Design */
@@ -1367,11 +1348,6 @@ table td:last-child {
     border-top: 2px solid #00d4ff;
     border-radius: 50%;
     animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
 }
 
 /* React-Matching Styles for Exact Parity */
@@ -2289,20 +2265,6 @@ table td:last-child {
     gap: 8px;
 }
 
-.spinner {
-    width: 16px;
-    height: 16px;
-    border: 2px solid transparent;
-    border-top: 2px solid currentColor;
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
-}
-
 /* Weight Update Styles */
 .weight-pair-item {
     display: flex;
@@ -2392,16 +2354,6 @@ table td:last-child {
     color: white;
     font-size: 12px;
     font-weight: bold;
-}
-
-/* Loading Spinner */
-.loading-spinner {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 10px;
-    padding: 20px;
-    color: #666;
 }
 
 /* Modal Loading Animation - Modern Circular Spinner */

--- a/css/components.css
+++ b/css/components.css
@@ -17,21 +17,6 @@
     text-align: center;
 }
 
-.loading-spinner {
-    width: 40px;
-    height: 40px;
-    border: 3px solid var(--border-primary);
-    border-top: 3px solid var(--primary-color);
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
-    margin: 0 auto var(--space-4);
-}
-
-@keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
-}
-
 /* Network Warning */
 .network-warning {
     position: fixed;
@@ -267,45 +252,7 @@
     outline-offset: 2px;
 }
 
-.btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-}
-
 /* Button Variants */
-.btn-primary {
-    background-color: var(--primary-color);
-    color: white;
-    border-color: var(--primary-color);
-}
-
-.btn-primary:hover:not(:disabled) {
-    background-color: var(--primary-hover);
-    border-color: var(--primary-hover);
-}
-
-.btn-secondary {
-    background-color: var(--background-secondary);
-    color: var(--text-primary);
-    border-color: var(--border-primary);
-}
-
-.btn-secondary:hover:not(:disabled) {
-    background-color: var(--background-tertiary);
-    border-color: var(--border-secondary);
-}
-
-.btn-success {
-    background-color: var(--success-color);
-    color: white;
-    border-color: var(--success-color);
-}
-
-.btn-success:hover:not(:disabled) {
-    background-color: var(--success-600);
-    border-color: var(--success-600);
-}
-
 .btn-warning {
     background-color: var(--warning-color);
     color: white;
@@ -339,11 +286,6 @@
 }
 
 /* Button Sizes */
-.btn-small {
-    padding: var(--space-2) var(--space-3);
-    font-size: var(--font-size-xs);
-}
-
 .btn-large {
     padding: var(--space-4) var(--space-6);
     font-size: var(--font-size-base);
@@ -421,43 +363,6 @@
     color: var(--text-tertiary);
     font-size: var(--font-size-sm);
     margin-top: var(--space-1);
-}
-
-/* Cards */
-.card {
-    background-color: var(--background-secondary);
-    border: 1px solid var(--border-primary);
-    border-radius: var(--border-radius-lg);
-    box-shadow: var(--shadow);
-    overflow: hidden;
-}
-
-.card-header {
-    padding: var(--space-6);
-    border-bottom: 1px solid var(--border-primary);
-}
-
-.card-title {
-    font-size: var(--font-size-lg);
-    font-weight: var(--font-weight-semibold);
-    color: var(--text-primary);
-    margin: 0;
-}
-
-.card-subtitle {
-    font-size: var(--font-size-sm);
-    color: var(--text-secondary);
-    margin: var(--space-1) 0 0 0;
-}
-
-.card-body {
-    padding: var(--space-6);
-}
-
-.card-footer {
-    padding: var(--space-6);
-    border-top: 1px solid var(--border-primary);
-    background-color: var(--background-tertiary);
 }
 
 /* Tables */
@@ -807,10 +712,6 @@
 
 .btn-icon {
     font-size: 0.9em;
-}
-
-.btn-text {
-    font-weight: 500;
 }
 
 .expand-btn {
@@ -2837,19 +2738,6 @@
 
 .staking-modal .claim-button:hover:not(.disabled) {
     background: var(--liberdus-purple-dark);
-}
-
-/* Accessibility Features */
-.sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
 }
 
 /* Focus Management */

--- a/css/shared-header.css
+++ b/css/shared-header.css
@@ -1,15 +1,3 @@
-.container-xl {
-    max-width: 1536px;
-    margin: 0 auto;
-    padding: 0 var(--spacing-3);
-}
-
-.container-lg {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 var(--spacing-3);
-}
-
 .header {
     position: sticky;
     top: 0;

--- a/css/theme-toggle.css
+++ b/css/theme-toggle.css
@@ -12,6 +12,7 @@
 .theme-toggle {
     width: 40px;
     height: 40px;
+    padding: 0;
     border: none;
     border-radius: 50%;
     background: transparent;
@@ -20,7 +21,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: transform 0.3s ease-in-out;
+    transition: transform 0.3s ease-in-out, background 0.3s ease-in-out;
+    aspect-ratio: 1;
+    flex-shrink: 0;
 }
 
 .theme-toggle:hover {
@@ -30,14 +33,15 @@
 
 @media (hover: none) and (pointer: coarse) {
     .theme-toggle {
-        min-width: 44px;
-        min-height: 44px;
+        width: 44px;
+        height: 44px;
     }
 }
 
 /* Material Icons support */
 .theme-toggle .material-icons-outlined {
     transition: inherit;
+    flex-shrink: 0;
 }
 
 /* Accessibility - Reduced motion support */

--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -1433,7 +1433,7 @@ class AdminPage {
                         <h2>Multi-Signature Proposals</h2>
                     </div>
                     <div class="loading-container" style="text-align: center; padding: 40px;">
-                        <div class="loading-spinner" style="display: inline-block; width: 40px; height: 40px; border: 4px solid #f3f3f3; border-top: 4px solid #007bff; border-radius: 50%; animation: spin 1s linear infinite;"></div>
+                        <div class="loading-spinner" style="display: inline-block; border: 4px solid #f3f3f3; border-top: 4px solid #007bff; border-radius: 50%; animation: spin 1s linear infinite;"></div>
                         <div style="margin-top: 15px; color: #666;">Loading proposals...</div>
                         <div style="margin-top: 5px; font-size: 0.9em; color: #999;">This may take a few seconds</div>
                     </div>


### PR DESCRIPTION
## PR Summary

****

- **Consolidated spinner/loading styles:**
  - Moved all `.loading-spinner` and `.spinner` definitions to `admin-loading.css` (last loaded)
  - Removed duplicates from `admin.css`, `admin-theme.css`, `admin-homepage-theme.css`, and `components.css`
  - Added dark theme overrides and inline variants for spinner styles
  - Consolidated all `@keyframes spin` to `base.css` (single source of truth)

- **Removed duplicate container utilities:**
  - Removed `.container-lg` and `.container-xl` from `shared-header.css` (already in `base.css`)

- **Removed duplicate button/card components:**
  - Removed `.btn-primary`, `.btn-secondary`, `.btn-success`, `.btn-small` from `components.css` (already in `base.css`)
  - Removed `.card`, `.card-header`, `.card-body`, `.card-footer` from `components.css` (already in `base.css`)
  - Removed duplicate `.sr-only` utility from `components.css` (already in `base.css`)

- **Fixed theme-toggle hover circle:**
  - Added `aspect-ratio: 1` and `flex-shrink: 0` to keep perfect circle on hover
  - Ensures consistent circular hover state across home and admin pages

**Result:** `base.css` is the authoritative source for shared utilities, eliminating duplicate definitions and reducing CSS bundle size.