### PR TITLE
Fix first-load farm initialization race

### DIFF
--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -938,13 +938,25 @@ document.addEventListener('DOMContentLoaded', async () => {
         return;
     }
 
-    window.masterInitializer = new MasterInitializer();
-
     try {
+        if (window.versionCheckReady) {
+            try {
+                const versionCheckResult = await window.versionCheckReady;
+                if (versionCheckResult?.reloading || window.versionCheckReloading) {
+                    return;
+                }
+            } catch (versionError) {
+                console.warn('⚠️ Version check failed before initialization:', versionError);
+            }
+        }
+
+        window.masterInitializer = new MasterInitializer();
         await window.masterInitializer.init();
     } catch (error) {
         console.error('❌ System initialization failed:', error);
-        window.masterInitializer.handleInitializationError(error);
+        if (window.masterInitializer) {
+            window.masterInitializer.handleInitializationError(error);
+        }
     }
 });
 

--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -939,7 +939,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     try {
-        const versionCheckResult = await window.versionCheckReady;
+        const versionCheckResult = window.versionCheckReady
+            ? await window.versionCheckReady
+            : { status: 'ready' };
         if (versionCheckResult.status === 'reload') {
             return;
         }

--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -939,15 +939,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     try {
-        if (window.versionCheckReady) {
-            try {
-                const versionCheckResult = await window.versionCheckReady;
-                if (versionCheckResult?.reloading || window.versionCheckReloading) {
-                    return;
-                }
-            } catch (versionError) {
-                console.warn('⚠️ Version check failed before initialization:', versionError);
-            }
+        const versionCheckResult = await window.versionCheckReady;
+        if (versionCheckResult.status === 'reload') {
+            return;
+        }
+
+        if (versionCheckResult.status !== 'ready') {
+            throw new Error(`Unknown version check status: ${versionCheckResult.status}`);
         }
 
         window.masterInitializer = new MasterInitializer();

--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -941,15 +941,22 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     try {
-        const versionCheckTimeout = new Promise((resolve) => {
-            setTimeout(() => resolve({ status: 'ready' }), VERSION_CHECK_TIMEOUT_MS);
-        });
-        const versionCheckResult = window.versionCheckReady
-            ? await Promise.race([
+        let versionCheckResult = { status: 'ready' };
+        if (window.versionCheckReady) {
+            let timeoutId;
+            const versionCheckTimeout = new Promise((resolve) => {
+                timeoutId = setTimeout(() => {
+                    window.versionCheckSkipReload = true;
+                    resolve({ status: 'ready' });
+                }, VERSION_CHECK_TIMEOUT_MS);
+            });
+            versionCheckResult = await Promise.race([
                 window.versionCheckReady.catch(() => ({ status: 'ready' })),
                 versionCheckTimeout
-            ])
-            : { status: 'ready' };
+            ]);
+            clearTimeout(timeoutId);
+        }
+
         if (versionCheckResult.status === 'reload') {
             return;
         }

--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -940,7 +940,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     try {
         const versionCheckResult = window.versionCheckReady
-            ? await window.versionCheckReady
+            ? await window.versionCheckReady.catch(() => ({ status: 'ready' }))
             : { status: 'ready' };
         if (versionCheckResult.status === 'reload') {
             return;

--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -931,6 +931,8 @@ class MasterInitializer {
     }
 }
 
+const VERSION_CHECK_TIMEOUT_MS = 3000;
+
 // Auto-initialize when DOM is ready
 document.addEventListener('DOMContentLoaded', async () => {
     if (window.masterInitializer?.isReady) {
@@ -939,8 +941,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     try {
+        const versionCheckTimeout = new Promise((resolve) => {
+            setTimeout(() => resolve({ status: 'ready' }), VERSION_CHECK_TIMEOUT_MS);
+        });
         const versionCheckResult = window.versionCheckReady
-            ? await window.versionCheckReady.catch(() => ({ status: 'ready' }))
+            ? await Promise.race([
+                window.versionCheckReady.catch(() => ({ status: 'ready' })),
+                versionCheckTimeout
+            ])
             : { status: 'ready' };
         if (versionCheckResult.status === 'reload') {
             return;

--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -931,8 +931,6 @@ class MasterInitializer {
     }
 }
 
-const VERSION_CHECK_TIMEOUT_MS = 3000;
-
 // Auto-initialize when DOM is ready
 document.addEventListener('DOMContentLoaded', async () => {
     if (window.masterInitializer?.isReady) {
@@ -941,22 +939,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     try {
-        let versionCheckResult = { status: 'ready' };
-        if (window.versionCheckReady) {
-            let timeoutId;
-            const versionCheckTimeout = new Promise((resolve) => {
-                timeoutId = setTimeout(() => {
-                    window.versionCheckSkipReload = true;
-                    resolve({ status: 'ready' });
-                }, VERSION_CHECK_TIMEOUT_MS);
-            });
-            versionCheckResult = await Promise.race([
-                window.versionCheckReady.catch(() => ({ status: 'ready' })),
-                versionCheckTimeout
-            ]);
-            clearTimeout(timeoutId);
-        }
-
+        const versionCheckResult = window.versionCheckReady
+            ? await window.versionCheckReady.catch(() => ({ status: 'ready' }))
+            : { status: 'ready' };
         if (versionCheckResult.status === 'reload') {
             return;
         }

--- a/js/utils/version-check.js
+++ b/js/utils/version-check.js
@@ -10,8 +10,8 @@
     const isAdminPage = window.location.pathname.includes('admin');
     const VERSION_FILE = isAdminPage ? '../version.html' : 'version.html';
     const STORAGE_KEY = 'version';
+    const VERSION_CHECK_TIMEOUT_MS = 3000;
     let cachedVersion = null;
-    window.versionCheckSkipReload = false;
 
     /**
      * Get current version from localStorage or version.html
@@ -29,7 +29,7 @@
                 return stored;
             }
 
-            const response = await fetch(VERSION_FILE, {
+            const response = await fetchWithTimeout(VERSION_FILE, {
                 cache: 'reload',
                 headers: {
                     'Cache-Control': 'no-cache',
@@ -58,7 +58,7 @@
         let newVersion = storedVersion;
 
         try {
-            const response = await fetch(VERSION_FILE, {
+            const response = await fetchWithTimeout(VERSION_FILE, {
                 cache: 'reload',
                 headers: {
                     'Cache-Control': 'no-cache',
@@ -82,20 +82,10 @@
         const newVer = versionToNumber(newVersion);
 
         if (storedVer !== newVer) {
-            if (window.versionCheckSkipReload) {
-                window.versionCheckSkipReload = false;
-                return { status: 'ready', version: storedVersion };
-            }
-
             console.log(`🔄 Updating to version: ${newVersion} (from ${storedVersion})`);
             
             if (criticalFiles.length > 0) {
                 await forceReloadFiles(criticalFiles);
-            }
-
-            if (window.versionCheckSkipReload) {
-                window.versionCheckSkipReload = false;
-                return { status: 'ready', version: storedVersion };
             }
             
             localStorage.setItem(STORAGE_KEY, newVersion);
@@ -119,6 +109,17 @@
         return parseInt(parts.map((p, i) => p.padStart(3, '0')).join('')) || 0;
     }
 
+    async function fetchWithTimeout(url, options) {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), VERSION_CHECK_TIMEOUT_MS);
+
+        try {
+            return await fetch(url, { ...options, signal: controller.signal });
+        } finally {
+            clearTimeout(timeoutId);
+        }
+    }
+
     /**
      * Force reload files with cache-busting headers
      * @param {string[]} urls - Files to reload
@@ -126,7 +127,7 @@
     async function forceReloadFiles(urls) {
         try {
             const fetchPromises = urls.map(url =>
-                fetch(url, {
+                fetchWithTimeout(url, {
                     cache: 'reload',
                     headers: {
                         'Cache-Control': 'no-cache',

--- a/js/utils/version-check.js
+++ b/js/utils/version-check.js
@@ -11,6 +11,7 @@
     const VERSION_FILE = isAdminPage ? '../version.html' : 'version.html';
     const STORAGE_KEY = 'version';
     let cachedVersion = null;
+    window.versionCheckReloading = false;
 
     /**
      * Get current version from localStorage or version.html
@@ -73,7 +74,7 @@
         } catch (error) {
             console.error('Version check failed:', error);
             // Continue with stored version on error
-            return;
+            return { reloading: false, version: storedVersion };
         }
 
         // Compare versions (convert to comparable numbers: "1.2.3" -> 1002003)
@@ -84,15 +85,18 @@
             console.log(`🔄 Updating to version: ${newVersion} (from ${storedVersion})`);
             localStorage.setItem(STORAGE_KEY, newVersion);
             cachedVersion = newVersion;
+            window.versionCheckReloading = true;
             
             if (criticalFiles.length > 0) {
                 await forceReloadFiles(criticalFiles);
             }
             
             window.location.replace(window.location.href.split('?')[0]);
+            return { reloading: true, version: newVersion };
         } else {
             cachedVersion = storedVersion;
             console.log(`✅ Running version: ${storedVersion}`);
+            return { reloading: false, version: newVersion };
         }
     }
 
@@ -198,6 +202,6 @@
     window.getCurrentVersion = getCurrentVersion;
 
     // Auto-run version check on load
-    checkVersion(getCriticalFiles());
+    window.versionCheckReady = checkVersion(getCriticalFiles());
 
 })(window);

--- a/js/utils/version-check.js
+++ b/js/utils/version-check.js
@@ -11,7 +11,6 @@
     const VERSION_FILE = isAdminPage ? '../version.html' : 'version.html';
     const STORAGE_KEY = 'version';
     let cachedVersion = null;
-    window.versionCheckReloading = false;
 
     /**
      * Get current version from localStorage or version.html
@@ -74,7 +73,7 @@
         } catch (error) {
             console.error('Version check failed:', error);
             // Continue with stored version on error
-            return { reloading: false, version: storedVersion };
+            return { status: 'ready', version: storedVersion };
         }
 
         // Compare versions (convert to comparable numbers: "1.2.3" -> 1002003)
@@ -85,18 +84,17 @@
             console.log(`🔄 Updating to version: ${newVersion} (from ${storedVersion})`);
             localStorage.setItem(STORAGE_KEY, newVersion);
             cachedVersion = newVersion;
-            window.versionCheckReloading = true;
             
             if (criticalFiles.length > 0) {
                 await forceReloadFiles(criticalFiles);
             }
             
             window.location.replace(window.location.href.split('?')[0]);
-            return { reloading: true, version: newVersion };
+            return { status: 'reload', version: newVersion };
         } else {
             cachedVersion = storedVersion;
             console.log(`✅ Running version: ${storedVersion}`);
-            return { reloading: false, version: newVersion };
+            return { status: 'ready', version: newVersion };
         }
     }
 

--- a/js/utils/version-check.js
+++ b/js/utils/version-check.js
@@ -11,6 +11,7 @@
     const VERSION_FILE = isAdminPage ? '../version.html' : 'version.html';
     const STORAGE_KEY = 'version';
     let cachedVersion = null;
+    window.versionCheckSkipReload = false;
 
     /**
      * Get current version from localStorage or version.html
@@ -81,14 +82,24 @@
         const newVer = versionToNumber(newVersion);
 
         if (storedVer !== newVer) {
+            if (window.versionCheckSkipReload) {
+                window.versionCheckSkipReload = false;
+                return { status: 'ready', version: storedVersion };
+            }
+
             console.log(`🔄 Updating to version: ${newVersion} (from ${storedVersion})`);
-            localStorage.setItem(STORAGE_KEY, newVersion);
-            cachedVersion = newVersion;
             
             if (criticalFiles.length > 0) {
                 await forceReloadFiles(criticalFiles);
             }
+
+            if (window.versionCheckSkipReload) {
+                window.versionCheckSkipReload = false;
+                return { status: 'ready', version: storedVersion };
+            }
             
+            localStorage.setItem(STORAGE_KEY, newVersion);
+            cachedVersion = newVersion;
             window.location.replace(window.location.href.split('?')[0]);
             return { status: 'reload', version: newVersion };
         } else {


### PR DESCRIPTION
## Summary
- Coordinates app startup with the existing version check so the first mobile private-session visit does not show a false script-load initialization alert.
- Makes the version check return a clear startup decision: continue normally (`ready`) or stop because a reload is already being triggered (`reload`).
- Adds a 3s timeout to version-check fetches so startup is not held forever by a stuck cache/version request.
- Keeps the staking app usable if the version-check helper is missing or fails, because cache freshness should not be a hard dependency for loading the app.

## Problem
On a fresh mobile private browsing session, the page starts two pieces of startup work at nearly the same time: the cache/version refresh flow and the main app initializer. When the stored version is empty or stale, the version check can prefetch critical files and then reload the page. At the same time, `MasterInitializer` may already be loading dynamic scripts such as `libs/ethers.umd.min.js`.

If the version check reloads while that script load is in flight, the browser can report the interrupted request as a script-load failure. The user sees an `Initialization Error` alert even though the file exists and the page usually works after dismissing the alert or opening the site again. That is why the issue appears only on the first visit in a fresh private session.

## Fix
This PR makes startup wait for the version check to make its decision before constructing `MasterInitializer`. If the version check decides a reload is needed, app initialization does not begin on the page that is about to navigate away. If the version check says the page is ready, the normal initializer runs.

The timeout is handled inside `version-check.js` at the fetch boundary. That keeps the behavior simple: a slow or stuck version request resolves the version check as `ready`, so `MasterInitializer` can continue, and there is no abandoned background promise that can reload the page later after initialization has started.

If the version-check script is missing or its promise rejects, startup also continues as `ready`. That fallback is intentional because version checking is a cache freshness helper, not a core requirement for rendering the staking app.

## Validation
- `npm test` — 6 files passed, 70 tests passed
- `git diff --check e8d97484a235743f306972da199d880034e35067`