### PR TITLE
Make staking cards mobile friendly

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -44,6 +44,11 @@ body {
     padding: var(--spacing-6) var(--spacing-3);
 }
 
+.main-content > .container-xl {
+    width: 100%;
+    max-width: 1180px;
+}
+
 /* Page title */
 .page-title {
     text-align: center;
@@ -89,6 +94,8 @@ body {
 /* Table container */
 .table-container {
     width: 100%;
+    max-width: 960px;
+    margin: 0 auto;
     background: var(--background-paper);
     border-radius: 12px;
     box-shadow: var(--shadow-4);
@@ -127,6 +134,18 @@ body {
 
 .table tbody tr:last-child td {
     border-bottom: none;
+}
+
+.staking-cell {
+    vertical-align: middle;
+}
+
+.pair-link-stack {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+    min-width: 0;
 }
 
 /* Button styles matching MUI */
@@ -321,7 +340,7 @@ body {
     }
 
     .page-title-header {
-        flex-direction: column;
+        flex-direction: row;
         gap: var(--spacing-1);
     }
 
@@ -329,6 +348,167 @@ body {
     .table td {
         padding: 12px 8px;
         font-size: 14px;
+    }
+
+    .staking-table-container {
+        width: 100%;
+        max-width: 100%;
+        margin: 0;
+        overflow: visible;
+        background: transparent;
+        border-radius: 0;
+        box-shadow: none;
+    }
+
+    .staking-pairs-table {
+        width: 100%;
+        max-width: 100%;
+        min-width: 0;
+        border-collapse: separate;
+        border-spacing: 0;
+        table-layout: auto;
+    }
+
+    .staking-pairs-table thead {
+        display: none;
+    }
+
+    .staking-pairs-table,
+    .staking-pairs-table tbody,
+    .staking-pairs-table tr,
+    .staking-pairs-table td {
+        display: block;
+        width: 100%;
+    }
+
+    .staking-pairs-table tbody {
+        display: grid;
+        width: 100%;
+        max-width: 100%;
+        gap: 12px;
+        justify-items: stretch;
+    }
+
+    .staking-pairs-table tbody tr.pair-row,
+    .staking-pairs-table tbody tr.staking-skeleton-row {
+        display: grid;
+        width: 100%;
+        max-width: 100%;
+        justify-self: stretch;
+        box-sizing: border-box;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-areas:
+            "pair pair"
+            "apr weight"
+            "tvl tvl"
+            "share reward";
+        gap: 10px;
+        align-items: stretch;
+        padding: 12px;
+        border: 1px solid var(--divider);
+        border-radius: var(--border-radius-lg);
+        background: var(--background-paper);
+        box-shadow: var(--shadow-4);
+    }
+
+    .staking-pairs-table tbody tr.pair-row:hover {
+        background: var(--background-paper);
+    }
+
+    .staking-pairs-table td.staking-cell {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: flex-start;
+        gap: 6px;
+        width: auto;
+        min-width: 0;
+        min-height: 74px;
+        padding: 10px;
+        border: 1px solid var(--divider);
+        border-radius: var(--border-radius-lg);
+        background: var(--background-elevated);
+        white-space: normal;
+        overflow: visible;
+        text-overflow: clip;
+        font-size: 14px;
+    }
+
+    .staking-pairs-table td.staking-cell::before {
+        content: attr(data-label);
+        display: block;
+        flex: 0 0 auto;
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0;
+        color: var(--text-secondary);
+        line-height: 1.35;
+    }
+
+    .staking-pairs-table td.staking-cell > * {
+        min-width: 0;
+        max-width: 100%;
+    }
+
+    .staking-pairs-table td.staking-cell--pair {
+        grid-area: pair;
+    }
+
+    .staking-pairs-table td.staking-cell--apr {
+        grid-area: apr;
+    }
+
+    .staking-pairs-table td.staking-cell--weight {
+        grid-area: weight;
+    }
+
+    .staking-pairs-table td.staking-cell--tvl {
+        grid-area: tvl;
+    }
+
+    .staking-pairs-table td.staking-cell--share {
+        grid-area: share;
+    }
+
+    .staking-pairs-table td.staking-cell--reward {
+        grid-area: reward;
+    }
+
+    .staking-pairs-table td.staking-cell--share,
+    .staking-pairs-table td.staking-cell--reward {
+        min-height: 88px;
+    }
+
+    .staking-pairs-table .btn-share,
+    .staking-pairs-table .btn-earnings {
+        width: 100%;
+        min-width: 0 !important;
+        min-height: 44px;
+        padding: 10px 12px;
+        white-space: normal;
+    }
+
+    .staking-pairs-table .pair-link-stack,
+    .staking-pairs-table .platform-link {
+        max-width: 100%;
+    }
+
+    .staking-pairs-table .skeleton {
+        max-width: 100%;
+    }
+
+    .staking-pairs-table tbody tr.staking-empty-row {
+        display: block;
+        border: 1px solid var(--divider);
+        border-radius: var(--border-radius-lg);
+        background: var(--background-paper);
+        box-shadow: var(--shadow-4);
+    }
+
+    .staking-pairs-table td.staking-empty-cell {
+        display: block;
+        width: 100%;
+        border: none;
     }
 
     .footer-content {
@@ -361,21 +541,37 @@ body {
     }
 
     .page-title-header {
-        flex-direction: column;
+        flex-direction: row;
         align-items: center;
         gap: 8px;
     }
 
-    .table-container {
-        overflow-x: auto;
+    .staking-pairs-table td.staking-cell {
+        min-height: 0;
+        padding: 10px;
     }
 
-    .table {
-        min-width: 600px;
+    .staking-pairs-table td.staking-cell--share,
+    .staking-pairs-table td.staking-cell--reward {
+        min-height: 0;
     }
 }
 
 @media (max-width: 320px) {
+    .staking-pairs-table tbody tr.pair-row,
+    .staking-pairs-table tbody tr.staking-skeleton-row {
+        grid-template-columns: 1fr;
+        grid-template-areas:
+            "pair"
+            "apr"
+            "weight"
+            "tvl"
+            "share"
+            "reward";
+        gap: 8px;
+        padding: 10px;
+    }
+
     .page-title h1 {
         font-size: 1.5rem;
         line-height: 1.3;

--- a/css/home.css
+++ b/css/home.css
@@ -373,7 +373,15 @@ body {
     }
 
     .staking-pairs-table thead {
-        display: none;
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
     }
 
     .staking-pairs-table,

--- a/css/home.css
+++ b/css/home.css
@@ -409,10 +409,10 @@ body {
         box-sizing: border-box;
         grid-template-columns: repeat(2, minmax(0, 1fr));
         grid-template-areas:
-            "pair pair"
+            "pair tvl"
             "apr weight"
-            "tvl tvl"
-            "share reward";
+            "share share"
+            "reward reward";
         gap: 10px;
         align-items: stretch;
         padding: 12px;
@@ -574,9 +574,9 @@ body {
         grid-template-columns: 1fr;
         grid-template-areas:
             "pair"
+            "tvl"
             "apr"
             "weight"
-            "tvl"
             "share"
             "reward";
         gap: 8px;

--- a/css/home.css
+++ b/css/home.css
@@ -94,12 +94,15 @@ body {
 /* Table container */
 .table-container {
     width: 100%;
-    max-width: 960px;
-    margin: 0 auto;
     background: var(--background-paper);
     border-radius: 12px;
     box-shadow: var(--shadow-4);
     overflow: hidden;
+}
+
+.staking-table-container {
+    max-width: 960px;
+    margin: 0 auto;
 }
 
 .table {
@@ -140,7 +143,7 @@ body {
     vertical-align: middle;
 }
 
-.pair-link-stack {
+.staking-pairs-table .pair-link-stack {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
@@ -415,7 +418,7 @@ body {
         background: var(--background-paper);
     }
 
-    .staking-pairs-table td.staking-cell {
+    .staking-pairs-table .staking-cell {
         display: flex;
         flex-direction: column;
         align-items: flex-start;
@@ -434,7 +437,7 @@ body {
         font-size: 14px;
     }
 
-    .staking-pairs-table td.staking-cell::before {
+    .staking-pairs-table .staking-cell::before {
         content: attr(data-label);
         display: block;
         flex: 0 0 auto;
@@ -445,37 +448,37 @@ body {
         line-height: 1.35;
     }
 
-    .staking-pairs-table td.staking-cell > * {
+    .staking-pairs-table .staking-cell > * {
         min-width: 0;
         max-width: 100%;
     }
 
-    .staking-pairs-table td.staking-cell--pair {
+    .staking-pairs-table .staking-cell--pair {
         grid-area: pair;
     }
 
-    .staking-pairs-table td.staking-cell--apr {
+    .staking-pairs-table .staking-cell--apr {
         grid-area: apr;
     }
 
-    .staking-pairs-table td.staking-cell--weight {
+    .staking-pairs-table .staking-cell--weight {
         grid-area: weight;
     }
 
-    .staking-pairs-table td.staking-cell--tvl {
+    .staking-pairs-table .staking-cell--tvl {
         grid-area: tvl;
     }
 
-    .staking-pairs-table td.staking-cell--share {
+    .staking-pairs-table .staking-cell--share {
         grid-area: share;
     }
 
-    .staking-pairs-table td.staking-cell--reward {
+    .staking-pairs-table .staking-cell--reward {
         grid-area: reward;
     }
 
-    .staking-pairs-table td.staking-cell--share,
-    .staking-pairs-table td.staking-cell--reward {
+    .staking-pairs-table .staking-cell--share,
+    .staking-pairs-table .staking-cell--reward {
         min-height: 88px;
     }
 
@@ -546,13 +549,13 @@ body {
         gap: 8px;
     }
 
-    .staking-pairs-table td.staking-cell {
+    .staking-pairs-table .staking-cell {
         min-height: 0;
         padding: 10px;
     }
 
-    .staking-pairs-table td.staking-cell--share,
-    .staking-pairs-table td.staking-cell--reward {
+    .staking-pairs-table .staking-cell--share,
+    .staking-pairs-table .staking-cell--reward {
         min-height: 0;
     }
 }

--- a/css/shared-header.css
+++ b/css/shared-header.css
@@ -180,9 +180,38 @@
 }
 
 @media (max-width: 768px) {
+    .header {
+        height: auto;
+    }
+
+    .header-toolbar {
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .logo-section {
+        min-width: 0;
+    }
+
     .nav-section {
+        flex: 1 1 100%;
+        min-width: 0;
         width: 100%;
-        justify-content: space-between;
+        justify-content: flex-end;
+        flex-wrap: wrap;
+    }
+
+    .connect-wallet-btn {
+        min-width: 0;
+        max-width: 100%;
+    }
+
+    .connect-wallet-btn .wallet-status-text,
+    .connect-wallet-btn .wallet-address-text {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 }
 
@@ -205,6 +234,7 @@
     }
 
     .connect-wallet-btn {
+        flex: 1 1 160px;
         padding: 8px 12px;
         font-size: 13px;
     }

--- a/index.html
+++ b/index.html
@@ -83,8 +83,8 @@
 
             <div id="content-container" class="animate-fade-in">
                 <!-- Skeleton table shown immediately on page load -->
-                <div class="table-container">
-                    <table class="table">
+                <div class="table-container staking-table-container">
+                    <table class="table staking-pairs-table">
                         <thead>
                             <tr>
                                 <th><span class="material-icons">swap_horiz</span> Pair</th>
@@ -96,29 +96,29 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <tr>
-                                <td><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 60px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 100px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
+                            <tr class="staking-skeleton-row">
+                                <td class="staking-cell staking-cell--pair" data-label="Pair"><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
+                                <td class="staking-cell staking-cell--apr" data-label="APR"><div class="skeleton" style="height: 20px; width: 60px;"></div></td>
+                                <td class="staking-cell staking-cell--weight" data-label="Weight"><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
+                                <td class="staking-cell staking-cell--tvl" data-label="TVL"><div class="skeleton" style="height: 20px; width: 100px;"></div></td>
+                                <td class="staking-cell staking-cell--share" data-label="My Share"><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
+                                <td class="staking-cell staking-cell--reward" data-label="My Reward"><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
                             </tr>
-                            <tr>
-                                <td><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 60px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 100px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
+                            <tr class="staking-skeleton-row">
+                                <td class="staking-cell staking-cell--pair" data-label="Pair"><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
+                                <td class="staking-cell staking-cell--apr" data-label="APR"><div class="skeleton" style="height: 20px; width: 60px;"></div></td>
+                                <td class="staking-cell staking-cell--weight" data-label="Weight"><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
+                                <td class="staking-cell staking-cell--tvl" data-label="TVL"><div class="skeleton" style="height: 20px; width: 100px;"></div></td>
+                                <td class="staking-cell staking-cell--share" data-label="My Share"><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
+                                <td class="staking-cell staking-cell--reward" data-label="My Reward"><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
                             </tr>
-                            <tr>
-                                <td><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 60px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 100px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
+                            <tr class="staking-skeleton-row">
+                                <td class="staking-cell staking-cell--pair" data-label="Pair"><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
+                                <td class="staking-cell staking-cell--apr" data-label="APR"><div class="skeleton" style="height: 20px; width: 60px;"></div></td>
+                                <td class="staking-cell staking-cell--weight" data-label="Weight"><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
+                                <td class="staking-cell staking-cell--tvl" data-label="TVL"><div class="skeleton" style="height: 20px; width: 100px;"></div></td>
+                                <td class="staking-cell staking-cell--share" data-label="My Share"><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
+                                <td class="staking-cell staking-cell--reward" data-label="My Reward"><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
                             </tr>
                         </tbody>
                     </table>

--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -227,8 +227,8 @@ class HomePage {
 
     renderSkeleton() {
         return `
-            <div class="table-container">
-                <table class="table">
+            <div class="table-container staking-table-container">
+                <table class="table staking-pairs-table">
                     <thead>
                         <tr>
                             <th>
@@ -259,13 +259,13 @@ class HomePage {
                     </thead>
                     <tbody>
                         ${Array(3).fill(0).map(() => `
-                            <tr>
-                                <td><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 60px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 100px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
-                                <td><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
+                            <tr class="staking-skeleton-row">
+                                <td class="staking-cell staking-cell--pair" data-label="Pair"><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
+                                <td class="staking-cell staking-cell--apr" data-label="APR"><div class="skeleton" style="height: 20px; width: 60px;"></div></td>
+                                <td class="staking-cell staking-cell--weight" data-label="Weight"><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
+                                <td class="staking-cell staking-cell--tvl" data-label="TVL"><div class="skeleton" style="height: 20px; width: 100px;"></div></td>
+                                <td class="staking-cell staking-cell--share" data-label="My Share"><div class="skeleton" style="height: 20px; width: 80px;"></div></td>
+                                <td class="staking-cell staking-cell--reward" data-label="My Reward"><div class="skeleton" style="height: 20px; width: 120px;"></div></td>
                             </tr>
                         `).join('')}
                     </tbody>
@@ -351,8 +351,8 @@ class HomePage {
 
             // Show "no data" row when there are no pairs to display (after filtering)
             tbodyContent = `
-                <tr>
-                    <td colspan="6" style="text-align: center; padding: 48px 24px; color: var(--text-secondary);">
+                <tr class="staking-empty-row">
+                    <td class="staking-empty-cell" colspan="6" style="text-align: center; padding: 48px 24px; color: var(--text-secondary);">
                         <div style="display: flex; flex-direction: column; align-items: center; gap: 16px;">
                             <span class="material-icons" style="font-size: 48px; color: var(--text-secondary); opacity: 0.5;">inbox</span>
                             <div>
@@ -379,8 +379,8 @@ class HomePage {
         }
 
         return `
-            <div class="table-container">
-                <table class="table">
+            <div class="table-container staking-table-container">
+                <table class="table staking-pairs-table">
                     <thead>
                         <tr>
                             <th>
@@ -450,24 +450,24 @@ class HomePage {
         
         return `
             <tr class="pair-row" data-pair-id="${pair.id}" style="cursor: pointer;">
-                <td>
+                <td class="staking-cell staking-cell--pair" data-label="Pair">
                     <div class="pair-link-stack">
                         ${pairNameHtml}
                         ${platformHtml}
                     </div>
                 </td>
-                <td>
+                <td class="staking-cell staking-cell--apr" data-label="APR">
                     <span style="color: var(--success-main); font-weight: bold;">${pair.apr || '0.00'}%</span>
                 </td>
-                <td>
+                <td class="staking-cell staking-cell--weight" data-label="Weight">
                     <span style="font-weight: 600;">
                         ${pair.weightPercentage || '0.00'}%
                     </span>
                 </td>
-                <td>
+                <td class="staking-cell staking-cell--tvl" data-label="TVL">
                     <span style="font-weight: 600;">${this.formatTvlDisplay(pair)}</span>
                 </td>
-                <td>
+                <td class="staking-cell staking-cell--share" data-label="My Share">
                     <button class="btn btn-primary btn-small btn-share"
                             data-pair-id="${pair.id}"
                             data-pair-address="${pair.address}"
@@ -479,7 +479,7 @@ class HomePage {
                         ${userShares}%
                     </button>
                 </td>
-                <td>
+                <td class="staking-cell staking-cell--reward" data-label="My Reward">
                     <button class="btn btn-secondary btn-small btn-earnings"
                             data-pair-id="${pair.id}"
                             data-pair-address="${pair.address}"

--- a/tests/home-page.test.js
+++ b/tests/home-page.test.js
@@ -62,3 +62,52 @@ describe('HomePage.formatTvlDisplay', () => {
         expect(formatNumber).toHaveBeenCalledWith(123.456);
     });
 });
+
+describe('HomePage.renderPairRow', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+        globalThis.window = globalThis;
+        globalThis.Formatter = {
+            formatPairName: vi.fn().mockReturnValue('<span class="pair-name-link">LIB/BNB</span>'),
+            getPlatformUrl: vi.fn().mockReturnValue('https://example.com/pool')
+        };
+        globalThis.networkManager = {
+            isOnRequiredNetwork: vi.fn().mockReturnValue(true)
+        };
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete globalThis.Formatter;
+        delete globalThis.networkManager;
+        delete globalThis.HomePage;
+        delete globalThis.window;
+    });
+
+    it('adds mobile card labels and cell classes to each staking row cell', async () => {
+        const homePagePrototype = await loadHomePage();
+        const output = homePagePrototype.renderPairRow.call(
+            {
+                isWalletConnected: () => true,
+                formatTvlDisplay: () => '$1.2K'
+            },
+            {
+                id: '1',
+                address: '0x123',
+                name: 'LIB/BNB',
+                platform: 'PancakeSwap',
+                apr: '12.3',
+                weightPercentage: '25.00',
+                userShares: '3.50',
+                userEarnings: '1.2345'
+            }
+        );
+
+        expect(output).toContain('class="staking-cell staking-cell--pair" data-label="Pair"');
+        expect(output).toContain('class="staking-cell staking-cell--apr" data-label="APR"');
+        expect(output).toContain('class="staking-cell staking-cell--weight" data-label="Weight"');
+        expect(output).toContain('class="staking-cell staking-cell--tvl" data-label="TVL"');
+        expect(output).toContain('class="staking-cell staking-cell--share" data-label="My Share"');
+        expect(output).toContain('class="staking-cell staking-cell--reward" data-label="My Reward"');
+    });
+});

--- a/tests/home-page.test.js
+++ b/tests/home-page.test.js
@@ -103,11 +103,15 @@ describe('HomePage.renderPairRow', () => {
             }
         );
 
-        expect(output).toContain('class="staking-cell staking-cell--pair" data-label="Pair"');
-        expect(output).toContain('class="staking-cell staking-cell--apr" data-label="APR"');
-        expect(output).toContain('class="staking-cell staking-cell--weight" data-label="Weight"');
-        expect(output).toContain('class="staking-cell staking-cell--tvl" data-label="TVL"');
-        expect(output).toContain('class="staking-cell staking-cell--share" data-label="My Share"');
-        expect(output).toContain('class="staking-cell staking-cell--reward" data-label="My Reward"');
+        [
+            ['pair', 'Pair'],
+            ['apr', 'APR'],
+            ['weight', 'Weight'],
+            ['tvl', 'TVL'],
+            ['share', 'My Share'],
+            ['reward', 'My Reward']
+        ].forEach(([cell, label]) => {
+            expect(output).toContain(`class="staking-cell staking-cell--${cell}" data-label="${label}"`);
+        });
     });
 });


### PR DESCRIPTION
## What Changed

This PR makes the LP staking table usable as labeled cards on mobile while preserving the desktop table layout.

- `staking-pairs-table` now switches to a card-style grid below tablet width, with labeled cells for Pair, APR, Weight, TVL, My Share, and My Reward.
- `renderSkeleton`, `renderPairRow`, and the initial `index.html` skeleton now emit the same staking cell classes and `data-label` attributes so loading and loaded states share the responsive layout.
- The empty staking state gets mobile-safe table/card classes, and staking action buttons expand within their card cells.
- `shared-header` now allows the header controls to wrap on small screens and truncates wallet text to avoid mobile overflow.
- `HomePage.renderPairRow` test coverage verifies the mobile card classes and labels are present.

## Fixed Flow

1. A user opens the staking page on a mobile viewport.
2. The initial skeleton, loading skeleton, empty state, or loaded staking rows render inside the same responsive staking table structure.
3. Mobile CSS hides the table header visually and uses each cell's `data-label` as the card label.
4. The staking data and action buttons remain readable without relying on horizontal table scrolling.

## Why

The previous mobile layout kept the staking table as a wide desktop-style table, including a `600px` minimum width at small breakpoints. That made core staking information hard to scan on phones. The new structure keeps the semantic table source of truth while giving mobile users a labeled card layout that matches the same data flow as desktop.

## Validation

- `npm test -- --run tests/home-page.test.js`
- `git diff --check fa700913f18104bc35869b681ce9ac70c7884c78`

Closes #221

<img width="382" height="493" alt="image" src="https://github.com/user-attachments/assets/01bb22e3-e175-44fb-aaa0-8ec9c9b85f54" />
