### PR TITLE
Make modal close and header styles consistent

### DIFF
--- a/css/admin-combined.css
+++ b/css/admin-combined.css
@@ -1134,13 +1134,6 @@ table td:last-child {
   width: 8px;
 }
 
-.modal-header h3::before {
-  content: '✨';
-  font-size: 2rem;
-  flex-shrink: 0;
-  display: inline-block;
-}
-
 .modal-body > * {
   max-width: 100%;
   box-sizing: border-box;
@@ -2070,37 +2063,6 @@ body.admin-page {
 .modal-body small,
 .modal-body .form-help {
   color: var(--text-secondary) !important;
-}
-
-.modal-close {
-  background: transparent !important;
-  color: var(--text-secondary) !important;
-  border: none !important;
-  cursor: pointer;
-  padding: var(--space-2);
-  font-size: var(--font-size-xl);
-  line-height: 1;
-  border-radius: var(--border-radius);
-  transition: all var(--transition-fast);
-  width: 32px;
-  height: 32px;
-  background-color: transparent;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: bold;
-  position: absolute;
-  top: 1.5rem;
-  right: 1.5rem;
-}
-
-.modal-close:hover {
-  background: var(--action-hover) !important;
-  color: var(--text-primary) !important;
-  background-color: var(--background-tertiary);
-  transform: rotate(90deg) scale(1.05);
-  box-shadow: 0 0 20px rgba(231, 76, 60, 0.6);
-  border-color: rgba(231, 76, 60, 0.5);
 }
 
 .proposal-id-container {

--- a/css/base.css
+++ b/css/base.css
@@ -672,3 +672,34 @@ ol {
     stroke-linejoin: round;
     fill: none;
 }
+
+/* Shared Modal Styles */
+.modal-close {
+  background: transparent !important;
+  color: var(--text-secondary) !important;
+  border: none !important;
+  cursor: pointer;
+  padding: var(--space-2);
+  font-size: var(--font-size-xl);
+  line-height: 1;
+  border-radius: var(--border-radius);
+  transition: all var(--transition-fast);
+  width: 32px;
+  height: 32px;
+  background-color: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+}
+
+.modal-close:hover {
+  background: var(--action-hover) !important;
+  color: var(--text-primary) !important;
+  background-color: var(--background-tertiary);
+  box-shadow: 0 0 20px rgba(231, 76, 60, 0.6);
+  border-color: rgba(231, 76, 60, 0.5);
+}

--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -73,21 +73,6 @@
     font-size: 14px;
 }
 
-.modal-close {
-    background: transparent;
-    border: none;
-    color: var(--text-secondary);
-    cursor: pointer;
-    padding: var(--spacing-1);
-    border-radius: 50%;
-    transition: all 0.2s;
-}
-
-.modal-close:hover {
-    background: var(--action-hover);
-    color: var(--text-primary);
-}
-
 /* Modal Tabs */
 .modal-tabs {
     display: flex;

--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -780,15 +780,6 @@ class AdminPage {
                 return;
             }
 
-            // Modal close buttons
-            if (e.target.classList.contains('modal-close') ||
-                e.target.closest('.modal-close')) {
-                e.preventDefault();
-                console.log('🔘 Modal close button clicked');
-                this.closeModal();
-                return;
-            }
-
             // Modal overlay click (close modal)
             if (e.target.classList.contains('modal-overlay')) {
                 e.preventDefault();
@@ -3779,18 +3770,6 @@ class AdminPage {
             }
         }
 
-        // Also add click handler to modal close button (X)
-        const closeButton = modalContent?.querySelector('.modal-close');
-        if (closeButton) {
-            closeButton.onclick = (e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                console.log('🔘 Close button (X) clicked via explicit handler');
-                this.closeModal();
-            };
-            console.log('🔧 DEBUG: Added click handler to close button (X)');
-        }
-
         if (modalOverlay) {
             modalOverlay.style.zIndex = '999999';
             modalOverlay.style.opacity = '1';
@@ -3828,7 +3807,9 @@ class AdminPage {
                 <div class="modal-content" onclick="event.stopPropagation()">
                     <div class="modal-header">
                         <h3>Update Hourly Rate</h3>
-                        <button class="modal-close" type="button">×</button>
+                        <button class="modal-close" type="button" onclick="adminPage.closeModal()">
+                            <span class="material-icons">close</span>
+                        </button>
                     </div>
 
                     <div class="modal-body">
@@ -3885,7 +3866,9 @@ class AdminPage {
                 <div class="modal-content" onclick="event.stopPropagation()">
                     <div class="modal-header">
                         <h3>Add New Pair</h3>
-                        <button class="modal-close" type="button">×</button>
+                        <button class="modal-close" type="button" onclick="adminPage.closeModal()">
+                            <span class="material-icons">close</span>
+                        </button>
                     </div>
 
                     <div class="modal-body">
@@ -3989,11 +3972,11 @@ class AdminPage {
             <div class="modal-overlay">
                 <div class="modal-content" onclick="event.stopPropagation()" style="max-width: 700px;">
                     <div class="modal-header" style="padding: 24px; border-bottom: 1px solid var(--divider);">
-                        <h3 style="margin: 0; font-size: 24px; font-weight: 600; display: flex; align-items: center; gap: 10px;">
-                            <span style="font-size: 28px;">⚖️</span>
-                            Update Pair Weights
-                        </h3>
-                        <button class="modal-close" type="button" style="font-size: 28px; color: var(--text-secondary);">×</button>
+                        <h3>
+                            Update Pair Weights</h3>
+                        <button class="modal-close" type="button" onclick="adminPage.closeModal()">
+                            <span class="material-icons">close</span>
+                        </button>
                     </div>
 
                     <div class="modal-body" style="padding: 24px; max-height: 600px; overflow-y: auto;">
@@ -4057,8 +4040,10 @@ class AdminPage {
             <div class="modal-overlay" onclick="adminPage.closeModal()">
                 <div class="modal-content" onclick="event.stopPropagation()">
                     <div class="modal-header">
-                        <h3>✨ Remove LP Pair</h3>
-                        <button class="modal-close" onclick="adminPage.closeModal()">×</button>
+                        <h3>Remove LP Pair</h3>
+                        <button class="modal-close" type="button" onclick="adminPage.closeModal()">
+                            <span class="material-icons">close</span>
+                        </button>
                     </div>
 
                     <div class="modal-body">
@@ -4198,7 +4183,9 @@ class AdminPage {
                 <div class="modal-content" onclick="event.stopPropagation()">
                     <div class="modal-header">
                         <h3>Change Signer</h3>
-                        <button class="modal-close" onclick="adminPage.closeModal()">×</button>
+                        <button class="modal-close" type="button" onclick="adminPage.closeModal()">
+                            <span class="material-icons">close</span>
+                        </button>
                     </div>
 
                     <div class="modal-body">
@@ -4264,7 +4251,9 @@ class AdminPage {
                 <div class="modal-content" onclick="event.stopPropagation()">
                     <div class="modal-header">
                         <h3>Withdraw Rewards</h3>
-                        <button class="modal-close" onclick="adminPage.closeModal()">×</button>
+                        <button class="modal-close" type="button" onclick="adminPage.closeModal()">
+                            <span class="material-icons">close</span>
+                        </button>
                     </div>
 
                     <div class="modal-body">


### PR DESCRIPTION
- Standardize modal close style moving shared style into base.css
- Change admin proposal modals to use the material icon close instead of 'x' character matching the staking modal
- Remove extra modal-close events in admin-page now that all modal-close buttons use the same onclick function
- Standardize proposal modal headers removing extra css emoji and inline styles