### PR TITLE
Remove Unused CSS Utilities and Legacy Styles

### DIFF
--- a/css/admin-homepage-theme.css
+++ b/css/admin-homepage-theme.css
@@ -101,7 +101,6 @@ body {
 .btn-secondary,
 .btn-danger,
 .btn-error,
-.btn-warning,
 .btn-success {
     background: var(--primary-main) !important;
     border: none !important;
@@ -123,10 +122,6 @@ body {
 .btn-danger,
 .btn-error {
     background: var(--error-main) !important;
-}
-
-.btn-warning {
-    background: var(--warning-main) !important;
 }
 
 .btn-success {
@@ -154,11 +149,6 @@ body {
     box-shadow: 0 4px 12px rgba(244, 67, 54, 0.3) !important;
 }
 
-.btn-warning:hover:not(:disabled) {
-    background: #fb8c00 !important;
-    transform: translateY(-1px) !important;
-    box-shadow: var(--shadow-4) !important;
-}
 
 .btn-success:hover:not(:disabled) {
     background: #43a047 !important;
@@ -604,7 +594,6 @@ textarea::placeholder {
 /* ========================================
    ERROR STATES - HOMEPAGE STYLE
    ======================================== */
-.error-state,
 .error-message {
     background: rgba(244, 67, 54, 0.1) !important;
     border: 1px solid var(--error-main) !important;
@@ -924,22 +913,6 @@ select option:disabled,
     }
 }
 
-.loading-spinner-container {
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-    padding: 40px !important;
-    color: var(--text-secondary) !important;
-}
-
-.loading-spinner-container .spinner {
-    width: 40px !important;
-    height: 40px !important;
-    border: 4px solid var(--divider) !important;
-    border-top-color: var(--primary-main) !important;
-    border-radius: 50% !important;
-    animation: spin 0.8s linear infinite !important;
-}
 
 .loading-text {
     margin-left: 12px !important;
@@ -964,7 +937,6 @@ select option:disabled,
 button[type="submit"] .btn-text,
 .btn-primary .btn-text,
 .btn-danger .btn-text,
-.btn-warning .btn-text,
 .btn-secondary .btn-text {
     color: white !important;
 }
@@ -1049,7 +1021,6 @@ button[type="submit"] .btn-text,
 .btn-primary:active:not(:disabled),
 .btn-danger:active:not(:disabled),
 .btn-error:active:not(:disabled),
-.btn-warning:active:not(:disabled),
 .btn-secondary:active:not(:disabled),
 .proposal-btn:active:not(:disabled) {
     transform: translateY(0) !important;

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -90,7 +90,6 @@ label {
 }
 
 .form-input,
-.form-control,
 input[type="text"],
 input[type="number"],
 input[type="email"],
@@ -108,7 +107,6 @@ select {
 }
 
 .form-input:focus,
-.form-control:focus,
 input:focus,
 textarea:focus,
 select:focus {
@@ -117,7 +115,6 @@ select:focus {
 }
 
 .form-input:disabled,
-.form-control:disabled,
 input:disabled,
 textarea:disabled,
 select:disabled {

--- a/css/admin.css
+++ b/css/admin.css
@@ -340,25 +340,6 @@
     font-weight: 500;
 }
 
-/* Error Display */
-.error-display {
-    text-align: center;
-    padding: 60px 20px;
-    background: rgba(244, 67, 54, 0.1);
-    border: 1px solid rgba(244, 67, 54, 0.3);
-    border-radius: 12px;
-}
-
-.error-display h3 {
-    margin: 0 0 15px 0;
-    color: #ff6b6b;
-    font-size: 20px;
-}
-
-.error-display p {
-    color: #a0a0a0;
-    margin-bottom: 25px;
-}
 
 /* Loading States */
 .loading {
@@ -1251,7 +1232,6 @@ table td:last-child {
 
 /* SUBMIT BUTTON VISIBILITY FIXES */
 .modal-footer .btn-danger,
-.modal-footer .btn-warning,
 .modal-footer button[type="submit"],
 .modal-footer button[form="remove-pair-form"],
 .modal-footer button[form="change-signer-form"] {
@@ -1270,11 +1250,6 @@ table td:last-child {
 
 
 
-.new-proposal-highlight {
-    background: linear-gradient(90deg, #e8f5e8 0%, #ffffff 100%) !important;
-    border-left: 4px solid #4caf50 !important;
-    animation: newProposalGlow 3s ease-out;
-}
 
 @keyframes optimisticPulse {
     0%, 100% { opacity: 1; }
@@ -1286,16 +1261,6 @@ table td:last-child {
     50% { transform: scale(1.05); }
 }
 
-@keyframes newProposalGlow {
-    0% {
-        background: linear-gradient(90deg, #c8e6c9 0%, #ffffff 100%);
-        transform: scale(1.02);
-    }
-    100% {
-        background: linear-gradient(90deg, #ffffff 0%, #ffffff 100%);
-        transform: scale(1);
-    }
-}
 
 .form-group label {
     display: block;

--- a/css/components.css
+++ b/css/components.css
@@ -998,47 +998,6 @@
     max-width: 600px;
 }
 
-.staking-modal-content {
-    padding: 0;
-}
-
-.staking-modal-header {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: var(--space-6);
-    gap: var(--space-3);
-}
-
-.staking-modal-header .header-icon {
-    color: var(--primary-color);
-}
-
-.staking-modal-header .modal-title {
-    font-size: 1.5rem;
-    font-weight: 600;
-    margin: 0;
-    color: var(--text-primary);
-}
-
-.staking-modal-loading {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: var(--space-8);
-    gap: var(--space-4);
-}
-
-.staking-modal-loading .loading-spinner {
-    width: 40px;
-    height: 40px;
-    border: 3px solid var(--border-color);
-    border-top: 3px solid var(--primary-color);
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
-}
-
 .tab-button {
     display: flex;
     align-items: center;

--- a/css/notifications.css
+++ b/css/notifications.css
@@ -210,34 +210,6 @@
     color: #334155;
 }
 
-/* ========================================
-   DARK MODE THEME (Body class variant)
-   ======================================== */
-body.dark-mode .notification {
-    background: rgba(30, 41, 59, 0.95);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    border: 1px solid rgba(71, 85, 105, 0.5);
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-}
-
-body.dark-mode .notification-title {
-    color: #f1f5f9;
-}
-
-body.dark-mode .notification-message {
-    color: #cbd5e1;
-}
-
-body.dark-mode .notification-close {
-    background: rgba(71, 85, 105, 0.4);
-    color: #94a3b8;
-}
-
-body.dark-mode .notification-close:hover {
-    background: rgba(100, 116, 139, 0.6);
-    color: #e2e8f0;
-}
 
 @media (prefers-contrast: high) {
     .notification {

--- a/css/shared-header.css
+++ b/css/shared-header.css
@@ -175,25 +175,6 @@
     font-weight: var(--liberdus-font-medium);
 }
 
-/* Theme Toggle Button */
-.theme-toggle-btn {
-  width: 36px;
-  height: 36px;
-  border-radius: 0.375rem;
-  background: var(--liberdus-bg-tertiary);
-  border: 1px solid var(--liberdus-border-primary);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: all var(--transition-fast);
-}
-
-.theme-toggle-btn:hover {
-  background: var(--liberdus-bg-hover);
-  border-color: var(--liberdus-border-secondary);
-}
-
 .theme-icon {
   font-size: 1.125rem;
 }

--- a/css/wallet-popup.css
+++ b/css/wallet-popup.css
@@ -169,10 +169,6 @@
         padding: var(--spacing-2);
     }
 
-    .avatar-circle {
-        width: 56px;
-        height: 56px;
-    }
 
     .address-text {
         font-size: 0.875rem;
@@ -184,28 +180,6 @@
     }
 }
 
-/* Animation Classes */
-.wallet-popup-enter {
-    opacity: 0;
-    transform: translateY(-10px) scale(0.95);
-}
-
-.wallet-popup-enter-active {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-    transition: all 0.2s ease-out;
-}
-
-.wallet-popup-exit {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-}
-
-.wallet-popup-exit-active {
-    opacity: 0;
-    transform: translateY(-10px) scale(0.95);
-    transition: all 0.15s ease-in;
-}
 
 /* Focus States for Accessibility */
 .action-button:focus,


### PR DESCRIPTION
- remove CSS utility classes in `css/base.css`, `css/home.css`, and associated components (admin theme, shared header, wallet popup, notifications) to eliminate 68 unused selectors  
- Drop legacy utility names and state-specific entries that no longer exist in the codebase  
- strip unused button/error/modal styles from admin-related CSS files (e.g., `btn-warning`, `error-display`, `staking-modal-*`, wallet popup animations)