### PR TITLE
Fix projected stake APR estimate

### DIFF
--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -222,6 +222,7 @@ class StakingModalNew {
                 }
                 this.stakeAmount = sanitizedValue;
                 this.updateSlider('stake');
+                this.updateStakeEstimatedAPR();
 
                 // Reset approval state when amount changes
                 this.isApproved = false;
@@ -889,6 +890,7 @@ class StakingModalNew {
                     stakeInput.value = sanitizedValue;
                 }
                 this.stakeAmount = sanitizedValue;
+                this.updateStakeEstimatedAPR();
                 this.updateButtonStates();
             });
         }
@@ -953,7 +955,7 @@ class StakingModalNew {
 
             <div class="balance-info">
                 <span class="balance-label">Estimated APR:</span>
-                <span class="balance-value success-text">${this.currentPair?.apr || '0.00'}%</span>
+                <span id="stake-estimated-apr" class="balance-value success-text">${this.getStakeEstimatedAPRDisplay()}%</span>
             </div>
 
             <div class="modal-actions">
@@ -964,6 +966,35 @@ class StakingModalNew {
                 </button>
             </div>
         `;
+    }
+
+    calculateEstimatedStakeAPR() {
+        if (window.rewardsCalculator?.calcProjectedAPR) {
+            return window.rewardsCalculator.calcProjectedAPR({
+                hourlyRate: window.homePage?.hourlyRewardRate ?? this.currentPair?.hourlyRewardRate,
+                currentTvlLpTokens: this.currentPair?.tvl ?? this.currentPair?.totalStaked,
+                addedLpTokens: this.stakeAmount,
+                libPerLp: this.currentPair?.libPerLp,
+                poolWeight: this.currentPair?.weight,
+                totalWeight: window.homePage?.totalWeight ?? this.currentPair?.totalWeight,
+                fallbackApr: this.currentPair?.apr
+            });
+        }
+
+        const fallbackApr = Number(this.currentPair?.apr);
+        return Number.isFinite(fallbackApr) ? fallbackApr : 0;
+    }
+
+    getStakeEstimatedAPRDisplay() {
+        const apr = this.calculateEstimatedStakeAPR();
+        return Number.isFinite(apr) ? apr.toFixed(1) : '0.0';
+    }
+
+    updateStakeEstimatedAPR() {
+        const aprElement = document.getElementById('stake-estimated-apr');
+        if (aprElement) {
+            aprElement.textContent = `${this.getStakeEstimatedAPRDisplay()}%`;
+        }
     }
 
     renderUnstakeTab() {
@@ -1085,6 +1116,7 @@ class StakingModalNew {
             this.needsApproval = false;
 
             // Update button states
+            this.updateStakeEstimatedAPR();
             this.updateButtonStates();
         } else if (this.currentTab === 'unstake') {
             this.unstakeAmount = amount;
@@ -1132,10 +1164,13 @@ class StakingModalNew {
             this.stakeAmount = amount;
             const input = document.getElementById('stake-amount-input');
             if (input) input.value = amount;
+            this.updateStakeEstimatedAPR();
+            this.updateButtonStates();
         } else if (type === 'unstake') {
             this.unstakeAmount = amount;
             const input = document.getElementById('unstake-amount-input');
             if (input) input.value = amount;
+            this.updateButtonStates();
         }
     }
 

--- a/js/utils/rewards-calculator.js
+++ b/js/utils/rewards-calculator.js
@@ -78,6 +78,47 @@
             return (annualRewards / (tvlLpTokens * libPerLp)) * 100;
         }
 
+        calcProjectedAPR({
+            hourlyRate = 0,
+            currentTvlLpTokens = 0,
+            addedLpTokens = 0,
+            libPerLp = 0,
+            poolWeight = 1,
+            totalWeight = 1,
+            fallbackApr = 0
+        }) {
+            const currentApr = this.parseAmount(fallbackApr);
+            const currentTvl = this.parseAmount(currentTvlLpTokens);
+            const addedTvl = this.parseAmount(addedLpTokens);
+
+            if (addedTvl <= 0) {
+                return currentApr;
+            }
+
+            const projectedTvl = currentTvl + addedTvl;
+            if (projectedTvl <= 0) {
+                return currentApr;
+            }
+
+            const projectedApr = this.calcAPR(
+                this.parseAmount(hourlyRate),
+                projectedTvl,
+                this.parseAmount(libPerLp),
+                this.parseAmount(poolWeight),
+                this.parseAmount(totalWeight)
+            );
+
+            if (projectedApr > 0) {
+                return projectedApr;
+            }
+
+            if (currentApr > 0 && currentTvl > 0) {
+                return currentApr * (currentTvl / projectedTvl);
+            }
+
+            return currentApr;
+        }
+
         normalizeAddress(address) {
             return typeof address === 'string' ? address.toLowerCase() : null;
         }

--- a/tests/rewards-calculator.test.js
+++ b/tests/rewards-calculator.test.js
@@ -80,6 +80,30 @@ describe('RewardsCalculator', () => {
         expect(calculator.calcAPR(hourlyRate, tvlLpTokens, libPerLp, poolWeight, totalWeight)).toBeCloseTo(expected);
     });
 
+    it('calculates projected APR with newly added LP tokens included in TVL', async () => {
+        const calculator = await loadRewardsCalculator();
+
+        expect(calculator.calcProjectedAPR({
+            hourlyRate: 0.01,
+            currentTvlLpTokens: 10,
+            addedLpTokens: 5,
+            libPerLp: 10,
+            poolWeight: 70,
+            totalWeight: 100,
+            fallbackApr: 61.32
+        })).toBeCloseTo(40.88);
+    });
+
+    it('falls back by scaling current APR when projected APR inputs are incomplete', async () => {
+        const calculator = await loadRewardsCalculator();
+
+        expect(calculator.calcProjectedAPR({
+            currentTvlLpTokens: 10,
+            addedLpTokens: 5,
+            fallbackApr: 60
+        })).toBeCloseTo(40);
+    });
+
     it.each([
         {
             input: {


### PR DESCRIPTION
## Summary

Fixes the stake modal APR estimate so it includes the LP amount the user is about to stake instead of displaying the already-loaded current pool APR unchanged.

## Root Cause

The stake modal rendered `currentPair.apr` directly for the "Estimated APR" value. That value was calculated from the current pool TVL, so typing a stake amount did not affect the displayed estimate.

## Changes

- Added `RewardsCalculator.calcProjectedAPR(...)` to reuse the existing APR formula with projected TVL.
- Updated the stake modal to pass the entered LP amount into the projected APR helper and refresh the displayed estimate while typing, using percentage buttons, or moving the slider.
- Added unit coverage for projected APR and fallback scaling when full APR inputs are unavailable.
