### PR TITLE
refactor: modularize token pricing fallbacks

### DIFF
--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -119,6 +119,8 @@ class MasterInitializer {
 
         // Only load rewards calculator on homepage
         if (!this.isAdminPage) {
+            walletScripts.push('js/utils/pricing/gecko-terminal-price-provider.js');
+            walletScripts.push('js/utils/pricing/dex-screener-price-provider.js');
             walletScripts.push('js/utils/rewards-calculator.js');
         } else {
             console.log('⏭️ Skipping homepage utilities (admin mode)');

--- a/js/utils/pricing/dex-screener-price-provider.js
+++ b/js/utils/pricing/dex-screener-price-provider.js
@@ -1,0 +1,102 @@
+/**
+ * DexScreenerPriceProvider - Secondary token USD pricing fallback by chain + liquidity.
+ */
+(function(global) {
+    'use strict';
+
+    if (global.DexScreenerPriceProvider) {
+        console.warn('DexScreenerPriceProvider already registered, skipping redeclaration');
+        return;
+    }
+
+    class DexScreenerPriceProvider {
+        constructor() {
+            this.name = 'dexscreener';
+            this.baseUrl = 'https://api.dexscreener.com/latest/dex/tokens';
+        }
+
+        normalizeAddress(address) {
+            return typeof address === 'string' ? address.toLowerCase() : null;
+        }
+
+        parseAmount(value) {
+            const parsed = Number(value);
+            return Number.isFinite(parsed) ? parsed : 0;
+        }
+
+        getChainId(chainId) {
+            switch (Number(chainId)) {
+                case 56:
+                    return 'bsc';
+                case 137:
+                    return 'polygon';
+                default:
+                    return null;
+            }
+        }
+
+        getPairLiquidityUsd(pair) {
+            return this.parseAmount(pair?.liquidity?.usd);
+        }
+
+        getBestPair(address, data, context = {}) {
+            const normalizedAddress = this.normalizeAddress(address);
+            const resolvedChainId = this.getChainId(context.chainId);
+            const pairs = Array.isArray(data?.pairs) ? data.pairs : [];
+            const candidatePairs = pairs.filter((pair) => {
+                const priceUsd = Number.parseFloat(pair?.priceUsd || '0') || 0;
+                const baseTokenAddress = this.normalizeAddress(pair?.baseToken?.address);
+
+                if (priceUsd <= 0 || !normalizedAddress || baseTokenAddress !== normalizedAddress) {
+                    return false;
+                }
+
+                if (resolvedChainId && pair?.chainId !== resolvedChainId) {
+                    return false;
+                }
+
+                return true;
+            });
+
+            if (candidatePairs.length === 0) {
+                return null;
+            }
+
+            return candidatePairs.reduce((bestPair, pair) => {
+                if (!bestPair) {
+                    return pair;
+                }
+
+                const bestLiquidityUsd = this.getPairLiquidityUsd(bestPair);
+                const pairLiquidityUsd = this.getPairLiquidityUsd(pair);
+
+                if (pairLiquidityUsd > bestLiquidityUsd) {
+                    return pair;
+                }
+
+                return bestPair;
+            }, null);
+        }
+
+        async fetchTokenPrice(address, context = {}) {
+            const normalizedAddress = this.normalizeAddress(address);
+            const resolvedChainId = this.getChainId(context.chainId);
+
+            if (!normalizedAddress || !resolvedChainId || typeof fetch !== 'function') {
+                return 0;
+            }
+
+            const response = await fetch(`${this.baseUrl}/${normalizedAddress}`);
+            if (!response.ok) {
+                throw new Error(`DexScreener price request failed: ${response.status}`);
+            }
+
+            const data = await response.json();
+            const bestPair = this.getBestPair(normalizedAddress, data, context);
+            return Number.parseFloat(bestPair?.priceUsd || '0') || 0;
+        }
+    }
+
+    global.DexScreenerPriceProvider = DexScreenerPriceProvider;
+    console.log('✅ DexScreenerPriceProvider class registered globally');
+})(typeof window !== 'undefined' ? window : global);

--- a/js/utils/pricing/gecko-terminal-price-provider.js
+++ b/js/utils/pricing/gecko-terminal-price-provider.js
@@ -1,0 +1,68 @@
+/**
+ * GeckoTerminalPriceProvider - Primary token USD pricing by chain + token address.
+ */
+(function(global) {
+    'use strict';
+
+    if (global.GeckoTerminalPriceProvider) {
+        console.warn('GeckoTerminalPriceProvider already registered, skipping redeclaration');
+        return;
+    }
+
+    class GeckoTerminalPriceProvider {
+        constructor() {
+            this.name = 'geckoterminal';
+            this.baseUrl = 'https://api.geckoterminal.com/api/v2/simple/networks';
+        }
+
+        normalizeAddress(address) {
+            return typeof address === 'string' ? address.toLowerCase() : null;
+        }
+
+        getNetworkId(chainId) {
+            switch (Number(chainId)) {
+                case 56:
+                    return 'bsc';
+                case 137:
+                    return 'polygon_pos';
+                default:
+                    return null;
+            }
+        }
+
+        parseTokenPrice(address, data) {
+            const normalizedAddress = this.normalizeAddress(address);
+            const tokenPrices = data?.data?.attributes?.token_prices;
+
+            if (!normalizedAddress || !tokenPrices || typeof tokenPrices !== 'object') {
+                return 0;
+            }
+
+            const matchedEntry = Object.entries(tokenPrices).find(([tokenAddress]) => {
+                return this.normalizeAddress(tokenAddress) === normalizedAddress;
+            });
+
+            return Number.parseFloat(matchedEntry?.[1] || '0') || 0;
+        }
+
+        async fetchTokenPrice(address, context = {}) {
+            const normalizedAddress = this.normalizeAddress(address);
+            const networkId = this.getNetworkId(context.chainId);
+
+            if (!normalizedAddress || !networkId || typeof fetch !== 'function') {
+                return 0;
+            }
+
+            const response = await fetch(`${this.baseUrl}/${networkId}/token_price/${normalizedAddress}`);
+            if (!response.ok) {
+                throw new Error(`GeckoTerminal price request failed: ${response.status}`);
+            }
+
+            const data = await response.json();
+            return this.parseTokenPrice(normalizedAddress, data);
+        }
+    }
+
+    global.GeckoTerminalPriceProvider = GeckoTerminalPriceProvider;
+    console.log('✅ GeckoTerminalPriceProvider class registered globally');
+})(typeof window !== 'undefined' ? window : global);

--- a/js/utils/rewards-calculator.js
+++ b/js/utils/rewards-calculator.js
@@ -20,7 +20,11 @@
             this.isInitialized = false;
             this.priceCache = new Map();
             this.priceCacheTtlMs = 5 * 60 * 1000;
-            this.dexScreenerBaseUrl = 'https://api.dexscreener.com/latest/dex/tokens';
+            this.tokenPriceProviderNames = [
+                'GeckoTerminalPriceProvider',
+                'DexScreenerPriceProvider'
+            ];
+            this.tokenPriceProviders = null;
         }
 
         async initialize(contractManagerOrOptions) {
@@ -83,38 +87,33 @@
             return Number.isFinite(parsed) ? parsed : 0;
         }
 
-        getCurrentDexScreenerChainContext() {
+        getCurrentPricingChainContext() {
             const chainId = Number(globalThis?.window?.networkSelector?.getCurrentChainId?.());
 
-            if (!Number.isFinite(chainId) || chainId <= 0) {
-                return {
-                    dexScreenerChainId: null,
-                    isSupported: null
-                };
-            }
-
-            switch (chainId) {
-                case 56:
-                    return { dexScreenerChainId: 'bsc', isSupported: true };
-                case 137:
-                    return { dexScreenerChainId: 'polygon', isSupported: true };
-                case 97:
-                case 80002:
-                    return { dexScreenerChainId: null, isSupported: false };
-                default:
-                    return {
-                        dexScreenerChainId: null,
-                        isSupported: null
-                    };
-            }
+            return {
+                chainId: Number.isFinite(chainId) && chainId > 0 ? chainId : null
+            };
         }
 
-        getPriceCacheKey(address, dexScreenerChainId = null) {
-            return `${dexScreenerChainId || 'any'}:${address}`;
+        getTokenPriceProviders() {
+            if (this.tokenPriceProviders) {
+                return this.tokenPriceProviders;
+            }
+
+            this.tokenPriceProviders = this.tokenPriceProviderNames
+                .map((providerName) => globalThis?.window?.[providerName])
+                .filter((ProviderClass) => typeof ProviderClass === 'function')
+                .map((ProviderClass) => new ProviderClass());
+
+            return this.tokenPriceProviders;
         }
 
-        getCachedTokenPrice(address, dexScreenerChainId = null) {
-            const cacheKey = this.getPriceCacheKey(address, dexScreenerChainId);
+        getPriceCacheKey(address, chainId = null) {
+            return `${chainId || 'any'}:${address}`;
+        }
+
+        getCachedTokenPrice(address, chainId = null) {
+            const cacheKey = this.getPriceCacheKey(address, chainId);
             const cachedEntry = this.priceCache.get(cacheKey);
             if (!cachedEntry) {
                 return null;
@@ -124,96 +123,49 @@
             return cacheAgeMs < this.priceCacheTtlMs ? cachedEntry.price : null;
         }
 
-        setCachedTokenPrice(address, dexScreenerChainId, price) {
+        setCachedTokenPrice(address, chainId, price) {
             if (price <= 0) {
                 return;
             }
 
-            const cacheKey = this.getPriceCacheKey(address, dexScreenerChainId);
+            const cacheKey = this.getPriceCacheKey(address, chainId);
             this.priceCache.set(cacheKey, {
                 price,
                 timestamp: Date.now()
             });
         }
 
-        getDexScreenerPairLiquidityUsd(pair) {
-            return this.parseAmount(pair?.liquidity?.usd);
-        }
-
-        getBestDexScreenerPair(address, data, dexScreenerChainId = null) {
-            const normalizedAddress = this.normalizeAddress(address);
-            const pairs = Array.isArray(data?.pairs) ? data.pairs : [];
-            const pricedPairs = pairs.filter((pair) => {
-                const priceUsd = Number.parseFloat(pair?.priceUsd || '0') || 0;
-                if (priceUsd <= 0) {
-                    return false;
-                }
-
-                const baseTokenAddress = this.normalizeAddress(pair?.baseToken?.address);
-                return !normalizedAddress || baseTokenAddress === normalizedAddress;
-            });
-
-            if (pricedPairs.length === 0) {
-                return null;
-            }
-
-            const sameChainPairs = dexScreenerChainId
-                ? pricedPairs.filter((pair) => pair?.chainId === dexScreenerChainId)
-                : pricedPairs;
-            const candidatePairs = sameChainPairs.length > 0 ? sameChainPairs : pricedPairs;
-
-            return candidatePairs.reduce((bestPair, pair) => {
-                if (!bestPair) {
-                    return pair;
-                }
-
-                const bestLiquidityUsd = this.getDexScreenerPairLiquidityUsd(bestPair);
-                const pairLiquidityUsd = this.getDexScreenerPairLiquidityUsd(pair);
-
-                if (pairLiquidityUsd > bestLiquidityUsd) {
-                    return pair;
-                }
-
-                return bestPair;
-            }, null);
-        }
-
-        parseDexScreenerPriceUsd(address, data, dexScreenerChainId = null) {
-            const bestPair = this.getBestDexScreenerPair(address, data, dexScreenerChainId);
-            return Number.parseFloat(bestPair?.priceUsd || '0') || 0;
-        }
-
-        async requestTokenPriceByAddress(address, dexScreenerChainId = null) {
-            const response = await fetch(`${this.dexScreenerBaseUrl}/${address}`);
-            if (!response.ok) {
-                throw new Error(`DexScreener price request failed: ${response.status}`);
-            }
-
-            const data = await response.json();
-            return this.parseDexScreenerPriceUsd(address, data, dexScreenerChainId);
-        }
-
         async fetchTokenPriceByAddress(address) {
             const normalizedAddress = this.normalizeAddress(address);
-            const chainContext = this.getCurrentDexScreenerChainContext();
+            const chainContext = this.getCurrentPricingChainContext();
 
-            if (!normalizedAddress || typeof fetch !== 'function' || chainContext.isSupported === false) {
+            if (!normalizedAddress || typeof fetch !== 'function') {
                 return 0;
             }
 
-            const cachedPrice = this.getCachedTokenPrice(normalizedAddress, chainContext.dexScreenerChainId);
+            const cachedPrice = this.getCachedTokenPrice(normalizedAddress, chainContext.chainId);
             if (cachedPrice !== null) {
                 return cachedPrice;
             }
 
-            try {
-                const price = await this.requestTokenPriceByAddress(normalizedAddress, chainContext.dexScreenerChainId);
-                this.setCachedTokenPrice(normalizedAddress, chainContext.dexScreenerChainId, price);
-                return price;
-            } catch (error) {
-                console.warn(`Failed to fetch token price for ${normalizedAddress}:`, error?.message || error);
-                return 0;
+            let lastError = null;
+            for (const provider of this.getTokenPriceProviders()) {
+                try {
+                    const price = await provider.fetchTokenPrice(normalizedAddress, chainContext);
+                    if (price > 0) {
+                        this.setCachedTokenPrice(normalizedAddress, chainContext.chainId, price);
+                        return price;
+                    }
+                } catch (error) {
+                    lastError = error;
+                }
             }
+
+            if (lastError) {
+                console.warn(`Failed to fetch token price for ${normalizedAddress}:`, lastError?.message || lastError);
+            }
+
+            return 0;
         }
 
         buildPoolMetrics({

--- a/js/utils/rewards-calculator.js
+++ b/js/utils/rewards-calculator.js
@@ -83,8 +83,39 @@
             return Number.isFinite(parsed) ? parsed : 0;
         }
 
-        getCachedTokenPrice(address) {
-            const cachedEntry = this.priceCache.get(address);
+        getCurrentDexScreenerChainContext() {
+            const chainId = Number(globalThis?.window?.networkSelector?.getCurrentChainId?.());
+
+            if (!Number.isFinite(chainId) || chainId <= 0) {
+                return {
+                    dexScreenerChainId: null,
+                    isSupported: null
+                };
+            }
+
+            switch (chainId) {
+                case 56:
+                    return { dexScreenerChainId: 'bsc', isSupported: true };
+                case 137:
+                    return { dexScreenerChainId: 'polygon', isSupported: true };
+                case 97:
+                case 80002:
+                    return { dexScreenerChainId: null, isSupported: false };
+                default:
+                    return {
+                        dexScreenerChainId: null,
+                        isSupported: null
+                    };
+            }
+        }
+
+        getPriceCacheKey(address, dexScreenerChainId = null) {
+            return `${dexScreenerChainId || 'any'}:${address}`;
+        }
+
+        getCachedTokenPrice(address, dexScreenerChainId = null) {
+            const cacheKey = this.getPriceCacheKey(address, dexScreenerChainId);
+            const cachedEntry = this.priceCache.get(cacheKey);
             if (!cachedEntry) {
                 return null;
             }
@@ -93,45 +124,91 @@
             return cacheAgeMs < this.priceCacheTtlMs ? cachedEntry.price : null;
         }
 
-        setCachedTokenPrice(address, price) {
+        setCachedTokenPrice(address, dexScreenerChainId, price) {
             if (price <= 0) {
                 return;
             }
 
-            this.priceCache.set(address, {
+            const cacheKey = this.getPriceCacheKey(address, dexScreenerChainId);
+            this.priceCache.set(cacheKey, {
                 price,
                 timestamp: Date.now()
             });
         }
 
-        parseDexScreenerPriceUsd(data) {
-            return Number.parseFloat(data?.pairs?.[0]?.priceUsd || '0') || 0;
+        getDexScreenerPairLiquidityUsd(pair) {
+            return this.parseAmount(pair?.liquidity?.usd);
         }
 
-        async requestTokenPriceByAddress(address) {
+        getBestDexScreenerPair(address, data, dexScreenerChainId = null) {
+            const normalizedAddress = this.normalizeAddress(address);
+            const pairs = Array.isArray(data?.pairs) ? data.pairs : [];
+            const pricedPairs = pairs.filter((pair) => {
+                const priceUsd = Number.parseFloat(pair?.priceUsd || '0') || 0;
+                if (priceUsd <= 0) {
+                    return false;
+                }
+
+                const baseTokenAddress = this.normalizeAddress(pair?.baseToken?.address);
+                return !normalizedAddress || baseTokenAddress === normalizedAddress;
+            });
+
+            if (pricedPairs.length === 0) {
+                return null;
+            }
+
+            const sameChainPairs = dexScreenerChainId
+                ? pricedPairs.filter((pair) => pair?.chainId === dexScreenerChainId)
+                : pricedPairs;
+            const candidatePairs = sameChainPairs.length > 0 ? sameChainPairs : pricedPairs;
+
+            return candidatePairs.reduce((bestPair, pair) => {
+                if (!bestPair) {
+                    return pair;
+                }
+
+                const bestLiquidityUsd = this.getDexScreenerPairLiquidityUsd(bestPair);
+                const pairLiquidityUsd = this.getDexScreenerPairLiquidityUsd(pair);
+
+                if (pairLiquidityUsd > bestLiquidityUsd) {
+                    return pair;
+                }
+
+                return bestPair;
+            }, null);
+        }
+
+        parseDexScreenerPriceUsd(address, data, dexScreenerChainId = null) {
+            const bestPair = this.getBestDexScreenerPair(address, data, dexScreenerChainId);
+            return Number.parseFloat(bestPair?.priceUsd || '0') || 0;
+        }
+
+        async requestTokenPriceByAddress(address, dexScreenerChainId = null) {
             const response = await fetch(`${this.dexScreenerBaseUrl}/${address}`);
             if (!response.ok) {
                 throw new Error(`DexScreener price request failed: ${response.status}`);
             }
 
             const data = await response.json();
-            return this.parseDexScreenerPriceUsd(data);
+            return this.parseDexScreenerPriceUsd(address, data, dexScreenerChainId);
         }
 
         async fetchTokenPriceByAddress(address) {
             const normalizedAddress = this.normalizeAddress(address);
-            if (!normalizedAddress || typeof fetch !== 'function') {
+            const chainContext = this.getCurrentDexScreenerChainContext();
+
+            if (!normalizedAddress || typeof fetch !== 'function' || chainContext.isSupported === false) {
                 return 0;
             }
 
-            const cachedPrice = this.getCachedTokenPrice(normalizedAddress);
+            const cachedPrice = this.getCachedTokenPrice(normalizedAddress, chainContext.dexScreenerChainId);
             if (cachedPrice !== null) {
                 return cachedPrice;
             }
 
             try {
-                const price = await this.requestTokenPriceByAddress(normalizedAddress);
-                this.setCachedTokenPrice(normalizedAddress, price);
+                const price = await this.requestTokenPriceByAddress(normalizedAddress, chainContext.dexScreenerChainId);
+                this.setCachedTokenPrice(normalizedAddress, chainContext.dexScreenerChainId, price);
                 return price;
             } catch (error) {
                 console.warn(`Failed to fetch token price for ${normalizedAddress}:`, error?.message || error);

--- a/js/utils/version-check.js
+++ b/js/utils/version-check.js
@@ -165,6 +165,8 @@
             // JavaScript - Utils (only existing files)
             `${basePath}js/utils/admin-test.js`,
             `${basePath}js/utils/formatter.js`,
+            `${basePath}js/utils/pricing/gecko-terminal-price-provider.js`,
+            `${basePath}js/utils/pricing/dex-screener-price-provider.js`,
             `${basePath}js/utils/rewards-calculator.js`,
             `${basePath}js/utils/rpc-test.js`,
             `${basePath}js/utils/ses-safe-handler.js`,
@@ -199,4 +201,3 @@
     checkVersion(getCriticalFiles());
 
 })(window);
-

--- a/tests/rewards-calculator.test.js
+++ b/tests/rewards-calculator.test.js
@@ -14,6 +14,10 @@ async function loadRewardsCalculator() {
 describe('RewardsCalculator', () => {
     beforeEach(() => {
         globalThis.fetch = vi.fn();
+        globalThis.window = globalThis;
+        globalThis.window.networkSelector = {
+            getCurrentChainId: vi.fn(() => 56)
+        };
         vi.spyOn(console, 'log').mockImplementation(() => {});
         vi.spyOn(console, 'warn').mockImplementation(() => {});
     });
@@ -21,6 +25,7 @@ describe('RewardsCalculator', () => {
     afterEach(() => {
         vi.restoreAllMocks();
         delete globalThis.fetch;
+        delete globalThis.networkSelector;
         delete globalThis.RewardsCalculator;
         delete globalThis.rewardsCalculator;
         delete globalThis.window;
@@ -108,22 +113,100 @@ describe('RewardsCalculator', () => {
         expect(calculator.calculateTvlUsd(input)).toBe(expected);
     });
 
-    it('caches repeated token price lookups by normalized address', async () => {
+    it('selects the deepest-liquidity pair on the active chain and caches repeated lookups', async () => {
         const calculator = await loadRewardsCalculator();
         globalThis.fetch.mockResolvedValue({
             ok: true,
             json: vi.fn().mockResolvedValue({
-                pairs: [{ priceUsd: '1.23' }]
+                pairs: [
+                    {
+                        chainId: 'bsc',
+                        baseToken: { address: '0xother' },
+                        quoteToken: { address: '0xabc' },
+                        priceUsd: '13.45',
+                        liquidity: { usd: 76300725.73 }
+                    },
+                    {
+                        chainId: 'ethereum',
+                        baseToken: { address: '0xabc' },
+                        quoteToken: { address: '0xusd' },
+                        priceUsd: '9.99',
+                        liquidity: { usd: 99999999 }
+                    },
+                    {
+                        chainId: 'bsc',
+                        baseToken: { address: '0xabc' },
+                        quoteToken: { address: '0xusd' },
+                        priceUsd: '3.11',
+                        liquidity: { usd: 1205785.98 }
+                    },
+                    {
+                        chainId: 'bsc',
+                        baseToken: { address: '0xABC' },
+                        quoteToken: { address: '0xusd' },
+                        priceUsd: '1.00042',
+                        liquidity: { usd: 44962438.69 }
+                    }
+                ]
             })
         });
 
         const first = await calculator.fetchTokenPriceByAddress('0xABC');
         const second = await calculator.fetchTokenPriceByAddress('0xabc');
 
-        expect(first).toBe(1.23);
-        expect(second).toBe(1.23);
+        expect(first).toBe(1.00042);
+        expect(second).toBe(1.00042);
         expect(globalThis.fetch).toHaveBeenCalledTimes(1);
         expect(globalThis.fetch).toHaveBeenCalledWith('https://api.dexscreener.com/latest/dex/tokens/0xabc');
+    });
+
+    it('scopes cached token prices to the active chain', async () => {
+        const calculator = await loadRewardsCalculator();
+
+        globalThis.fetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: vi.fn().mockResolvedValue({
+                    pairs: [
+                        {
+                            chainId: 'bsc',
+                            baseToken: { address: '0xabc' },
+                            quoteToken: { address: '0xusd' },
+                            priceUsd: '1.11',
+                            liquidity: { usd: 1000 }
+                        }
+                    ]
+                })
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: vi.fn().mockResolvedValue({
+                    pairs: [
+                        {
+                            chainId: 'polygon',
+                            baseToken: { address: '0xabc' },
+                            quoteToken: { address: '0xusd' },
+                            priceUsd: '2.22',
+                            liquidity: { usd: 2000 }
+                        }
+                    ]
+                })
+            });
+
+        expect(await calculator.fetchTokenPriceByAddress('0xabc')).toBe(1.11);
+
+        globalThis.window.networkSelector.getCurrentChainId.mockReturnValue(137);
+        expect(await calculator.fetchTokenPriceByAddress('0xabc')).toBe(2.22);
+
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns zero for unsupported testnet pricing contexts', async () => {
+        const calculator = await loadRewardsCalculator();
+        globalThis.window.networkSelector.getCurrentChainId.mockReturnValue(80002);
+
+        expect(await calculator.fetchTokenPriceByAddress('0xabc')).toBe(0);
+        expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 
     it('returns zero and does not cache failed or zero-priced lookups', async () => {
@@ -137,13 +220,13 @@ describe('RewardsCalculator', () => {
             .mockResolvedValueOnce({
                 ok: true,
                 json: vi.fn().mockResolvedValue({
-                    pairs: [{ priceUsd: '0' }]
+                    pairs: [{ chainId: 'bsc', baseToken: { address: '0xzero' }, quoteToken: { address: '0xusd' }, priceUsd: '0' }]
                 })
             })
             .mockResolvedValueOnce({
                 ok: true,
                 json: vi.fn().mockResolvedValue({
-                    pairs: [{ priceUsd: '0' }]
+                    pairs: [{ chainId: 'bsc', baseToken: { address: '0xzero' }, quoteToken: { address: '0xusd' }, priceUsd: '0' }]
                 })
             });
 

--- a/tests/rewards-calculator.test.js
+++ b/tests/rewards-calculator.test.js
@@ -4,9 +4,13 @@ async function loadRewardsCalculator() {
     vi.resetModules();
     globalThis.window = globalThis;
     globalThis.global = globalThis;
+    delete globalThis.GeckoTerminalPriceProvider;
+    delete globalThis.DexScreenerPriceProvider;
     delete globalThis.RewardsCalculator;
     delete globalThis.rewardsCalculator;
 
+    await import('../js/utils/pricing/gecko-terminal-price-provider.js');
+    await import('../js/utils/pricing/dex-screener-price-provider.js');
     await import('../js/utils/rewards-calculator.js');
     return new globalThis.RewardsCalculator();
 }
@@ -26,6 +30,8 @@ describe('RewardsCalculator', () => {
         vi.restoreAllMocks();
         delete globalThis.fetch;
         delete globalThis.networkSelector;
+        delete globalThis.GeckoTerminalPriceProvider;
+        delete globalThis.DexScreenerPriceProvider;
         delete globalThis.RewardsCalculator;
         delete globalThis.rewardsCalculator;
         delete globalThis.window;
@@ -113,51 +119,28 @@ describe('RewardsCalculator', () => {
         expect(calculator.calculateTvlUsd(input)).toBe(expected);
     });
 
-    it('selects the deepest-liquidity pair on the active chain and caches repeated lookups', async () => {
+    it('uses GeckoTerminal first and caches repeated lookups by normalized address', async () => {
         const calculator = await loadRewardsCalculator();
         globalThis.fetch.mockResolvedValue({
             ok: true,
             json: vi.fn().mockResolvedValue({
-                pairs: [
-                    {
-                        chainId: 'bsc',
-                        baseToken: { address: '0xother' },
-                        quoteToken: { address: '0xabc' },
-                        priceUsd: '13.45',
-                        liquidity: { usd: 76300725.73 }
-                    },
-                    {
-                        chainId: 'ethereum',
-                        baseToken: { address: '0xabc' },
-                        quoteToken: { address: '0xusd' },
-                        priceUsd: '9.99',
-                        liquidity: { usd: 99999999 }
-                    },
-                    {
-                        chainId: 'bsc',
-                        baseToken: { address: '0xabc' },
-                        quoteToken: { address: '0xusd' },
-                        priceUsd: '3.11',
-                        liquidity: { usd: 1205785.98 }
-                    },
-                    {
-                        chainId: 'bsc',
-                        baseToken: { address: '0xABC' },
-                        quoteToken: { address: '0xusd' },
-                        priceUsd: '1.00042',
-                        liquidity: { usd: 44962438.69 }
+                data: {
+                    attributes: {
+                        token_prices: {
+                            '0xabc': '1.23'
+                        }
                     }
-                ]
+                }
             })
         });
 
         const first = await calculator.fetchTokenPriceByAddress('0xABC');
         const second = await calculator.fetchTokenPriceByAddress('0xabc');
 
-        expect(first).toBe(1.00042);
-        expect(second).toBe(1.00042);
+        expect(first).toBe(1.23);
+        expect(second).toBe(1.23);
         expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-        expect(globalThis.fetch).toHaveBeenCalledWith('https://api.dexscreener.com/latest/dex/tokens/0xabc');
+        expect(globalThis.fetch).toHaveBeenCalledWith('https://api.geckoterminal.com/api/v2/simple/networks/bsc/token_price/0xabc');
     });
 
     it('scopes cached token prices to the active chain', async () => {
@@ -167,29 +150,25 @@ describe('RewardsCalculator', () => {
             .mockResolvedValueOnce({
                 ok: true,
                 json: vi.fn().mockResolvedValue({
-                    pairs: [
-                        {
-                            chainId: 'bsc',
-                            baseToken: { address: '0xabc' },
-                            quoteToken: { address: '0xusd' },
-                            priceUsd: '1.11',
-                            liquidity: { usd: 1000 }
+                    data: {
+                        attributes: {
+                            token_prices: {
+                                '0xabc': '1.11'
+                            }
                         }
-                    ]
+                    }
                 })
             })
             .mockResolvedValueOnce({
                 ok: true,
                 json: vi.fn().mockResolvedValue({
-                    pairs: [
-                        {
-                            chainId: 'polygon',
-                            baseToken: { address: '0xabc' },
-                            quoteToken: { address: '0xusd' },
-                            priceUsd: '2.22',
-                            liquidity: { usd: 2000 }
+                    data: {
+                        attributes: {
+                            token_prices: {
+                                '0xabc': '2.22'
+                            }
                         }
-                    ]
+                    }
                 })
             });
 
@@ -209,6 +188,41 @@ describe('RewardsCalculator', () => {
         expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 
+    it('falls back to DexScreener when GeckoTerminal cannot price the token', async () => {
+        const calculator = await loadRewardsCalculator();
+
+        globalThis.fetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: vi.fn().mockResolvedValue({
+                    data: {
+                        attributes: {
+                            token_prices: {}
+                        }
+                    }
+                })
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: vi.fn().mockResolvedValue({
+                    pairs: [
+                        {
+                            chainId: 'bsc',
+                            baseToken: { address: '0xabc' },
+                            quoteToken: { address: '0xusd' },
+                            priceUsd: '1.00042',
+                            liquidity: { usd: 44962438.69 }
+                        }
+                    ]
+                })
+            });
+
+        expect(await calculator.fetchTokenPriceByAddress('0xabc')).toBe(1.00042);
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+        expect(globalThis.fetch).toHaveBeenNthCalledWith(1, 'https://api.geckoterminal.com/api/v2/simple/networks/bsc/token_price/0xabc');
+        expect(globalThis.fetch).toHaveBeenNthCalledWith(2, 'https://api.dexscreener.com/latest/dex/tokens/0xabc');
+    });
+
     it('returns zero and does not cache failed or zero-priced lookups', async () => {
         const calculator = await loadRewardsCalculator();
 
@@ -226,6 +240,32 @@ describe('RewardsCalculator', () => {
             .mockResolvedValueOnce({
                 ok: true,
                 json: vi.fn().mockResolvedValue({
+                    data: {
+                        attributes: {
+                            token_prices: {}
+                        }
+                    }
+                })
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: vi.fn().mockResolvedValue({
+                    pairs: [{ chainId: 'bsc', baseToken: { address: '0xzero' }, quoteToken: { address: '0xusd' }, priceUsd: '0' }]
+                })
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: vi.fn().mockResolvedValue({
+                    data: {
+                        attributes: {
+                            token_prices: {}
+                        }
+                    }
+                })
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: vi.fn().mockResolvedValue({
                     pairs: [{ chainId: 'bsc', baseToken: { address: '0xzero' }, quoteToken: { address: '0xusd' }, priceUsd: '0' }]
                 })
             });
@@ -235,7 +275,7 @@ describe('RewardsCalculator', () => {
         expect(await calculator.fetchTokenPriceByAddress('0xzero')).toBe(0);
         expect(await calculator.fetchTokenPriceByAddress('')).toBe(0);
 
-        expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+        expect(globalThis.fetch).toHaveBeenCalledTimes(6);
         expect(console.warn).toHaveBeenCalledTimes(1);
     });
 

--- a/tests/token-price-providers.test.js
+++ b/tests/token-price-providers.test.js
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function loadPriceProviders() {
+    vi.resetModules();
+    globalThis.window = globalThis;
+    globalThis.global = globalThis;
+    delete globalThis.GeckoTerminalPriceProvider;
+    delete globalThis.DexScreenerPriceProvider;
+
+    await import('../js/utils/pricing/gecko-terminal-price-provider.js');
+    await import('../js/utils/pricing/dex-screener-price-provider.js');
+
+    return {
+        GeckoTerminalPriceProvider: globalThis.GeckoTerminalPriceProvider,
+        DexScreenerPriceProvider: globalThis.DexScreenerPriceProvider
+    };
+}
+
+describe('Token price providers', () => {
+    beforeEach(() => {
+        globalThis.fetch = vi.fn();
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete globalThis.fetch;
+        delete globalThis.GeckoTerminalPriceProvider;
+        delete globalThis.DexScreenerPriceProvider;
+        delete globalThis.window;
+    });
+
+    it('GeckoTerminalPriceProvider fetches a chain-specific token price by address', async () => {
+        const { GeckoTerminalPriceProvider } = await loadPriceProviders();
+        const provider = new GeckoTerminalPriceProvider();
+
+        globalThis.fetch.mockResolvedValue({
+            ok: true,
+            json: vi.fn().mockResolvedValue({
+                data: {
+                    attributes: {
+                        token_prices: {
+                            '0xAbC': '0.9876'
+                        }
+                    }
+                }
+            })
+        });
+
+        expect(await provider.fetchTokenPrice('0xabc', { chainId: 56 })).toBe(0.9876);
+        expect(globalThis.fetch).toHaveBeenCalledWith('https://api.geckoterminal.com/api/v2/simple/networks/bsc/token_price/0xabc');
+    });
+
+    it('GeckoTerminalPriceProvider returns zero for unsupported pricing networks', async () => {
+        const { GeckoTerminalPriceProvider } = await loadPriceProviders();
+        const provider = new GeckoTerminalPriceProvider();
+
+        expect(await provider.fetchTokenPrice('0xabc', { chainId: 80002 })).toBe(0);
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('DexScreenerPriceProvider selects the deepest-liquidity same-chain base-token pair', async () => {
+        const { DexScreenerPriceProvider } = await loadPriceProviders();
+        const provider = new DexScreenerPriceProvider();
+
+        globalThis.fetch.mockResolvedValue({
+            ok: true,
+            json: vi.fn().mockResolvedValue({
+                pairs: [
+                    {
+                        chainId: 'bsc',
+                        baseToken: { address: '0xother' },
+                        quoteToken: { address: '0xabc' },
+                        priceUsd: '13.45',
+                        liquidity: { usd: 76300725.73 }
+                    },
+                    {
+                        chainId: 'ethereum',
+                        baseToken: { address: '0xabc' },
+                        quoteToken: { address: '0xusd' },
+                        priceUsd: '9.99',
+                        liquidity: { usd: 99999999 }
+                    },
+                    {
+                        chainId: 'bsc',
+                        baseToken: { address: '0xabc' },
+                        quoteToken: { address: '0xusd' },
+                        priceUsd: '3.11',
+                        liquidity: { usd: 1205785.98 }
+                    },
+                    {
+                        chainId: 'bsc',
+                        baseToken: { address: '0xABC' },
+                        quoteToken: { address: '0xusd' },
+                        priceUsd: '1.00042',
+                        liquidity: { usd: 44962438.69 }
+                    }
+                ]
+            })
+        });
+
+        expect(await provider.fetchTokenPrice('0xabc', { chainId: 56 })).toBe(1.00042);
+        expect(globalThis.fetch).toHaveBeenCalledWith('https://api.dexscreener.com/latest/dex/tokens/0xabc');
+    });
+
+    it('DexScreenerPriceProvider returns zero when only cross-chain or quote-side matches exist', async () => {
+        const { DexScreenerPriceProvider } = await loadPriceProviders();
+        const provider = new DexScreenerPriceProvider();
+
+        globalThis.fetch.mockResolvedValue({
+            ok: true,
+            json: vi.fn().mockResolvedValue({
+                pairs: [
+                    {
+                        chainId: 'polygon',
+                        baseToken: { address: '0xabc' },
+                        quoteToken: { address: '0xusd' },
+                        priceUsd: '2.22',
+                        liquidity: { usd: 99999 }
+                    },
+                    {
+                        chainId: 'bsc',
+                        baseToken: { address: '0xother' },
+                        quoteToken: { address: '0xabc' },
+                        priceUsd: '7.77',
+                        liquidity: { usd: 99999 }
+                    }
+                ]
+            })
+        });
+
+        expect(await provider.fetchTokenPrice('0xabc', { chainId: 56 })).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary
- split token pricing into modular GeckoTerminal and DexScreener provider files
- make GeckoTerminal the primary source and DexScreener the ordered fallback inside RewardsCalculator
- keep token price caching in RewardsCalculator while scoping cache entries by chain
- add coverage for provider-specific parsing, fallback order, unsupported networks, and chain-scoped caching

## Fallback Behavior
- provider order is `GeckoTerminalPriceProvider` then `DexScreenerPriceProvider`
- fallback happens when the current provider returns no positive USD price or throws
- GeckoTerminal is skipped on unsupported networks because it cannot resolve a valid network id there
- DexScreener only accepts same-chain pairs where the queried token is the base token, then picks the deepest-liquidity match

## Testing
- `npm test`
- `node --check js/utils/pricing/gecko-terminal-price-provider.js`
- `node --check js/utils/pricing/dex-screener-price-provider.js`
- `node --check js/utils/rewards-calculator.js`

## Test Coverage
- GeckoTerminal primary-source success path
- GeckoTerminal to DexScreener fallback path
- unsupported-network short-circuit behavior
- chain-scoped cache behavior
- DexScreener same-chain liquidity selection
- DexScreener rejection of quote-side and cross-chain matches