### PR TITLE
Sort data rows alphabetically by pair name

### DIFF
--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -351,22 +351,11 @@ class HomePage {
                 </tr>
             `;
         } else {
-            // Show data rows
+            // Show data rows sorted alphabetically by pair name
             tbodyContent = [...displayPairs].sort((a, b) => {
-                const parseValue = (value) => {
-                    const num = parseFloat(value ?? '0');
-                    return Number.isFinite(num) ? num : 0;
-                };
-
-                const aprA = parseValue(a.apr);
-                const aprB = parseValue(b.apr);
-                if (aprB !== aprA) {
-                    return aprB - aprA;
-                }
-
-                const tvlA = parseValue(a.tvl ?? a.totalStaked);
-                const tvlB = parseValue(b.tvl ?? b.totalStaked);
-                return tvlB - tvlA;
+                const nameA = (a.name || '').toLowerCase();
+                const nameB = (b.name || '').toLowerCase();
+                return nameA.localeCompare(nameB);
             }).map(pair => this.renderPairRow(pair)).join('');
         }
 


### PR DESCRIPTION
Sorts the displayed data rows alphabetically based on the pair name instead of by APR and TVL values, so that pairs don't jump around in the table as users stake and unstake.