### PR TITLE
Display staking TVL in USD

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -1,0 +1,27 @@
+name: PR Unit Tests
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20.19.3'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run unit tests
+        run: npm test

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -19,9 +19,11 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '20.19.3'
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run unit tests
         run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,6 @@ test-server/
 .fuse_hidden*
 
 # Package manager files
-package-lock.json
 yarn.lock
 pnpm-lock.yaml
 

--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -448,7 +448,7 @@ class HomePage {
                     </span>
                 </td>
                 <td>
-                    <span style="font-weight: 600;">${this.formatNumber(pair.tvl || 0)}</span>
+                    <span style="font-weight: 600;">${this.formatTvlDisplay(pair)}</span>
                 </td>
                 <td>
                     <button class="btn btn-primary btn-small btn-share"
@@ -710,6 +710,8 @@ class HomePage {
                             platform: pairInfo.platform || '',
                             apr: pairInfo.apr || '0.00',
                             tvl: pairInfo.tvl || 0,
+                            tvlUsd: null,
+                            tvlCalculated: false,
                             userShares: '0.00', // Will be updated if wallet connected
                             userEarnings: '0.00', // Will be updated if wallet connected
                             totalStaked: pairInfo.totalStaked || '0',
@@ -737,7 +739,12 @@ class HomePage {
                     console.log('⚡ Calculating TVL and APR for all pairs...');
                     await this.calculateTVLAndAPR();
                     console.log('🎨 Re-rendering after TVL/APR calculation...');
-                    console.log('📊 Pairs data after calculation:', this.pairs.map(p => ({ name: p.name, tvl: p.tvl, apr: p.apr })));
+                    console.log('📊 Pairs data after calculation:', this.pairs.map(p => ({
+                        name: p.name,
+                        tvlLp: p.tvl,
+                        tvlUsd: p.tvlUsd,
+                        apr: p.apr
+                    })));
                     this.render(); // Re-render with TVL and APR data
                 }
 
@@ -835,8 +842,8 @@ class HomePage {
 
     /**
      * Calculate TVL and APR for all pairs using on-chain LP composition.
-     * TVL remains in LP token units, while APR now leverages the LIB-per-LP
-     * ratio derived from Uniswap V2 reserve data instead of external pricing.
+     * Raw LP totals remain available for share math, while the TVL column
+     * uses USD pricing for the underlying tokens when a price feed exists.
      */
     async calculateTVLAndAPR() {
         if (this.pairs.length === 0) {
@@ -862,6 +869,27 @@ class HomePage {
             const totalWeight = Number(this.totalWeight) || 1;
 
             const breakdowns = await window.contractManager.getLPStakeBreakdowns(this.pairs);
+            const tokenAddresses = new Set();
+
+            breakdowns.forEach((breakdown) => {
+                const token0Address = breakdown?.token0?.address?.toLowerCase?.();
+                const token1Address = breakdown?.token1?.address?.toLowerCase?.();
+
+                if (token0Address) {
+                    tokenAddresses.add(token0Address);
+                }
+
+                if (token1Address) {
+                    tokenAddresses.add(token1Address);
+                }
+            });
+
+            const tokenPricesUsd = new Map();
+            await Promise.all(Array.from(tokenAddresses).map(async (address) => {
+                const priceUsd = await window.rewardsCalculator.fetchTokenPriceByAddress(address);
+                tokenPricesUsd.set(address, priceUsd);
+            }));
+
             const calculations = this.pairs.map(async (pair, index) => {
                 try {
                     console.log(`🔍 Calculating TVL/APR for ${pair.name}...`);
@@ -871,87 +899,69 @@ class HomePage {
                     const breakdown = resolvedAddress ? breakdowns.get(resolvedAddress) : null;
                     if (!breakdown) {
                         console.warn(`⚠️ LP breakdown not available for ${pair.name}, skipping`);
+                        this.pairs[index].tvlUsd = null;
+                        this.pairs[index].tvlCalculated = true;
                         return;
                     }
-                    const lpDecimals = Number(breakdown?.lpToken?.decimals) || 18;
-                    const stakedBn = ethers.BigNumber.from(breakdown?.lpToken?.stakedBalance?.raw || '0');
-                    const tvlInTokens = Number(ethers.utils.formatUnits(stakedBn, lpDecimals)) || 0;
-
-                    const poolWeight = Number(pair.weight) || 1;
-
                     const token0 = breakdown?.token0;
                     const token1 = breakdown?.token1;
                     const token0Addr = token0?.address?.toLowerCase?.();
                     const token1Addr = token1?.address?.toLowerCase?.();
-
-                    let libToken = null;
-                    if (rewardTokenAddressLower && token0Addr === rewardTokenAddressLower) {
-                        libToken = token0;
-                    } else if (rewardTokenAddressLower && token1Addr === rewardTokenAddressLower) {
-                        libToken = token1;
-                    }
-
-                    if (!libToken) {
-                        console.warn(`⚠️ LIB token not found for ${pair.name}, skipping APR calculation`);
-                        return;
-                    }
-
-                    const libStaked = Number(libToken?.staked?.formatted) || 0;
-                    const libReserve = Number(libToken?.reserve?.formatted) || 0;
-
-                    const otherToken = libToken === token0 ? token1 : token0;
-                    const otherStaked = Number(otherToken?.staked?.formatted) || 0;
-                    const otherReserve = Number(otherToken?.reserve?.formatted) || 0;
-
-                    // Convert the counter token stake to a LIB-equivalent amount using the reserve ratio
-                    let otherTokenLibEquivalent = 0;
-                    if (otherStaked > 0 && otherReserve > 0 && libReserve > 0) {
-                        const otherToLibRate = libReserve / otherReserve;
-                        otherTokenLibEquivalent = otherStaked * otherToLibRate;
-                    }
-
-                    const totalStakeValueInLib = libStaked + otherTokenLibEquivalent;
-                    const stakeValuePerLpInLib = tvlInTokens > 0 ? totalStakeValueInLib / tvlInTokens : 0;
-
-                    if (stakeValuePerLpInLib <= 0) {
-                        console.warn(`⚠️ Invalid LIB-equivalent value per LP for ${pair.name}, skipping APR calculation`);
-                        return;
-                    }
-
-                    const apr = window.rewardsCalculator.calcAPR(
+                    const token0PriceUsd = token0Addr ? (tokenPricesUsd.get(token0Addr) || 0) : 0;
+                    const token1PriceUsd = token1Addr ? (tokenPricesUsd.get(token1Addr) || 0) : 0;
+                    const parsedPoolWeight = Number(pair.weight);
+                    const poolWeight = Number.isFinite(parsedPoolWeight) ? parsedPoolWeight : 1;
+                    const metrics = window.rewardsCalculator.buildPoolMetrics({
+                        breakdown,
+                        rewardTokenAddress,
                         hourlyRate,
-                        tvlInTokens,
-                        stakeValuePerLpInLib,
                         poolWeight,
-                        totalWeight
-                    );
+                        totalWeight,
+                        token0PriceUsd,
+                        token1PriceUsd
+                    });
+                    const tvlInTokens = metrics.tvlLpTokens;
+                    const tvlUsd = metrics.tvlUsd;
 
-                    const tvl = tvlInTokens;
+                    if (!metrics.isSupportedPair) {
+                        console.warn(`⚠️ Reward token not found in ${pair.name}, APR remains 0`);
+                    }
+
+                    if (metrics.rewardTokenPerLp <= 0) {
+                        console.warn(`⚠️ Invalid reward-token value per LP for ${pair.name}, APR remains 0`);
+                    }
 
                     console.log(`  📊 TVL (LP tokens): ${tvlInTokens}`);
-                    console.log(`  💧 LIB-equivalent value per LP token: ${stakeValuePerLpInLib}`);
-                    console.log(`  💠 LIB tokens in stake: ${libStaked}`);
-                    console.log(`  🔁 Counter-token LIB equivalent: ${otherTokenLibEquivalent}`);
-                    console.log(`  📈 Calculated APR: ${apr.toFixed(1)}%`);
+                    console.log(`  💵 TVL (USD): ${tvlUsd === null ? 'N/A' : tvlUsd}`);
+                    console.log(`  💧 Reward-token value per LP token: ${metrics.rewardTokenPerLp}`);
+                    console.log(`  💠 Reward tokens in stake: ${metrics.rewardTokenStaked}`);
+                    console.log(`  🔁 Counter-token reward equivalent: ${metrics.counterTokenRewardEquivalent}`);
+                    console.log(`  📈 Calculated APR: ${metrics.apr.toFixed(1)}%`);
 
                     // Update pair data to match React structure
                     console.log(`🔧 Updating pair ${index} (${pair.name}):`);
-                    console.log(`  Before: tvl=${this.pairs[index].tvl}, apr=${this.pairs[index].apr}`);
+                    console.log(`  Before: tvl=${this.pairs[index].tvl}, tvlUsd=${this.pairs[index].tvlUsd}, apr=${this.pairs[index].apr}`);
 
-                    this.pairs[index].tvl = tvl;  // Token count, not USD
-                    this.pairs[index].apr = apr.toFixed(1);  // React uses .toFixed(1)
+                    this.pairs[index].tvl = tvlInTokens;  // Raw LP token count for share math
+                    this.pairs[index].tvlUsd = tvlUsd;
+                    this.pairs[index].tvlCalculated = true;
+                    this.pairs[index].apr = metrics.apr.toFixed(1);  // React uses .toFixed(1)
                     this.pairs[index].totalStaked = tvlInTokens.toFixed(6);
-                    this.pairs[index].libPerLp = stakeValuePerLpInLib;
-                    this.pairs[index].libTokensStaked = libStaked;
-                    this.pairs[index].counterTokenStaked = otherStaked;
-                    this.pairs[index].counterTokenLibEquivalent = otherTokenLibEquivalent;
-                    this.pairs[index].totalStakeValueInLib = totalStakeValueInLib;
+                    this.pairs[index].libPerLp = metrics.rewardTokenPerLp;
+                    this.pairs[index].libTokensStaked = metrics.rewardTokenStaked;
+                    this.pairs[index].counterTokenStaked = metrics.counterTokenStaked;
+                    this.pairs[index].counterTokenLibEquivalent = metrics.counterTokenRewardEquivalent;
+                    this.pairs[index].totalStakeValueInLib = metrics.totalStakeValueInRewardToken;
 
-                    console.log(`  After: tvl=${this.pairs[index].tvl}, apr=${this.pairs[index].apr}`);
-                    console.log(`✅ ${pair.name}: TVL=${tvl.toFixed(2)} LP, APR=${apr.toFixed(1)}%`);
+                    console.log(`  After: tvl=${this.pairs[index].tvl}, tvlUsd=${this.pairs[index].tvlUsd}, apr=${this.pairs[index].apr}`);
+                    console.log(`✅ ${pair.name}: TVL=${tvlInTokens.toFixed(2)} LP (${tvlUsd === null ? 'N/A' : window.Formatter?.formatCurrency(tvlUsd) || `$${tvlUsd.toFixed(2)}`}), APR=${metrics.apr.toFixed(1)}%`);
 
                 } catch (error) {
                     console.error(`❌ Failed to calculate TVL/APR for ${pair.name}:`, error);
+                    if (this.pairs[index]) {
+                        this.pairs[index].tvlUsd = null;
+                        this.pairs[index].tvlCalculated = true;
+                    }
                     window.notificationManager?.error(`Failed to calculate TVL/APR for ${pair.name}`);
                     // Keep default values (0)
                 }
@@ -1019,6 +1029,18 @@ class HomePage {
             return (num / 1000).toFixed(2) + 'K';
         }
         return num.toFixed(2);
+    }
+
+    formatTvlDisplay(pair) {
+        if (!pair?.tvlCalculated) {
+            return '...';
+        }
+
+        if (pair.tvlUsd === null || pair.tvlUsd === undefined) {
+            return 'N/A';
+        }
+
+        return window.Formatter?.formatCompactCurrency(pair.tvlUsd) || `$${this.formatNumber(pair.tvlUsd)}`;
     }
 
 

--- a/js/utils/formatter.js
+++ b/js/utils/formatter.js
@@ -138,4 +138,30 @@ window.Formatter = {
             </a>
         `;
     },
+
+    formatCurrency(value) {
+        const amount = Number(value);
+        if (!Number.isFinite(amount)) return '$0.00';
+
+        return `$${amount.toFixed(2)}`;
+    },
+
+    formatCompactCurrency(value) {
+        const amount = Number(value);
+        if (!Number.isFinite(amount)) return '$0.00';
+
+        if (amount >= 1000000000) {
+            return `$${(amount / 1000000000).toFixed(2)}B`;
+        }
+
+        if (amount >= 1000000) {
+            return `$${(amount / 1000000).toFixed(2)}M`;
+        }
+
+        if (amount >= 1000) {
+            return `$${(amount / 1000).toFixed(2)}K`;
+        }
+
+        return this.formatCurrency(amount);
+    }
 };

--- a/js/utils/rewards-calculator.js
+++ b/js/utils/rewards-calculator.js
@@ -55,19 +55,12 @@
          *
          * @param {number} hourlyRate - Total LIB distributed per hour across all pools.
          * @param {number} tvlLpTokens - Total LP tokens staked in this pool (formatted, not wei).
-         * @param {number|Object} libPerLp - LIB-equivalent value backing one LP token, or legacy options object with libPerLp/poolWeight/totalWeight.
+         * @param {number} libPerLp - LIB-equivalent value backing one LP token.
          * @param {number} [poolWeight=1] - Pool-specific weight used for reward distribution.
          * @param {number} [totalWeight=1] - Sum of all pool weights.
          * @returns {number} APR percentage (e.g., 150 equals 150%).
          */
         calcAPR(hourlyRate, tvlLpTokens, libPerLp, poolWeight = 1, totalWeight = 1) {
-            if (typeof libPerLp === 'object' && libPerLp !== null) {
-                const opts = libPerLp;
-                libPerLp = opts.libPerLp ?? 0;
-                poolWeight = opts.poolWeight ?? poolWeight;
-                totalWeight = opts.totalWeight ?? totalWeight;
-            }
-
             if (!hourlyRate || !tvlLpTokens || !libPerLp || !poolWeight || !totalWeight) {
                 return 0;
             }

--- a/js/utils/rewards-calculator.js
+++ b/js/utils/rewards-calculator.js
@@ -18,6 +18,9 @@
         constructor() {
             this.contractManager = null;
             this.isInitialized = false;
+            this.priceCache = new Map();
+            this.priceCacheTtlMs = 5 * 60 * 1000;
+            this.dexScreenerBaseUrl = 'https://api.dexscreener.com/latest/dex/tokens';
         }
 
         async initialize(contractManagerOrOptions) {
@@ -76,6 +79,212 @@
 
             const annualRewards = hourlyRate * 8760 * pairPct;
             return (annualRewards / (tvlLpTokens * libPerLp)) * 100;
+        }
+
+        normalizeAddress(address) {
+            return typeof address === 'string' ? address.toLowerCase() : null;
+        }
+
+        parseAmount(value) {
+            const parsed = Number(value);
+            return Number.isFinite(parsed) ? parsed : 0;
+        }
+
+        getCachedTokenPrice(address) {
+            const cachedEntry = this.priceCache.get(address);
+            if (!cachedEntry) {
+                return null;
+            }
+
+            const cacheAgeMs = Date.now() - cachedEntry.timestamp;
+            return cacheAgeMs < this.priceCacheTtlMs ? cachedEntry.price : null;
+        }
+
+        setCachedTokenPrice(address, price) {
+            if (price <= 0) {
+                return;
+            }
+
+            this.priceCache.set(address, {
+                price,
+                timestamp: Date.now()
+            });
+        }
+
+        parseDexScreenerPriceUsd(data) {
+            return Number.parseFloat(data?.pairs?.[0]?.priceUsd || '0') || 0;
+        }
+
+        async requestTokenPriceByAddress(address) {
+            const response = await fetch(`${this.dexScreenerBaseUrl}/${address}`);
+            if (!response.ok) {
+                throw new Error(`DexScreener price request failed: ${response.status}`);
+            }
+
+            const data = await response.json();
+            return this.parseDexScreenerPriceUsd(data);
+        }
+
+        async fetchTokenPriceByAddress(address) {
+            const normalizedAddress = this.normalizeAddress(address);
+            if (!normalizedAddress || typeof fetch !== 'function') {
+                return 0;
+            }
+
+            const cachedPrice = this.getCachedTokenPrice(normalizedAddress);
+            if (cachedPrice !== null) {
+                return cachedPrice;
+            }
+
+            try {
+                const price = await this.requestTokenPriceByAddress(normalizedAddress);
+                this.setCachedTokenPrice(normalizedAddress, price);
+                return price;
+            } catch (error) {
+                console.warn(`Failed to fetch token price for ${normalizedAddress}:`, error?.message || error);
+                return 0;
+            }
+        }
+
+        buildPoolMetrics({
+            breakdown,
+            rewardTokenAddress,
+            hourlyRate = 0,
+            poolWeight = 1,
+            totalWeight = 1,
+            token0PriceUsd = 0,
+            token1PriceUsd = 0
+        }) {
+            if (!breakdown) {
+                return {
+                    isValid: false,
+                    isSupportedPair: false,
+                    tvlLpTokens: 0,
+                    token0Staked: 0,
+                    token1Staked: 0,
+                    rewardTokenPerLp: 0,
+                    rewardTokenStaked: 0,
+                    counterTokenStaked: 0,
+                    counterTokenRewardEquivalent: 0,
+                    totalStakeValueInRewardToken: 0,
+                    token0PriceUsd: 0,
+                    token1PriceUsd: 0,
+                    tvlUsd: null,
+                    apr: 0
+                };
+            }
+
+            const tvlLpTokens = this.parseAmount(breakdown?.lpToken?.stakedBalance?.formatted);
+            const rewardTokenAddressLower = this.normalizeAddress(rewardTokenAddress);
+            const token0 = breakdown?.token0 || null;
+            const token1 = breakdown?.token1 || null;
+            const token0Address = this.normalizeAddress(token0?.address);
+            const token1Address = this.normalizeAddress(token1?.address);
+
+            let rewardToken = null;
+            if (rewardTokenAddressLower && token0Address === rewardTokenAddressLower) {
+                rewardToken = token0;
+            } else if (rewardTokenAddressLower && token1Address === rewardTokenAddressLower) {
+                rewardToken = token1;
+            }
+
+            if (!rewardToken) {
+                const token0Staked = this.parseAmount(token0?.staked?.formatted);
+                const token1Staked = this.parseAmount(token1?.staked?.formatted);
+                const tvlUsd = this.calculateTvlUsd({
+                    token0Staked,
+                    token1Staked,
+                    token0PriceUsd,
+                    token1PriceUsd
+                });
+
+                return {
+                    isValid: false,
+                    isSupportedPair: false,
+                    tvlLpTokens,
+                    token0Staked,
+                    token1Staked,
+                    rewardTokenPerLp: 0,
+                    rewardTokenStaked: 0,
+                    counterTokenStaked: 0,
+                    counterTokenRewardEquivalent: 0,
+                    totalStakeValueInRewardToken: 0,
+                    token0PriceUsd,
+                    token1PriceUsd,
+                    tvlUsd,
+                    apr: 0
+                };
+            }
+
+            const token0Staked = this.parseAmount(token0?.staked?.formatted);
+            const token1Staked = this.parseAmount(token1?.staked?.formatted);
+            const rewardTokenStaked = this.parseAmount(rewardToken?.staked?.formatted);
+            const rewardTokenReserve = this.parseAmount(rewardToken?.reserve?.formatted);
+            const counterToken = rewardToken === token0 ? token1 : token0;
+            const counterTokenStaked = this.parseAmount(counterToken?.staked?.formatted);
+            const counterTokenReserve = this.parseAmount(counterToken?.reserve?.formatted);
+
+            let counterTokenRewardEquivalent = 0;
+            if (counterTokenStaked > 0 && counterTokenReserve > 0 && rewardTokenReserve > 0) {
+                const counterToRewardRate = rewardTokenReserve / counterTokenReserve;
+                counterTokenRewardEquivalent = counterTokenStaked * counterToRewardRate;
+            }
+
+            const totalStakeValueInRewardToken = rewardTokenStaked + counterTokenRewardEquivalent;
+            const rewardTokenPerLp = tvlLpTokens > 0 ? totalStakeValueInRewardToken / tvlLpTokens : 0;
+            const tvlUsd = this.calculateTvlUsd({
+                token0Staked,
+                token1Staked,
+                token0PriceUsd,
+                token1PriceUsd
+            });
+            const apr = this.calcAPR(
+                hourlyRate,
+                tvlLpTokens,
+                rewardTokenPerLp,
+                poolWeight,
+                totalWeight
+            );
+
+            return {
+                isValid: rewardTokenPerLp > 0,
+                isSupportedPair: true,
+                tvlLpTokens,
+                token0Staked,
+                token1Staked,
+                rewardTokenPerLp,
+                rewardTokenStaked,
+                counterTokenStaked,
+                counterTokenRewardEquivalent,
+                totalStakeValueInRewardToken,
+                token0PriceUsd,
+                token1PriceUsd,
+                tvlUsd,
+                apr
+            };
+        }
+
+        calculateTvlUsd({
+            token0Staked = 0,
+            token1Staked = 0,
+            token0PriceUsd = 0,
+            token1PriceUsd = 0
+        }) {
+            const hasToken0Stake = token0Staked > 0;
+            const hasToken1Stake = token1Staked > 0;
+
+            if (!hasToken0Stake && !hasToken1Stake) {
+                return 0;
+            }
+
+            const hasToken0Price = !hasToken0Stake || token0PriceUsd > 0;
+            const hasToken1Price = !hasToken1Stake || token1PriceUsd > 0;
+
+            if (!hasToken0Price || !hasToken1Price) {
+                return null;
+            }
+
+            return (token0Staked * token0PriceUsd) + (token1Staked * token1PriceUsd);
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1894 @@
+{
+  "name": "lp-staking-vanilla",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lp-staking-vanilla",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "http-server": "^14.1.1",
+        "vitest": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
+      "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
+      "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
+      "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
+      "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
+      "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
+      "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
+      "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
+      "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+      "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.126.0",
+        "@rolldown/pluginutils": "1.0.0-rc.16"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
+      "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.16",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "start": "node cors-server.js",
     "dev": "node cors-server.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "serve": "python -m http.server 5500",
     "serve-cors": "npx http-server -p 5500 --cors"
   },
@@ -20,9 +22,7 @@
   "author": "LP Staking Team",
   "license": "MIT",
   "devDependencies": {
-    "http-server": "^14.1.1"
-  },
-  "engines": {
-    "node": ">=14.0.0"
+    "http-server": "^14.1.1",
+    "vitest": "^4.1.5"
   }
 }

--- a/tests/formatter.test.js
+++ b/tests/formatter.test.js
@@ -20,27 +20,26 @@ describe('Formatter currency helpers', () => {
         delete globalThis.window;
     });
 
-    it('formats currency values with cents and safe defaults', async () => {
+    it.each([
+        { input: 12.345, expected: '$12.35' },
+        { input: -5, expected: '$-5.00' },
+        { input: 'not-a-number', expected: '$0.00' }
+    ])('formatCurrency(%j) -> %s', async ({ input, expected }) => {
         const formatter = await loadFormatter();
 
-        expect(formatter.formatCurrency(12.345)).toBe('$12.35');
-        expect(formatter.formatCurrency(-5)).toBe('$-5.00');
-        expect(formatter.formatCurrency('not-a-number')).toBe('$0.00');
+        expect(formatter.formatCurrency(input)).toBe(expected);
     });
 
-    it('formats compact currency at threshold boundaries', async () => {
+    it.each([
+        { input: 999.5, expected: '$999.50' },
+        { input: 1000, expected: '$1.00K' },
+        { input: 1500000, expected: '$1.50M' },
+        { input: 2000000000, expected: '$2.00B' },
+        { input: Number.POSITIVE_INFINITY, expected: '$0.00' },
+        { input: undefined, expected: '$0.00' }
+    ])('formatCompactCurrency(%j) -> %s', async ({ input, expected }) => {
         const formatter = await loadFormatter();
 
-        expect(formatter.formatCompactCurrency(999.5)).toBe('$999.50');
-        expect(formatter.formatCompactCurrency(1000)).toBe('$1.00K');
-        expect(formatter.formatCompactCurrency(1500000)).toBe('$1.50M');
-        expect(formatter.formatCompactCurrency(2000000000)).toBe('$2.00B');
-    });
-
-    it('returns a safe default for non-finite compact currency input', async () => {
-        const formatter = await loadFormatter();
-
-        expect(formatter.formatCompactCurrency(Number.POSITIVE_INFINITY)).toBe('$0.00');
-        expect(formatter.formatCompactCurrency(undefined)).toBe('$0.00');
+        expect(formatter.formatCompactCurrency(input)).toBe(expected);
     });
 });

--- a/tests/formatter.test.js
+++ b/tests/formatter.test.js
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function loadFormatter() {
+    vi.resetModules();
+    globalThis.window = globalThis;
+    delete globalThis.Formatter;
+
+    await import('../js/utils/formatter.js');
+    return globalThis.Formatter;
+}
+
+describe('Formatter currency helpers', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete globalThis.Formatter;
+        delete globalThis.window;
+    });
+
+    it('formats currency values with cents and safe defaults', async () => {
+        const formatter = await loadFormatter();
+
+        expect(formatter.formatCurrency(12.345)).toBe('$12.35');
+        expect(formatter.formatCurrency(-5)).toBe('$-5.00');
+        expect(formatter.formatCurrency('not-a-number')).toBe('$0.00');
+    });
+
+    it('formats compact currency at threshold boundaries', async () => {
+        const formatter = await loadFormatter();
+
+        expect(formatter.formatCompactCurrency(999.5)).toBe('$999.50');
+        expect(formatter.formatCompactCurrency(1000)).toBe('$1.00K');
+        expect(formatter.formatCompactCurrency(1500000)).toBe('$1.50M');
+        expect(formatter.formatCompactCurrency(2000000000)).toBe('$2.00B');
+    });
+
+    it('returns a safe default for non-finite compact currency input', async () => {
+        const formatter = await loadFormatter();
+
+        expect(formatter.formatCompactCurrency(Number.POSITIVE_INFINITY)).toBe('$0.00');
+        expect(formatter.formatCompactCurrency(undefined)).toBe('$0.00');
+    });
+});

--- a/tests/home-page.test.js
+++ b/tests/home-page.test.js
@@ -21,18 +21,15 @@ describe('HomePage.formatTvlDisplay', () => {
         delete globalThis.window;
     });
 
-    it('returns a loading placeholder until TVL is calculated', async () => {
+    it.each([
+        { pair: undefined, expected: '...' },
+        { pair: { tvlCalculated: false }, expected: '...' },
+        { pair: { tvlCalculated: true, tvlUsd: null }, expected: 'N/A' },
+        { pair: { tvlCalculated: true, tvlUsd: undefined }, expected: 'N/A' }
+    ])('formatTvlDisplay(%j) -> %s', async ({ pair, expected }) => {
         const homePagePrototype = await loadHomePage();
 
-        expect(homePagePrototype.formatTvlDisplay.call({}, undefined)).toBe('...');
-        expect(homePagePrototype.formatTvlDisplay.call({}, { tvlCalculated: false })).toBe('...');
-    });
-
-    it('returns N/A when USD pricing is unavailable', async () => {
-        const homePagePrototype = await loadHomePage();
-
-        expect(homePagePrototype.formatTvlDisplay.call({}, { tvlCalculated: true, tvlUsd: null })).toBe('N/A');
-        expect(homePagePrototype.formatTvlDisplay.call({}, { tvlCalculated: true, tvlUsd: undefined })).toBe('N/A');
+        expect(homePagePrototype.formatTvlDisplay.call({}, pair)).toBe(expected);
     });
 
     it('uses the shared formatter when available', async () => {

--- a/tests/home-page.test.js
+++ b/tests/home-page.test.js
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function loadHomePage() {
+    vi.resetModules();
+    globalThis.window = globalThis;
+    delete globalThis.HomePage;
+
+    await import('../js/components/home-page.js');
+    return globalThis.HomePage.prototype;
+}
+
+describe('HomePage.formatTvlDisplay', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete globalThis.Formatter;
+        delete globalThis.HomePage;
+        delete globalThis.window;
+    });
+
+    it('returns a loading placeholder until TVL is calculated', async () => {
+        const homePagePrototype = await loadHomePage();
+
+        expect(homePagePrototype.formatTvlDisplay.call({}, undefined)).toBe('...');
+        expect(homePagePrototype.formatTvlDisplay.call({}, { tvlCalculated: false })).toBe('...');
+    });
+
+    it('returns N/A when USD pricing is unavailable', async () => {
+        const homePagePrototype = await loadHomePage();
+
+        expect(homePagePrototype.formatTvlDisplay.call({}, { tvlCalculated: true, tvlUsd: null })).toBe('N/A');
+        expect(homePagePrototype.formatTvlDisplay.call({}, { tvlCalculated: true, tvlUsd: undefined })).toBe('N/A');
+    });
+
+    it('uses the shared formatter when available', async () => {
+        const homePagePrototype = await loadHomePage();
+        globalThis.Formatter = {
+            formatCompactCurrency: vi.fn().mockReturnValue('$1.23M')
+        };
+
+        const output = homePagePrototype.formatTvlDisplay.call(
+            {
+                formatNumber: vi.fn()
+            },
+            { tvlCalculated: true, tvlUsd: 1230000 }
+        );
+
+        expect(output).toBe('$1.23M');
+        expect(globalThis.Formatter.formatCompactCurrency).toHaveBeenCalledWith(1230000);
+    });
+
+    it('falls back to formatNumber when the formatter is unavailable', async () => {
+        const homePagePrototype = await loadHomePage();
+        const formatNumber = vi.fn().mockReturnValue('123.46');
+
+        const output = homePagePrototype.formatTvlDisplay.call(
+            { formatNumber },
+            { tvlCalculated: true, tvlUsd: 123.456 }
+        );
+
+        expect(output).toBe('$123.46');
+        expect(formatNumber).toHaveBeenCalledWith(123.456);
+    });
+});

--- a/tests/rewards-calculator.test.js
+++ b/tests/rewards-calculator.test.js
@@ -26,43 +26,86 @@ describe('RewardsCalculator', () => {
         delete globalThis.window;
     });
 
-    it('calculates weighted APR and preserves a zero-weight pool', async () => {
+    it.each([
+        {
+            hourlyRate: 0.01,
+            tvlLpTokens: 10,
+            libPerLp: 10,
+            poolWeight: 70,
+            totalWeight: 100,
+            expected: 61.32
+        },
+        {
+            hourlyRate: 0.01,
+            tvlLpTokens: 10,
+            libPerLp: 10,
+            poolWeight: 30,
+            totalWeight: 100,
+            expected: 26.28
+        },
+        {
+            hourlyRate: 0.01,
+            tvlLpTokens: 10,
+            libPerLp: 10,
+            poolWeight: 0,
+            totalWeight: 100,
+            expected: 0
+        }
+    ])('calcAPR($poolWeight / $totalWeight) -> $expected', async ({
+        hourlyRate,
+        tvlLpTokens,
+        libPerLp,
+        poolWeight,
+        totalWeight,
+        expected
+    }) => {
         const calculator = await loadRewardsCalculator();
 
-        expect(calculator.calcAPR(0.01, 10, 10, 70, 100)).toBeCloseTo(61.32);
-        expect(calculator.calcAPR(0.01, 10, 10, 30, 100)).toBeCloseTo(26.28);
-        expect(calculator.calcAPR(0.01, 10, 10, 0, 100)).toBe(0);
+        if (expected === 0) {
+            expect(calculator.calcAPR(hourlyRate, tvlLpTokens, libPerLp, poolWeight, totalWeight)).toBe(0);
+            return;
+        }
+
+        expect(calculator.calcAPR(hourlyRate, tvlLpTokens, libPerLp, poolWeight, totalWeight)).toBeCloseTo(expected);
     });
 
-    it('calculates USD TVL and handles missing prices safely', async () => {
-        const calculator = await loadRewardsCalculator();
-
-        expect(
-            calculator.calculateTvlUsd({
+    it.each([
+        {
+            input: {
                 token0Staked: 0,
                 token1Staked: 0,
                 token0PriceUsd: 0,
                 token1PriceUsd: 0
-            })
-        ).toBe(0);
-
-        expect(
-            calculator.calculateTvlUsd({
+            },
+            expected: 0
+        },
+        {
+            input: {
                 token0Staked: 10,
                 token1Staked: 2,
                 token0PriceUsd: 5,
                 token1PriceUsd: 0
-            })
-        ).toBeNull();
-
-        expect(
-            calculator.calculateTvlUsd({
+            },
+            expected: null
+        },
+        {
+            input: {
                 token0Staked: 10,
                 token1Staked: 0,
                 token0PriceUsd: 5,
                 token1PriceUsd: 0
-            })
-        ).toBe(50);
+            },
+            expected: 50
+        }
+    ])('calculateTvlUsd($input.token0Staked, $input.token1Staked) -> $expected', async ({ input, expected }) => {
+        const calculator = await loadRewardsCalculator();
+
+        if (expected === null) {
+            expect(calculator.calculateTvlUsd(input)).toBeNull();
+            return;
+        }
+
+        expect(calculator.calculateTvlUsd(input)).toBe(expected);
     });
 
     it('caches repeated token price lookups by normalized address', async () => {

--- a/tests/rewards-calculator.test.js
+++ b/tests/rewards-calculator.test.js
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function loadRewardsCalculator() {
+    vi.resetModules();
+    globalThis.window = globalThis;
+    globalThis.global = globalThis;
+    delete globalThis.RewardsCalculator;
+    delete globalThis.rewardsCalculator;
+
+    await import('../js/utils/rewards-calculator.js');
+    return new globalThis.RewardsCalculator();
+}
+
+describe('RewardsCalculator', () => {
+    beforeEach(() => {
+        globalThis.fetch = vi.fn();
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete globalThis.fetch;
+        delete globalThis.RewardsCalculator;
+        delete globalThis.rewardsCalculator;
+        delete globalThis.window;
+    });
+
+    it('calculates weighted APR and preserves a zero-weight pool', async () => {
+        const calculator = await loadRewardsCalculator();
+
+        expect(calculator.calcAPR(0.01, 10, 10, 70, 100)).toBeCloseTo(61.32);
+        expect(calculator.calcAPR(0.01, 10, 10, 30, 100)).toBeCloseTo(26.28);
+        expect(calculator.calcAPR(0.01, 10, 10, 0, 100)).toBe(0);
+    });
+
+    it('calculates USD TVL and handles missing prices safely', async () => {
+        const calculator = await loadRewardsCalculator();
+
+        expect(
+            calculator.calculateTvlUsd({
+                token0Staked: 0,
+                token1Staked: 0,
+                token0PriceUsd: 0,
+                token1PriceUsd: 0
+            })
+        ).toBe(0);
+
+        expect(
+            calculator.calculateTvlUsd({
+                token0Staked: 10,
+                token1Staked: 2,
+                token0PriceUsd: 5,
+                token1PriceUsd: 0
+            })
+        ).toBeNull();
+
+        expect(
+            calculator.calculateTvlUsd({
+                token0Staked: 10,
+                token1Staked: 0,
+                token0PriceUsd: 5,
+                token1PriceUsd: 0
+            })
+        ).toBe(50);
+    });
+
+    it('caches repeated token price lookups by normalized address', async () => {
+        const calculator = await loadRewardsCalculator();
+        globalThis.fetch.mockResolvedValue({
+            ok: true,
+            json: vi.fn().mockResolvedValue({
+                pairs: [{ priceUsd: '1.23' }]
+            })
+        });
+
+        const first = await calculator.fetchTokenPriceByAddress('0xABC');
+        const second = await calculator.fetchTokenPriceByAddress('0xabc');
+
+        expect(first).toBe(1.23);
+        expect(second).toBe(1.23);
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+        expect(globalThis.fetch).toHaveBeenCalledWith('https://api.dexscreener.com/latest/dex/tokens/0xabc');
+    });
+
+    it('returns zero and does not cache failed or zero-priced lookups', async () => {
+        const calculator = await loadRewardsCalculator();
+
+        globalThis.fetch
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 500
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: vi.fn().mockResolvedValue({
+                    pairs: [{ priceUsd: '0' }]
+                })
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: vi.fn().mockResolvedValue({
+                    pairs: [{ priceUsd: '0' }]
+                })
+            });
+
+        expect(await calculator.fetchTokenPriceByAddress('0xdef')).toBe(0);
+        expect(await calculator.fetchTokenPriceByAddress('0xzero')).toBe(0);
+        expect(await calculator.fetchTokenPriceByAddress('0xzero')).toBe(0);
+        expect(await calculator.fetchTokenPriceByAddress('')).toBe(0);
+
+        expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+        expect(console.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('builds pool metrics for a reward token on token0', async () => {
+        const calculator = await loadRewardsCalculator();
+        const metrics = calculator.buildPoolMetrics({
+            rewardTokenAddress: '0xlib',
+            hourlyRate: 0.01,
+            poolWeight: 70,
+            totalWeight: 100,
+            token0PriceUsd: 0.5,
+            token1PriceUsd: 2000,
+            breakdown: {
+                lpToken: {
+                    stakedBalance: { formatted: '10' }
+                },
+                token0: {
+                    address: '0xlib',
+                    staked: { formatted: '50' },
+                    reserve: { formatted: '500' }
+                },
+                token1: {
+                    address: '0xweth',
+                    staked: { formatted: '0.2' },
+                    reserve: { formatted: '2' }
+                }
+            }
+        });
+
+        expect(metrics.isSupportedPair).toBe(true);
+        expect(metrics.rewardTokenPerLp).toBeCloseTo(10);
+        expect(metrics.tvlUsd).toBeCloseTo(425);
+        expect(metrics.apr).toBeCloseTo(61.32);
+    });
+
+    it('builds pool metrics for a reward token on token1 and preserves a zero-weight pool', async () => {
+        const calculator = await loadRewardsCalculator();
+        const metrics = calculator.buildPoolMetrics({
+            rewardTokenAddress: '0xlib',
+            hourlyRate: 1,
+            poolWeight: 0,
+            totalWeight: 100,
+            token0PriceUsd: 2500,
+            token1PriceUsd: 0.4,
+            breakdown: {
+                lpToken: {
+                    stakedBalance: { formatted: '20' }
+                },
+                token0: {
+                    address: '0xweth',
+                    staked: { formatted: '1' },
+                    reserve: { formatted: '10' }
+                },
+                token1: {
+                    address: '0xlib',
+                    staked: { formatted: '250' },
+                    reserve: { formatted: '2500' }
+                }
+            }
+        });
+
+        expect(metrics.isSupportedPair).toBe(true);
+        expect(metrics.rewardTokenStaked).toBe(250);
+        expect(metrics.counterTokenRewardEquivalent).toBe(250);
+        expect(metrics.rewardTokenPerLp).toBe(25);
+        expect(metrics.tvlUsd).toBeCloseTo(2600);
+        expect(metrics.apr).toBe(0);
+    });
+
+    it('returns safe defaults for unsupported pairs and unresolved USD pricing', async () => {
+        const calculator = await loadRewardsCalculator();
+
+        const unsupportedMetrics = calculator.buildPoolMetrics({
+            rewardTokenAddress: '0xlib',
+            token0PriceUsd: 2,
+            token1PriceUsd: 5,
+            breakdown: {
+                lpToken: {
+                    stakedBalance: { formatted: '3' }
+                },
+                token0: {
+                    address: '0xaaa',
+                    staked: { formatted: '4' },
+                    reserve: { formatted: '40' }
+                },
+                token1: {
+                    address: '0xbbb',
+                    staked: { formatted: '6' },
+                    reserve: { formatted: '60' }
+                }
+            }
+        });
+
+        const unresolvedPricingMetrics = calculator.buildPoolMetrics({
+            rewardTokenAddress: '0xlib',
+            token0PriceUsd: 1,
+            token1PriceUsd: 0,
+            breakdown: {
+                lpToken: {
+                    stakedBalance: { formatted: '5' }
+                },
+                token0: {
+                    address: '0xlib',
+                    staked: { formatted: '10' },
+                    reserve: { formatted: '100' }
+                },
+                token1: {
+                    address: '0xusdc',
+                    staked: { formatted: '10' },
+                    reserve: { formatted: '100' }
+                }
+            }
+        });
+
+        expect(unsupportedMetrics.isSupportedPair).toBe(false);
+        expect(unsupportedMetrics.apr).toBe(0);
+        expect(unsupportedMetrics.tvlUsd).toBe(38);
+
+        expect(unresolvedPricingMetrics.isSupportedPair).toBe(true);
+        expect(unresolvedPricingMetrics.tvlUsd).toBeNull();
+        expect(unresolvedPricingMetrics.rewardTokenPerLp).toBeCloseTo(4);
+    });
+});


### PR DESCRIPTION
## Summary
- display homepage TVL in USD using underlying token prices for each LP pair
- keep raw LP balances for share calculations while formatting the TVL column separately
- split token price lookup into smaller cached helpers and preserve explicit zero pool weights
- add Vitest coverage for the new utility logic and remove the unused `calcAPR()` object-form compatibility path
- add a pull request workflow that installs dependencies and runs the unit test suite on GitHub Actions
- commit `package-lock.json` and switch CI to cached `npm ci` installs

## Test Coverage
- `RewardsCalculator`: APR weighting, zero-weight handling, USD TVL calculation, token price caching, failed/zero-priced lookups, supported and unsupported pair metrics
- `Formatter`: currency formatting defaults and compact-threshold formatting
- `HomePage.formatTvlDisplay()`: loading state, unavailable pricing state, formatter path, and fallback path
<img width="1063" height="487" alt="image" src="https://github.com/user-attachments/assets/c8d776e7-41e8-4eec-adc7-6e57a681fc90" />

