### PR TITLE
Refactor table layout: Move platform info under pair name to save space*

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -118,7 +118,6 @@ body {
 
 .table th .material-icons {
     vertical-align: middle;
-    margin-right: var(--spacing-1);
     color: var(--primary-main);
 }
 

--- a/index.html
+++ b/index.html
@@ -88,7 +88,6 @@
                         <thead>
                             <tr>
                                 <th><span class="material-icons">swap_horiz</span> Pair</th>
-                                <th><span class="material-icons">business</span> Platform</th>
                                 <th><span class="material-icons">trending_up</span> APR</th>
                                 <th><span class="material-icons">fitness_center</span> Weight</th>
                                 <th><span class="material-icons">account_balance</span> TVL</th>
@@ -97,9 +96,30 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <tr><td><div class="skeleton" style="height: 20px; width: 120px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 60px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 100px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 120px;"></div></td></tr>
-                            <tr><td><div class="skeleton" style="height: 20px; width: 120px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 60px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 100px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 120px;"></div></td></tr>
-                            <tr><td><div class="skeleton" style="height: 20px; width: 120px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 60px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 100px;"></div></td><td><div class="skeleton" style="height: 20px; width: 80px;"></div></td><td><div class="skeleton" style="height: 20px; width: 120px;"></div></td></tr>
+                            <tr>
+                                <td><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
+                                <td><div class="skeleton" style="height: 20px; width: 60px;"></div></td>
+                                <td><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
+                                <td><div class="skeleton" style="height: 20px; width: 100px;"></div></td>
+                                <td><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
+                                <td><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
+                            </tr>
+                            <tr>
+                                <td><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
+                                <td><div class="skeleton" style="height: 20px; width: 60px;"></div></td>
+                                <td><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
+                                <td><div class="skeleton" style="height: 20px; width: 100px;"></div></td>
+                                <td><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
+                                <td><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
+                            </tr>
+                            <tr>
+                                <td><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
+                                <td><div class="skeleton" style="height: 20px; width: 60px;"></div></td>
+                                <td><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
+                                <td><div class="skeleton" style="height: 20px; width: 100px;"></div></td>
+                                <td><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
+                                <td><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
+                            </tr>
                         </tbody>
                     </table>
                 </div>

--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -224,10 +224,6 @@ class HomePage {
                                 Pair
                             </th>
                             <th>
-                                <span class="material-icons">business</span>
-                                Platform
-                            </th>
-                            <th>
                                 <span class="material-icons">trending_up</span>
                                 APR
                             </th>
@@ -253,7 +249,6 @@ class HomePage {
                         ${Array(3).fill(0).map(() => `
                             <tr>
                                 <td><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
                                 <td><div class="skeleton" style="height: 20px; width: 60px;"></div></td>
                                 <td><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
                                 <td><div class="skeleton" style="height: 20px; width: 100px;"></div></td>
@@ -337,7 +332,7 @@ class HomePage {
             // Show "no data" row when there are no pairs
             tbodyContent = `
                 <tr>
-                    <td colspan="7" style="text-align: center; padding: 48px 24px; color: var(--text-secondary);">
+                    <td colspan="6" style="text-align: center; padding: 48px 24px; color: var(--text-secondary);">
                         <div style="display: flex; flex-direction: column; align-items: center; gap: 16px;">
                             <span class="material-icons" style="font-size: 48px; color: var(--text-secondary); opacity: 0.5;">inbox</span>
                             <div>
@@ -384,10 +379,6 @@ class HomePage {
                                 Pair
                             </th>
                             <th>
-                                <span class="material-icons">business</span>
-                                Platform
-                            </th>
-                            <th>
                                 <span class="material-icons">trending_up</span>
                                 APR
                             </th>
@@ -423,13 +414,16 @@ class HomePage {
         const userShares = pair.userShares || '0.00';
         const userEarnings = pair.userEarnings || '0.00';
         
+        const pairNameHtml = window.Formatter?.formatPairName(pair.name, pair.address, pair.platform) || pair.name;
+        const platformHtml = pair.platform ? `<div style="font-size: 12px; color: var(--text-secondary);">${pair.platform}</div>` : '';
+        
         return `
             <tr class="pair-row" data-pair-id="${pair.id}" style="cursor: pointer;">
                 <td>
-                    ${window.Formatter?.formatPairName(pair.name, pair.address, pair.platform) || pair.name}
-                </td>
-                <td>
-                    ${pair.platform ? `<span style="font-weight: 600; font-size: smaller;">${pair.platform}</span>` : '<span>-</span>'}
+                    <div style="display: flex; flex-direction: column;">
+                        ${pairNameHtml}
+                        ${platformHtml}
+                    </div>
                 </td>
                 <td>
                     <span style="color: var(--success-main); font-weight: bold;">${pair.apr || '0.00'}%</span>


### PR DESCRIPTION
## PR summary
- Removed Platform column from the staking pairs table to save horizontal space
- Moved platform information to display as small text (12px) directly under the pair name
- Updated table structure from 7 columns to 6 columns across all table instances
- Updated skeleton loader rows to match new column structure (removed platform column)
- Fixed colspan from 7 to 6 in "no data" empty state message
- Removed unnecessary margin-right spacing from table header icons in CSS

### Files changed
- `js/components/home-page.js` - Updated table rendering logic, removed platform column cell
- `index.html` - Updated skeleton table structure with improved formatting
- `css/home.css` - Cleaned up table header icon spacing

### Benefits
- More compact table layout with better space utilization
- Cleaner visual hierarchy with platform as secondary information
- Consistent styling with platform displayed in smaller, secondary text color