### PR TITLE
Fix reward runway calculation precision

### DIFF
--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -4386,8 +4386,9 @@ class AdminPage {
                     if (balanceBig && obligationBig && rateBig && rateBig.gt(0)) {
                         const effectiveBalance = balanceBig.sub(obligationBig);
                         if (effectiveBalance.gt(0)) {
-                            const runwayHoursBig = effectiveBalance.div(rateBig);
-                            const runwayHours = Number(ethers.utils.formatEther(runwayHoursBig));
+                            // runwayHours = (effectiveBalance * 1e18) / rateBig, then formatEther to get decimal
+                            const scaledHours = effectiveBalance.mul(ethers.constants.WeiPerEther).div(rateBig);
+                            const runwayHours = Number(ethers.utils.formatEther(scaledHours));
                             const runwayDays = runwayHours / 24;
                             return `${runwayHours.toFixed(1)} hours (${runwayDays.toFixed(1)} days)`;
                         } else {


### PR DESCRIPTION
Problem: The reward runway was always displaying 0.0 hours (0.0 days) due to a precision loss bug.

Root cause: When dividing two BigNumbers in wei scale, the result lost decimal precision. Then formatEther() was incorrectly applied to the integer result, dividing by 10^18 again and producing a tiny value (~9e-18) that rounded to 0.

Fix: Scale up by 10^18 before division to preserve precision