### PR TITLE
Transition frontend network support to BNB mainnet and testnet

### DIFF
--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -288,7 +288,7 @@ class AdminPage {
 
     renderUnauthorizedNetworkOptions() {
         const selectedNetwork = window.networkSelector?.getSelectedNetworkKey?.() || '';
-        const networks = Object.entries(window.CONFIG?.NETWORKS || {});
+        const networks = window.networkSelector?.getSelectableNetworkEntries?.() || [];
 
         return networks.map(([key, network]) => `
             <option value="${key}" ${selectedNetwork === key ? 'selected' : ''}>${network.NAME}</option>

--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -286,12 +286,20 @@ class AdminPage {
         `;
     }
 
+    renderUnauthorizedNetworkOptions() {
+        const selectedNetwork = window.networkSelector?.getSelectedNetworkKey?.() || '';
+        const networks = Object.entries(window.CONFIG?.NETWORKS || {});
+
+        return networks.map(([key, network]) => `
+            <option value="${key}" ${selectedNetwork === key ? 'selected' : ''}>${network.NAME}</option>
+        `).join('');
+    }
 
     showUnauthorizedAccess() {
         const container = document.getElementById('admin-content') || document.body;
         const currentNetwork = window.networkSelector?.getCurrentNetworkName();
         const currentChainId = window.networkSelector?.getCurrentChainId();
-        const currentContract = window.networkSelector?.getStakingContractAddress();
+        const currentContract = window.networkSelector?.getStakingContractAddress() || 'Not deployed yet';
         
         container.innerHTML = `
             <div class="admin-unauthorized">
@@ -320,8 +328,7 @@ class AdminPage {
                         <p>Or try switching to a network where you have admin permissions:</p>
                         <div class="network-selector-container">
                             <select id="unauthorized-network-select" class="network-select">
-                                <option value="AMOY" ${(window.networkSelector.getSelectedNetworkKey() || '') === 'AMOY' ? 'selected' : ''}>Amoy Testnet</option>
-                                <option value="POLYGON_MAINNET" ${(window.networkSelector.getSelectedNetworkKey() || '') === 'POLYGON_MAINNET' ? 'selected' : ''}>Polygon Mainnet</option>
+                                ${this.renderUnauthorizedNetworkOptions()}
                             </select>
                         </div>
                     </div>
@@ -1124,11 +1131,14 @@ class AdminPage {
         }
 
         statusContainer.className = `transaction-status ${statusClass}`;
+        const txUrl = hash
+            ? window.networkManager?.getTransactionUrl(hash, window.networkSelector?.getCurrentChainId?.())
+            : '';
         statusContainer.innerHTML = `
             <div class="status-content">
                 <span class="status-icon">${icon}</span>
                 <span class="status-message">${message}</span>
-                ${hash ? `<a href="https://amoy.polygonscan.com/tx/${hash}" target="_blank" class="tx-link">View Transaction</a>` : ''}
+                ${txUrl ? `<a href="${txUrl}" target="_blank" class="tx-link">View Transaction</a>` : ''}
                 ${error ? `<div class="error-details">${error}</div>` : ''}
             </div>
             <button class="close-status" onclick="this.parentNode.style.display='none'">×</button>

--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -330,6 +330,13 @@ class HomePage {
         // Generate table rows - either data rows or "no data" row
         let tbodyContent = '';
         if (displayPairs.length === 0) {
+            const networkName = window.networkSelector?.getCurrentNetworkName?.() || 'this network';
+            const hasConfiguredContract = !!window.networkSelector?.getStakingContractAddress?.()?.trim();
+            const emptyStateTitle = hasConfiguredContract ? 'No Staking Pairs Available' : 'Staking Not Deployed Yet';
+            const emptyStateMessage = hasConfiguredContract
+                ? 'There are currently no staking pairs configured in the contract. Please check back later.'
+                : `Liberdus LP Staking is not deployed on ${networkName} yet. Please check back after the contract is deployed.`;
+
             // Show "no data" row when there are no pairs to display (after filtering)
             tbodyContent = `
                 <tr>
@@ -337,9 +344,9 @@ class HomePage {
                         <div style="display: flex; flex-direction: column; align-items: center; gap: 16px;">
                             <span class="material-icons" style="font-size: 48px; color: var(--text-secondary); opacity: 0.5;">inbox</span>
                             <div>
-                                <p style="font-size: 16px; font-weight: 500; margin: 0 0 8px 0; color: var(--text-primary);">No Staking Pairs Available</p>
+                                <p style="font-size: 16px; font-weight: 500; margin: 0 0 8px 0; color: var(--text-primary);">${emptyStateTitle}</p>
                                 <p style="font-size: 14px; margin: 0; color: var(--text-secondary);">
-                                    There are currently no staking pairs configured in the contract. Please check back later.
+                                    ${emptyStateMessage}
                                 </p>
                             </div>
                             <button class="btn btn-primary" id="retry-load" type="button" style="margin-top: 8px;">

--- a/js/components/network-indicator-selector.js
+++ b/js/components/network-indicator-selector.js
@@ -15,12 +15,24 @@ class NetworkSelector {
         this.isInitialized = false;
         this.eventListeners = new Map(); // Store event listeners for cleanup
         this._networkSwitching = false; // Track network switching state
-        this.defaultNetwork = 'AMOY';
+        this.defaultNetwork = 'BSC_MAINNET';
+        this.selectableNetworks = ['BSC_MAINNET', 'BSC_TESTNET'];
+    }
+
+    getSelectableNetworkEntries() {
+        const networks = window.CONFIG?.NETWORKS || {};
+        return this.selectableNetworks
+            .map((networkKey) => [networkKey, networks[networkKey]])
+            .filter(([, network]) => !!network);
+    }
+
+    isSelectableNetworkKey(networkKey) {
+        return this.getSelectableNetworkEntries().some(([key]) => key === networkKey);
     }
 
     getSelectedNetworkKey() {
-        const selectedNetworkKey = localStorage.getItem('liberdus-selected-network')
-        if (!selectedNetworkKey) {
+        const selectedNetworkKey = localStorage.getItem('liberdus-selected-network');
+        if (!selectedNetworkKey || !this.isSelectableNetworkKey(selectedNetworkKey)) {
             localStorage.setItem('liberdus-selected-network', this.defaultNetwork);
             return this.defaultNetwork;
         }
@@ -101,7 +113,7 @@ class NetworkSelector {
      * Get the HTML for the network selector dropdown
      */
     getSelectorHTML() {
-        const networks = Object.entries(window.CONFIG.NETWORKS);
+        const networks = this.getSelectableNetworkEntries();
         const selectedNetwork = this.getSelectedNetworkKey();
         
         return `

--- a/js/components/network-indicator-selector.js
+++ b/js/components/network-indicator-selector.js
@@ -371,28 +371,6 @@ class NetworkSelector {
  */
 class NetworkIndicator {
     /**
-     * Ensure the indicator shell exists without rebuilding the selector on every update.
-     * @param {HTMLElement} indicator
-     * @param {string} selectorId
-     * @returns {{ statusDot: HTMLElement | null, selectorContainer: HTMLElement | null }}
-     */
-    static ensureStructure(indicator, selectorId) {
-        let statusDot = indicator.querySelector('.network-status-dot');
-        let selectorContainer = indicator.querySelector(`#${selectorId}`);
-
-        if (!statusDot || !selectorContainer) {
-            indicator.innerHTML = `
-                <span class="network-status-dot gray"></span>
-                <div id="${selectorId}"></div>
-            `;
-            statusDot = indicator.querySelector('.network-status-dot');
-            selectorContainer = indicator.querySelector(`#${selectorId}`);
-        }
-
-        return { statusDot, selectorContainer };
-    }
-
-    /**
      * Update network indicator for a given context
      * @param {string} indicatorId - ID of the indicator element
      * @param {string} selectorId - ID of the network selector container
@@ -402,33 +380,17 @@ class NetworkIndicator {
         const indicator = document.getElementById(indicatorId);
         if (!indicator) return;
 
-        const requestKey = `${indicatorId}:${selectorId}:${context}`;
-        const nextRequestId = (NetworkIndicator._requestTokens.get(requestKey) || 0) + 1;
-        NetworkIndicator._requestTokens.set(requestKey, nextRequestId);
-
         // Always show the network indicator
         indicator.style.display = 'flex';
 
-        const { statusDot, selectorContainer } = this.ensureStructure(indicator, selectorId);
-
-        // Show loading state initially, but preserve the existing selector DOM to avoid flicker.
+        // Show loading state initially
+        indicator.innerHTML = `
+            <span class="network-status-dot gray"></span>
+            <div id="${selectorId}"></div>
+        `;
         indicator.className = `network-indicator-home loading`;
-        if (statusDot) {
-            statusDot.className = 'network-status-dot gray';
-        }
-
-        if (selectorContainer && window.networkSelector) {
-            const hasSelector = selectorContainer.querySelector('.network-selector');
-            if (!hasSelector) {
-                window.networkSelector.createSelector(selectorId, context);
-            } else {
-                window.networkSelector.updateNetworkDisplay();
-            }
-        }
 
         const isWalletConnected = window.walletManager && window.walletManager.isConnected();
-        let nextClassName = 'network-indicator-home no-wallet';
-        let nextDotClassName = 'network-status-dot gray';
 
         // Check permission asynchronously if wallet is connected
         if (isWalletConnected && window.networkManager) {
@@ -436,32 +398,48 @@ class NetworkIndicator {
                 const hasPermission = await window.networkManager.hasRequiredNetworkPermission();
 
                 if (hasPermission) {
-                    nextClassName = 'network-indicator-home has-permission';
-                    nextDotClassName = 'network-status-dot green';
+                    // Green indicator - has permission
+                    indicator.innerHTML = `
+                        <span class="network-status-dot green"></span>
+                        <div id="${selectorId}"></div>
+                    `;
+                    indicator.className = `network-indicator-home has-permission`;
                 } else {
-                    nextClassName = 'network-indicator-home missing-permission';
-                    nextDotClassName = 'network-status-dot red';
+                    // Red indicator - missing permission
+                    indicator.innerHTML = `
+                        <span class="network-status-dot red"></span>
+                        <div id="${selectorId}"></div>
+                    `;
+                    indicator.className = `network-indicator-home missing-permission`;
                 }
             } catch (error) {
                 console.error('Error checking network permission:', error);
-                nextClassName = 'network-indicator-home missing-permission';
-                nextDotClassName = 'network-status-dot red';
+                // Fallback to no permission state
+                indicator.innerHTML = `
+                    <span class="network-status-dot red"></span>
+                    <div id="${selectorId}"></div>
+                `;
+                indicator.className = `network-indicator-home missing-permission`;
             }
+        } else {
+            // No wallet connected - show network selector only
+            indicator.innerHTML = `
+                <span class="network-status-dot gray"></span>
+                <div id="${selectorId}"></div>
+            `;
+            indicator.className = `network-indicator-home no-wallet`;
         }
 
-        // Ignore stale async updates from earlier network/permission checks.
-        if (NetworkIndicator._requestTokens.get(requestKey) !== nextRequestId) {
-            return;
-        }
-
-        indicator.className = nextClassName;
-        if (statusDot) {
-            statusDot.className = nextDotClassName;
-        }
+        // Add network selector after DOM update
+        setTimeout(() => {
+            const container = document.getElementById(selectorId);
+            if (container && window.networkSelector) {
+                container.innerHTML = '';
+                window.networkSelector.createSelector(selectorId, context);
+            }
+        }, 100);
     }
 }
-
-NetworkIndicator._requestTokens = new Map();
 
 // Create global instances
 window.networkSelector = new NetworkSelector();

--- a/js/components/network-indicator-selector.js
+++ b/js/components/network-indicator-selector.js
@@ -371,6 +371,28 @@ class NetworkSelector {
  */
 class NetworkIndicator {
     /**
+     * Ensure the indicator shell exists without rebuilding the selector on every update.
+     * @param {HTMLElement} indicator
+     * @param {string} selectorId
+     * @returns {{ statusDot: HTMLElement | null, selectorContainer: HTMLElement | null }}
+     */
+    static ensureStructure(indicator, selectorId) {
+        let statusDot = indicator.querySelector('.network-status-dot');
+        let selectorContainer = indicator.querySelector(`#${selectorId}`);
+
+        if (!statusDot || !selectorContainer) {
+            indicator.innerHTML = `
+                <span class="network-status-dot gray"></span>
+                <div id="${selectorId}"></div>
+            `;
+            statusDot = indicator.querySelector('.network-status-dot');
+            selectorContainer = indicator.querySelector(`#${selectorId}`);
+        }
+
+        return { statusDot, selectorContainer };
+    }
+
+    /**
      * Update network indicator for a given context
      * @param {string} indicatorId - ID of the indicator element
      * @param {string} selectorId - ID of the network selector container
@@ -380,17 +402,33 @@ class NetworkIndicator {
         const indicator = document.getElementById(indicatorId);
         if (!indicator) return;
 
+        const requestKey = `${indicatorId}:${selectorId}:${context}`;
+        const nextRequestId = (NetworkIndicator._requestTokens.get(requestKey) || 0) + 1;
+        NetworkIndicator._requestTokens.set(requestKey, nextRequestId);
+
         // Always show the network indicator
         indicator.style.display = 'flex';
 
-        // Show loading state initially
-        indicator.innerHTML = `
-            <span class="network-status-dot gray"></span>
-            <div id="${selectorId}"></div>
-        `;
+        const { statusDot, selectorContainer } = this.ensureStructure(indicator, selectorId);
+
+        // Show loading state initially, but preserve the existing selector DOM to avoid flicker.
         indicator.className = `network-indicator-home loading`;
+        if (statusDot) {
+            statusDot.className = 'network-status-dot gray';
+        }
+
+        if (selectorContainer && window.networkSelector) {
+            const hasSelector = selectorContainer.querySelector('.network-selector');
+            if (!hasSelector) {
+                window.networkSelector.createSelector(selectorId, context);
+            } else {
+                window.networkSelector.updateNetworkDisplay();
+            }
+        }
 
         const isWalletConnected = window.walletManager && window.walletManager.isConnected();
+        let nextClassName = 'network-indicator-home no-wallet';
+        let nextDotClassName = 'network-status-dot gray';
 
         // Check permission asynchronously if wallet is connected
         if (isWalletConnected && window.networkManager) {
@@ -398,48 +436,32 @@ class NetworkIndicator {
                 const hasPermission = await window.networkManager.hasRequiredNetworkPermission();
 
                 if (hasPermission) {
-                    // Green indicator - has permission
-                    indicator.innerHTML = `
-                        <span class="network-status-dot green"></span>
-                        <div id="${selectorId}"></div>
-                    `;
-                    indicator.className = `network-indicator-home has-permission`;
+                    nextClassName = 'network-indicator-home has-permission';
+                    nextDotClassName = 'network-status-dot green';
                 } else {
-                    // Red indicator - missing permission
-                    indicator.innerHTML = `
-                        <span class="network-status-dot red"></span>
-                        <div id="${selectorId}"></div>
-                    `;
-                    indicator.className = `network-indicator-home missing-permission`;
+                    nextClassName = 'network-indicator-home missing-permission';
+                    nextDotClassName = 'network-status-dot red';
                 }
             } catch (error) {
                 console.error('Error checking network permission:', error);
-                // Fallback to no permission state
-                indicator.innerHTML = `
-                    <span class="network-status-dot red"></span>
-                    <div id="${selectorId}"></div>
-                `;
-                indicator.className = `network-indicator-home missing-permission`;
+                nextClassName = 'network-indicator-home missing-permission';
+                nextDotClassName = 'network-status-dot red';
             }
-        } else {
-            // No wallet connected - show network selector only
-            indicator.innerHTML = `
-                <span class="network-status-dot gray"></span>
-                <div id="${selectorId}"></div>
-            `;
-            indicator.className = `network-indicator-home no-wallet`;
         }
 
-        // Add network selector after DOM update
-        setTimeout(() => {
-            const container = document.getElementById(selectorId);
-            if (container && window.networkSelector) {
-                container.innerHTML = '';
-                window.networkSelector.createSelector(selectorId, context);
-            }
-        }, 100);
+        // Ignore stale async updates from earlier network/permission checks.
+        if (NetworkIndicator._requestTokens.get(requestKey) !== nextRequestId) {
+            return;
+        }
+
+        indicator.className = nextClassName;
+        if (statusDot) {
+            statusDot.className = nextDotClassName;
+        }
     }
 }
+
+NetworkIndicator._requestTokens = new Map();
 
 // Create global instances
 window.networkSelector = new NetworkSelector();

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -73,7 +73,7 @@ window.CONFIG = {
             BLOCK_EXPLORER: 'https://testnet.bscscan.com',
             NATIVE_CURRENCY: { name: 'Test BNB', symbol: 'tBNB', decimals: 18 },
             CONTRACTS: {
-                STAKING_CONTRACT: '' // Populate after the BSC testnet staking deployment is live
+                STAKING_CONTRACT: '0x24F28129B65E9AeDdAfE3f1Fc67ab82DDCF30dF9'
             }
         }
     },

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -60,6 +60,21 @@ window.CONFIG = {
             CONTRACTS: {
                 STAKING_CONTRACT: '' // Populate after the BSC staking deployment is live
             }
+        },
+        BSC_TESTNET: {
+            CHAIN_ID: 97,
+            NAME: 'BNB Smart Chain Testnet',
+            RPC_URL: 'https://data-seed-prebsc-1-s1.bnbchain.org:8545',
+            FALLBACK_RPCS: [
+                'https://bsc-testnet-dataseed.bnbchain.org',
+                'https://bsc-testnet.bnbchain.org',
+                'https://bsc-prebsc-dataseed.bnbchain.org'
+            ],
+            BLOCK_EXPLORER: 'https://testnet.bscscan.com',
+            NATIVE_CURRENCY: { name: 'Test BNB', symbol: 'tBNB', decimals: 18 },
+            CONTRACTS: {
+                STAKING_CONTRACT: '' // Populate after the BSC testnet staking deployment is live
+            }
         }
     },
 
@@ -67,6 +82,7 @@ window.CONFIG = {
     MULTICALL2: {
         1: '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696',      // Ethereum Mainnet
         56: '0xcA11bde05977b3631167028862bE2a173976CA11',     // BNB Smart Chain
+        97: '0xcA11bde05977b3631167028862bE2a173976CA11',     // BNB Smart Chain Testnet
         137: '0x275617327c958bD06b5D6b871E7f491D76113dd8',    // Polygon Mainnet
         80002: '0xcA11bde05977b3631167028862bE2a173976CA11',  // Polygon Amoy Testnet
         31337: '0xcA11bde05977b3631167028862bE2a173976CA11'   // Local Hardhat

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -58,7 +58,7 @@ window.CONFIG = {
             BLOCK_EXPLORER: 'https://bscscan.com',
             NATIVE_CURRENCY: { name: 'BNB', symbol: 'BNB', decimals: 18 },
             CONTRACTS: {
-                STAKING_CONTRACT: '' // Populate after the BSC staking deployment is live
+                STAKING_CONTRACT: '0x89E662CB5d784582DB631e2Cbc81bB6643BB2EF4'
             }
         },
         BSC_TESTNET: {

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -45,12 +45,28 @@ window.CONFIG = {
                                   /* '0x74b00fe491Ab0CDf5291af69bD8c4ECD5FBbE8Ca' */
 
             }
+        },
+        BSC_MAINNET: {
+            CHAIN_ID: 56,
+            NAME: 'BNB Smart Chain',
+            RPC_URL: 'https://bsc-dataseed.bnbchain.org',
+            FALLBACK_RPCS: [
+                'https://bsc-dataseed.nariox.org',
+                'https://bsc-dataseed.defibit.io',
+                'https://bsc-dataseed.ninicoin.io'
+            ],
+            BLOCK_EXPLORER: 'https://bscscan.com',
+            NATIVE_CURRENCY: { name: 'BNB', symbol: 'BNB', decimals: 18 },
+            CONTRACTS: {
+                STAKING_CONTRACT: '' // Populate after the BSC staking deployment is live
+            }
         }
     },
 
     // Multicall2 addresses (canonical deployment for batch loading optimization)
     MULTICALL2: {
         1: '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696',      // Ethereum Mainnet
+        56: '0xcA11bde05977b3631167028862bE2a173976CA11',     // BNB Smart Chain
         137: '0x275617327c958bD06b5D6b871E7f491D76113dd8',    // Polygon Mainnet
         80002: '0xcA11bde05977b3631167028862bE2a173976CA11',  // Polygon Amoy Testnet
         31337: '0xcA11bde05977b3631167028862bE2a173976CA11'   // Local Hardhat
@@ -121,11 +137,25 @@ window.CONFIG = {
         ],
         // Base URLs for each platform (address will be inserted where {address} appears)
         BASE_URLS: {
-            'Uniswap V2': 'https://app.uniswap.org/explore/pools/polygon/{address}',
-            'SushiSwap': 'https://www.sushi.com/analytics/pools/polygon/{address}',
-            'Curve Finance': 'https://curve.fi/polygon/pools/{address}',
-            'Balancer': 'https://app.balancer.fi/#/polygon/pool/{address}',
-            'PancakeSwap': 'https://pancakeswap.finance/pools/{address}'
+            'Uniswap V2': {
+                AMOY: 'https://app.uniswap.org/explore/pools/polygon/{address}',
+                POLYGON_MAINNET: 'https://app.uniswap.org/explore/pools/polygon/{address}'
+            },
+            'SushiSwap': {
+                AMOY: 'https://www.sushi.com/analytics/pools/polygon/{address}',
+                POLYGON_MAINNET: 'https://www.sushi.com/analytics/pools/polygon/{address}'
+            },
+            'Curve Finance': {
+                AMOY: 'https://curve.fi/polygon/pools/{address}',
+                POLYGON_MAINNET: 'https://curve.fi/polygon/pools/{address}'
+            },
+            'Balancer': {
+                AMOY: 'https://app.balancer.fi/#/polygon/pool/{address}',
+                POLYGON_MAINNET: 'https://app.balancer.fi/#/polygon/pool/{address}'
+            },
+            'PancakeSwap': {
+                default: 'https://pancakeswap.finance/pools/{address}'
+            }
         },
     },
 

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -140,6 +140,15 @@ class ContractManager {
             // Seed staking address from configuration so we can build the contract instance next
             this.loadStakingAddressFromConfig();
 
+            if (!this.hasConfiguredStakingContract()) {
+                const networkName = window.networkSelector?.getCurrentNetworkName?.() || 'the selected network';
+                console.warn(`No staking contract configured for ${networkName}; continuing in read-only empty state`);
+                this.stakingContract = null;
+                this.rewardTokenContract = null;
+                this.lpTokenContracts.clear();
+                return;
+            }
+
             // Initialize contract instances (read-only)
             await this.initializeContractsReadOnly();
 
@@ -308,6 +317,17 @@ class ContractManager {
 
             // Seed staking address from configuration before building the contract instance
             this.loadStakingAddressFromConfig();
+
+            if (!this.hasConfiguredStakingContract()) {
+                const networkName = window.networkSelector?.getCurrentNetworkName?.() || 'the selected network';
+                console.warn(`No staking contract configured for ${networkName}; continuing without contract instances`);
+                this.stakingContract = null;
+                this.rewardTokenContract = null;
+                this.lpTokenContracts.clear();
+                this.isInitialized = true;
+                this._notifyReadyCallbacks();
+                return true;
+            }
 
             // Initialize contract instances
             await this.initializeContracts();
@@ -824,6 +844,11 @@ class ContractManager {
         }
     }
 
+    hasConfiguredStakingContract() {
+        const stakingAddress = this.contractAddresses.get('STAKING') || window.networkSelector?.getStakingContractAddress();
+        return !!(stakingAddress && this.isValidContractAddress(stakingAddress));
+    }
+
     /**
      * Update LP contract addresses from contract-provided pairs list.
      */
@@ -1328,7 +1353,7 @@ class ContractManager {
         // Signer is optional (null in read-only mode)
         const ready = !!(this.isInitialized &&
                         this.provider &&
-                        (this.stakingContract || this.rewardTokenContract));
+                        ((this.stakingContract || this.rewardTokenContract) || !this.hasConfiguredStakingContract()));
 
         return ready;
     }
@@ -1350,6 +1375,20 @@ class ContractManager {
             this.stakingContract = null;
             this.rewardTokenContract = null;
             this.lpTokenContracts.clear();
+            this.provider = null;
+            this.signer = null;
+            this.transactionProvider = null;
+            this.contractAddresses.clear();
+            this.fallbackProviders = [];
+            this.fallbackProvidersInitialized = false;
+            this.cachedNetwork = null;
+            this.cachedPairs = null;
+            this.cachedBasicData = null;
+            this.cachedBasicDataTimestamp = 0;
+            this.disabledFeatures.clear();
+            if (this.rpcProviderCache?.clear) this.rpcProviderCache.clear();
+            if (this.lpStaticMetaCache?.clear) this.lpStaticMetaCache.clear();
+            if (this.tokenDecimalsCache?.clear) this.tokenDecimalsCache.clear();
 
             // Reset MulticallService
             if (this.multicallService) {
@@ -1363,6 +1402,11 @@ class ContractManager {
                 // Reset provider rotation for new network
                 this.currentProviderIndex = 0;
             }
+
+            // Reinitialize against the selected network even when no contracts are configured yet.
+            // initializeReadOnly() now handles the empty-contract case without throwing.
+            await this.initializeReadOnly();
+            return true;
 
             // Check if the new network has valid contract addresses
             const contractAddress = window.networkSelector?.getStakingContractAddress();
@@ -2944,7 +2988,8 @@ class ContractManager {
 
             // Verify signer is actually available
             if (!this.signer) {
-                throw new Error('No signer available. Please connect MetaMask and ensure you are on Polygon Amoy network.');
+                const networkName = window.networkSelector?.getCurrentNetworkName?.() || 'the selected network';
+                throw new Error(`No signer available. Please connect MetaMask and ensure you are on ${networkName}.`);
             }
 
             const result = await this.executeTransactionOnce(async () => {

--- a/js/utils/formatter.js
+++ b/js/utils/formatter.js
@@ -79,6 +79,28 @@ window.Formatter = {
     },
 
     /**
+     * Resolve a platform URL template for the currently selected network.
+     * Supports either legacy string values or per-network maps in CONFIG.
+     * @param {string} platform - The platform name from the contract
+     * @returns {string} URL template or empty string when not configured
+     */
+    getPlatformBaseUrl(platform) {
+        const platformsConfig = window.CONFIG?.PLATFORMS;
+        const platformConfig = platform && platformsConfig?.BASE_URLS?.[platform];
+
+        if (!platformConfig) {
+            return '';
+        }
+
+        if (typeof platformConfig === 'string') {
+            return platformConfig;
+        }
+
+        const selectedNetwork = window.networkSelector?.getSelectedNetworkKey?.();
+        return platformConfig[selectedNetwork] || platformConfig.default || '';
+    },
+
+    /**
      * Format pair name for display with platform-specific link
      * Uses the platform from contract data to link to the correct DEX
      * @param {string} pairName - The pair name from the contract
@@ -89,12 +111,13 @@ window.Formatter = {
     formatPairName(pairName, lpTokenAddress = '', platform = '') {
         if (!pairName) return `<span class="pair-name-link-text">Not provided</span>`;
 
-        const platformsConfig = window.CONFIG?.PLATFORMS;
-        const baseUrl = platform && platformsConfig?.BASE_URLS?.[platform];
+        const baseUrl = this.getPlatformBaseUrl(platform);
         
         // Only return a link if we have a valid platform URL configured
         if (!baseUrl) {
-            window.notificationManager.error(`Platform ${platform} not configured for pair ${pairName}`);
+            if (platform) {
+                console.warn(`Platform ${platform} is not configured for ${window.networkSelector?.getCurrentNetworkName?.() || 'the selected network'}`);
+            }
             return `<span class="pair-name-link-text">${pairName}</span>`;
         }
 
@@ -116,4 +139,3 @@ window.Formatter = {
         `;
     },
 };
-

--- a/js/utils/multicall-service.js
+++ b/js/utils/multicall-service.js
@@ -27,6 +27,7 @@
     // Multicall2 addresses (canonical deployment across networks)
     const MULTICALL2_ADDRESSES = {
         1: '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696',      // Ethereum Mainnet
+        56: '0xcA11bde05977b3631167028862bE2a173976CA11',     // BNB Smart Chain
         137: '0x275617327c958bD06b5D6b871E7f491D76113dd8',    // Polygon Mainnet
         80002: '0xcA11bde05977b3631167028862bE2a173976CA11',  // Polygon Amoy Testnet
         31337: '0xcA11bde05977b3631167028862bE2a173976CA11'   // Local Hardhat (if deployed)
@@ -320,4 +321,3 @@
     console.log('✅ MulticallService loaded');
 
 })(typeof window !== 'undefined' ? window : global);
-

--- a/js/utils/multicall-service.js
+++ b/js/utils/multicall-service.js
@@ -28,6 +28,7 @@
     const MULTICALL2_ADDRESSES = {
         1: '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696',      // Ethereum Mainnet
         56: '0xcA11bde05977b3631167028862bE2a173976CA11',     // BNB Smart Chain
+        97: '0xcA11bde05977b3631167028862bE2a173976CA11',     // BNB Smart Chain Testnet
         137: '0x275617327c958bD06b5D6b871E7f491D76113dd8',    // Polygon Mainnet
         80002: '0xcA11bde05977b3631167028862bE2a173976CA11',  // Polygon Amoy Testnet
         31337: '0xcA11bde05977b3631167028862bE2a173976CA11'   // Local Hardhat (if deployed)

--- a/js/wallet/network-manager.js
+++ b/js/wallet/network-manager.js
@@ -409,6 +409,7 @@ class NetworkManager {
             1: 'Ethereum Mainnet',
             5: 'Goerli',
             56: 'BNB Smart Chain',
+            97: 'BNB Smart Chain Testnet',
             11155111: 'Sepolia',
             137: 'Polygon Mainnet',
             80001: 'Mumbai Testnet',

--- a/js/wallet/network-manager.js
+++ b/js/wallet/network-manager.js
@@ -408,6 +408,7 @@ class NetworkManager {
         const networks = {
             1: 'Ethereum Mainnet',
             5: 'Goerli',
+            56: 'BNB Smart Chain',
             11155111: 'Sepolia',
             137: 'Polygon Mainnet',
             80001: 'Mumbai Testnet',


### PR DESCRIPTION
## Summary
- add `BSC_MAINNET` and `BSC_TESTNET` frontend configuration for chain IDs `56` and `97`, including RPCs, explorers, native currencies, and multicall support
- configure the deployed BNB Smart Chain mainnet staking contract at `0x89E662CB5d784582DB631e2Cbc81bB6643BB2EF4`
- configure the deployed BNB Smart Chain testnet staking contract at `0x24F28129B65E9AeDdAfE3f1Fc67ab82DDCF30dF9`
- update the network selector so it only shows BNB Smart Chain mainnet and BNB Smart Chain testnet
- make `BSC_MAINNET` the default selected network and migrate old stored Polygon/Amoy selections onto the BNB default
- keep network-dependent UI paths config-driven so admin selectors, transaction explorer links, and pool links do not assume Polygon-only routing

## Why
The frontend is transitioning away from Polygon. This PR moves active frontend network support to BNB mainnet and BNB testnet, wires in the deployed contract addresses, and removes Polygon/Amoy from the user-facing selector for now.

## Notes
- `CONFIG.NETWORKS.BSC_MAINNET.CONTRACTS.STAKING_CONTRACT` is set to `0x89E662CB5d784582DB631e2Cbc81bB6643BB2EF4`.
- `CONFIG.NETWORKS.BSC_TESTNET.CONTRACTS.STAKING_CONTRACT` is set to `0x24F28129B65E9AeDdAfE3f1Fc67ab82DDCF30dF9`.
- Polygon/Amoy configs and other repo references still exist outside the selector and are not fully removed in this PR.
- GitHub Issues are disabled in this repository, so the follow-up cleanup issue for remaining Polygon references could not be created here.
