### PR TITLE
Refine mobile header and footer layout

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -49,7 +49,7 @@
                 </a>
 
                 <nav class="nav-section" role="navigation" aria-label="Main navigation">
-                    <a href="../" id="admin-panel-link" class="nav-button">
+                    <a href="../" id="admin-panel-link" class="nav-button" aria-label="Home">
                         <span class="material-icons" aria-hidden="true">home</span>
                         <span>Home</span>
                     </a>

--- a/admin/index.html
+++ b/admin/index.html
@@ -60,6 +60,7 @@
 
                     <button id="connect-wallet-btn"
                             class="connect-wallet-btn"
+                            aria-label="Connect wallet"
                             aria-describedby="wallet-status"
                             aria-live="polite"
                             aria-busy="true"

--- a/css/home.css
+++ b/css/home.css
@@ -325,9 +325,11 @@ body {
     }
 
     .version-badge {
-        font-size: 10px;
-        margin-left: 8px;
-        padding: 2px 6px;
+        font-size: 9px;
+        margin-left: 0;
+        padding: 1px 5px;
+        border-radius: 8px;
+        line-height: 1.4;
     }
 
     .nav-section {
@@ -523,12 +525,21 @@ body {
     }
 
     .footer-content {
-        flex-direction: column;
+        flex-direction: row;
         text-align: center;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: nowrap;
     }
 
     .footer-actions {
-        width: 100%;
+        width: auto;
+    }
+
+    .footer-link-anchor {
+        height: 36px;
+        min-height: 36px;
+        padding: 0 12px;
     }
 
     .main-content {
@@ -545,6 +556,89 @@ body {
 
     .main-content {
         padding: var(--spacing-3) var(--spacing-2);
+    }
+
+    .footer {
+        padding: 10px 0;
+    }
+
+    .footer-content {
+        gap: 8px;
+        text-align: left;
+    }
+
+    .footer-text {
+        flex: 0 0 auto;
+        width: auto;
+        min-width: 0;
+        line-height: 1.2;
+        letter-spacing: 0;
+        white-space: nowrap;
+        font-size: 12px;
+    }
+
+    .footer-actions {
+        flex: 0 0 auto;
+        display: flex;
+        flex-wrap: nowrap;
+        gap: 4px;
+    }
+
+    .footer-link-anchor {
+        display: inline-flex;
+        align-items: center;
+        width: 30px;
+        height: 30px;
+        min-height: 30px;
+        justify-content: center;
+        padding: 0;
+        gap: 0;
+        white-space: nowrap;
+    }
+
+    .footer-link-icon {
+        display: block;
+        width: 18px;
+        height: 18px;
+        object-fit: contain;
+    }
+
+    .footer-link-action span {
+        display: none;
+    }
+
+    #staking-contract-link {
+        font-size: 0;
+    }
+
+    #staking-contract-link::before {
+        content: "description";
+        display: block;
+        font-family: "Material Icons";
+        font-size: 17px;
+        line-height: 17px;
+        width: 17px;
+        height: 17px;
+        text-align: center;
+    }
+
+    .social-links {
+        flex: 0 0 auto;
+        width: auto;
+        justify-content: flex-end;
+        gap: 4px;
+    }
+
+    .social-link {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 30px;
+        height: 30px;
+    }
+
+    .social-link .material-icons {
+        font-size: 20px;
     }
 
     .page-title {

--- a/css/network-indicator-selector.css
+++ b/css/network-indicator-selector.css
@@ -133,28 +133,56 @@ html[data-theme="light"] .network-indicator-home {
 /* Mobile responsive */
 @media (max-width: 768px) {
     .network-selector {
-        margin-left: 6px;
+        width: clamp(132px, 28vw, 150px);
+        min-width: 0;
+        margin-left: 0;
+    }
+
+    .network-selector-container,
+    .network-select-wrapper {
+        width: 100%;
+        height: 40px;
+        min-width: 0;
     }
     
     .network-select {
-        height: 34px !important;
-        line-height: 34px !important;
+        width: 100%;
+        height: 40px !important;
+        line-height: 40px !important;
         font-size: 12px !important;
-        padding: 0 40px 0 12px !important;
-        min-width: 130px;
+        padding: 0 28px 0 10px !important;
+        min-width: 0;
+    }
+
+    .network-indicator-home {
+        height: 40px;
+        min-height: 40px;
+        max-width: none;
+        padding: 0 6px 0 8px;
+        gap: 6px;
     }
 }
 
 @media (max-width: 480px) {
     .network-selector {
-        margin-left: 4px;
+        width: clamp(100px, 30vw, 112px);
     }
     
     .network-select {
-        height: 32px !important;
-        line-height: 32px !important;
         font-size: 11px !important;
-        padding: 0 36px 0 10px !important;
-        min-width: 110px;
+        padding: 0 22px 0 8px !important;
+    }
+
+    .network-indicator-home {
+        flex: 0 1 auto;
+        width: auto;
+        padding: 0 4px;
+        gap: 4px;
+    }
+}
+
+@media (max-width: 360px) {
+    .network-selector {
+        width: 100px;
     }
 }

--- a/css/shared-header.css
+++ b/css/shared-header.css
@@ -189,6 +189,10 @@
         gap: 8px;
     }
 
+    .logo-text {
+        display: none;
+    }
+
     .logo-section {
         flex: 0 1 auto;
         min-width: 0;

--- a/css/shared-header.css
+++ b/css/shared-header.css
@@ -185,43 +185,85 @@
     }
 
     .header-toolbar {
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         gap: 8px;
     }
 
     .logo-section {
+        flex: 0 1 auto;
         min-width: 0;
     }
 
     .nav-section {
-        flex: 1 1 100%;
+        flex: 0 1 auto;
         min-width: 0;
-        width: 100%;
         justify-content: flex-end;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
+        gap: 8px;
     }
 
     .connect-wallet-btn {
+        width: 40px;
+        height: 40px;
+        min-height: 40px;
         min-width: 0;
-        max-width: 100%;
+        padding: 0;
+        justify-content: center;
+        background: var(--error-main);
+        border-color: var(--error-main);
+        color: #fff;
+    }
+
+    .connect-wallet-btn.connected {
+        background: var(--success-main);
+        border-color: var(--success-main);
+        color: #fff;
+    }
+
+    .connect-wallet-btn svg {
+        display: block;
+        flex: 0 0 16px;
+        opacity: 1;
+        color: currentColor;
     }
 
     .connect-wallet-btn .wallet-status-text,
     .connect-wallet-btn .wallet-address-text {
-        min-width: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        display: none;
     }
 }
 
 @media (max-width: 480px) {
     .header {
-        padding: 12px 0;
+        padding: 8px 0;
+    }
+
+    .header-toolbar {
+        padding: 0;
+        min-height: 0;
+    }
+
+    .logo-section {
+        flex: 0 0 auto;
+        gap: 8px;
+        min-width: 0;
+    }
+
+    .version-badge {
+        font-size: 9px;
+        margin-left: 0;
+        padding: 1px 5px;
+        border-radius: 8px;
+        line-height: 1.4;
     }
 
     .nav-section {
-        gap: 8px;
+        display: flex;
+        flex: 1 1 auto;
+        min-width: 0;
+        justify-content: flex-end;
+        flex-wrap: nowrap;
+        gap: 6px;
     }
 
     .nav-button {
@@ -229,21 +271,48 @@
         font-size: 13px;
     }
 
+    .nav-button span:not(.material-icons) {
+        display: none;
+    }
+
     .nav-button .material-icons {
         font-size: 18px;
     }
 
     .connect-wallet-btn {
-        flex: 1 1 160px;
-        padding: 8px 12px;
+        width: 40px;
+        flex: 0 0 40px;
+        min-width: 0;
+        height: 40px;
+        padding: 0;
+        gap: 0;
         font-size: 13px;
+        justify-content: center;
+    }
+
+    .theme-toggle {
+        width: 40px;
+        height: 40px;
+        flex: 0 0 40px;
+        justify-self: auto;
+    }
+}
+
+@media (max-width: 360px) {
+    .logo {
+        width: 40px;
+        height: 40px;
+    }
+
+    .version-badge {
+        display: none;
     }
 }
 
 @media (hover: none) and (pointer: coarse) {
     .nav-button,
     .connect-wallet-btn {
-        min-height: 44px;
-        min-width: 44px;
+        min-height: 40px;
+        min-width: 40px;
     }
 }

--- a/css/theme-toggle.css
+++ b/css/theme-toggle.css
@@ -33,13 +33,16 @@
 
 @media (hover: none) and (pointer: coarse) {
     .theme-toggle {
-        width: 44px;
-        height: 44px;
+        width: 40px;
+        height: 40px;
     }
 }
 
 /* Material Icons support */
 .theme-toggle .material-icons-outlined {
+    display: block;
+    font-size: 22px;
+    line-height: 1;
     transition: inherit;
     flex-shrink: 0;
 }
@@ -54,4 +57,3 @@
         transform: none;
     }
 }
-

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
 
                     <button id="connect-wallet-btn"
                             class="connect-wallet-btn"
+                            aria-label="Connect wallet"
                             aria-describedby="wallet-status"
                             aria-live="polite"
                             aria-busy="true"

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
 
 
                 <nav class="nav-section" role="navigation" aria-label="Main navigation">
-                    <a href="admin/" id="admin-panel-link" class="nav-button" style="display: none;">
+                    <a href="admin/" id="admin-panel-link" class="nav-button" style="display: none;" aria-label="Admin Panel">
                         <span class="material-icons" aria-hidden="true">admin_panel_settings</span>
                         <span>Admin Panel</span>
                     </a>
@@ -133,7 +133,7 @@
             <div class="footer-content">
                 <span class="footer-text">&copy; <a href="https://liberdus.com" target="_blank" rel="noopener noreferrer" class="footer-brand-link">Liberdus</a> <span id="footer-year">2026</span></span>
                 <div class="footer-actions">
-                    <a id="add-token-link" href="#" class="footer-link-anchor footer-link-action" hidden>
+                    <a id="add-token-link" href="#" class="footer-link-anchor footer-link-action" aria-label="Add reward token to MetaMask" title="Add reward token to MetaMask" hidden>
                         <img src="assets/metamask-fox.svg" alt="" class="footer-link-icon" aria-hidden="true">
                         <span>Add to MetaMask</span>
                     </a>


### PR DESCRIPTION
**Summary**
- Tighten the shared mobile header so the logo, wallet, network, and theme controls fit without wrapping issues.
- Compress the home footer on small screens and keep the action links usable in the new compact layout.
- Adjust the network selector and theme toggle sizing for better mobile alignment.
- Preserve accessible labels for icon-only navigation and footer actions.

**Testing**
- Not run (not requested)
- Verified the updated responsive rules and mobile accessibility labels in the affected markup and styles.

<img width="374" height="670" alt="image" src="https://github.com/user-attachments/assets/71cc309f-dde6-4bda-8407-8f9b542bac00" />
<img width="965" height="966" alt="image" src="https://github.com/user-attachments/assets/e87ddd6d-788b-4cd2-9d31-bf2083f09167" />
