### PR TITLE
Fix mobile staking modal tabs

### DIFF
--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -105,24 +105,41 @@
 
 /* Modal Tabs */
 .modal-tabs {
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    width: 100%;
     border-bottom: 1px solid var(--divider);
 }
 
 .tab-button {
-    flex: 1;
     display: flex;
     align-items: center;
     justify-content: center;
     gap: var(--spacing-1);
     padding: var(--spacing-2);
+    min-width: 0;
+    min-height: 48px;
     border: none;
     background: transparent;
     color: var(--text-secondary);
     font-weight: 500;
+    line-height: 1.2;
+    white-space: nowrap;
     cursor: pointer;
     transition: all 0.2s;
     border-bottom: 2px solid transparent;
+}
+
+.tab-button .material-icons {
+    flex: 0 0 auto;
+    font-size: 20px;
+    line-height: 1;
+}
+
+.tab-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .tab-button:hover {
@@ -853,12 +870,9 @@
     }
 
     .tab-button {
-        padding: var(--spacing-1);
-        font-size: 14px;
-    }
-
-    .tab-button span:not(.material-icons) {
-        display: none;
+        gap: 4px;
+        padding: 10px 8px;
+        font-size: 13px;
     }
 
     .zap-input-row {
@@ -875,5 +889,16 @@
 
     .zap-custom-token-row {
         grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 480px) {
+    .tab-button {
+        min-height: 48px;
+        padding: 10px 6px;
+    }
+
+    .tab-label {
+        display: none;
     }
 }

--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -107,7 +107,6 @@
 .modal-tabs {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
-    width: 100%;
     border-bottom: 1px solid var(--divider);
 }
 
@@ -123,23 +122,10 @@
     background: transparent;
     color: var(--text-secondary);
     font-weight: 500;
-    line-height: 1.2;
     white-space: nowrap;
     cursor: pointer;
     transition: all 0.2s;
     border-bottom: 2px solid transparent;
-}
-
-.tab-button .material-icons {
-    flex: 0 0 auto;
-    font-size: 20px;
-    line-height: 1;
-}
-
-.tab-label {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
 }
 
 .tab-button:hover {
@@ -894,7 +880,6 @@
 
 @media (max-width: 480px) {
     .tab-button {
-        min-height: 48px;
         padding: 10px 6px;
     }
 

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -210,20 +210,20 @@ class StakingModalNew {
                         </button>
                     </div>
                     
-                    <div class="modal-tabs" role="group" aria-label="Staking actions">
-                        <button class="tab-button active" type="button" aria-pressed="true" aria-label="Create LP" title="Create LP" data-tab="zap">
+                    <div class="modal-tabs">
+                        <button class="tab-button active" aria-label="Create LP" data-tab="zap">
                             <span class="material-icons" aria-hidden="true">bolt</span>
                             <span class="tab-label">Create LP</span>
                         </button>
-                        <button class="tab-button" type="button" aria-pressed="false" aria-label="Stake" title="Stake" data-tab="stake">
+                        <button class="tab-button" aria-label="Stake" data-tab="stake">
                             <span class="material-icons" aria-hidden="true">add</span>
                             <span class="tab-label">Stake</span>
                         </button>
-                        <button class="tab-button" type="button" aria-pressed="false" aria-label="Unstake" title="Unstake" data-tab="unstake">
+                        <button class="tab-button" aria-label="Unstake" data-tab="unstake">
                             <span class="material-icons" aria-hidden="true">remove</span>
                             <span class="tab-label">Unstake</span>
                         </button>
-                        <button class="tab-button" type="button" aria-pressed="false" aria-label="Claim" title="Claim" data-tab="claim">
+                        <button class="tab-button" aria-label="Claim" data-tab="claim">
                             <span class="material-icons" aria-hidden="true">redeem</span>
                             <span class="tab-label">Claim</span>
                         </button>
@@ -2083,9 +2083,7 @@ class StakingModalNew {
 
         // Update tab buttons
         document.querySelectorAll('.tab-button').forEach(btn => {
-            const isActive = btn.dataset.tab === tab;
-            btn.classList.toggle('active', isActive);
-            btn.setAttribute('aria-pressed', String(isActive));
+            btn.classList.toggle('active', btn.dataset.tab === tab);
         });
 
         // Render tab content

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -210,22 +210,22 @@ class StakingModalNew {
                         </button>
                     </div>
                     
-                    <div class="modal-tabs">
-                        <button class="tab-button active" data-tab="zap">
-                            <span class="material-icons">bolt</span>
-                            Create LP
+                    <div class="modal-tabs" role="group" aria-label="Staking actions">
+                        <button class="tab-button active" type="button" aria-pressed="true" aria-label="Create LP" title="Create LP" data-tab="zap">
+                            <span class="material-icons" aria-hidden="true">bolt</span>
+                            <span class="tab-label">Create LP</span>
                         </button>
-                        <button class="tab-button" data-tab="stake">
-                            <span class="material-icons">add</span>
-                            Stake
+                        <button class="tab-button" type="button" aria-pressed="false" aria-label="Stake" title="Stake" data-tab="stake">
+                            <span class="material-icons" aria-hidden="true">add</span>
+                            <span class="tab-label">Stake</span>
                         </button>
-                        <button class="tab-button" data-tab="unstake">
-                            <span class="material-icons">remove</span>
-                            Unstake
+                        <button class="tab-button" type="button" aria-pressed="false" aria-label="Unstake" title="Unstake" data-tab="unstake">
+                            <span class="material-icons" aria-hidden="true">remove</span>
+                            <span class="tab-label">Unstake</span>
                         </button>
-                        <button class="tab-button" data-tab="claim">
-                            <span class="material-icons">redeem</span>
-                            Claim
+                        <button class="tab-button" type="button" aria-pressed="false" aria-label="Claim" title="Claim" data-tab="claim">
+                            <span class="material-icons" aria-hidden="true">redeem</span>
+                            <span class="tab-label">Claim</span>
                         </button>
                     </div>
                     
@@ -2083,7 +2083,9 @@ class StakingModalNew {
 
         // Update tab buttons
         document.querySelectorAll('.tab-button').forEach(btn => {
-            btn.classList.toggle('active', btn.dataset.tab === tab);
+            const isActive = btn.dataset.tab === tab;
+            btn.classList.toggle('active', isActive);
+            btn.setAttribute('aria-pressed', String(isActive));
         });
 
         // Render tab content

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -20,13 +20,20 @@ function createClassList(initialClasses = []) {
 }
 
 function createElement({ id = '', classes = [], value = '' } = {}) {
+    const attributes = new Map();
+
     return {
         id,
         value,
         style: {},
         dataset: {},
+        innerHTML: '',
         classList: createClassList(classes),
         querySelector: vi.fn(() => null),
+        setAttribute: vi.fn((name, attributeValue) => {
+            attributes.set(name, String(attributeValue));
+        }),
+        getAttribute: vi.fn(name => attributes.get(name) || null),
         childNodes: []
     };
 }
@@ -45,6 +52,10 @@ function createDocumentMock() {
         querySelectorAll: vi.fn(selector => {
             if (selector === '.zap-percentage-btn') {
                 return allElements.filter(element => element.classList.contains('zap-percentage-btn'));
+            }
+
+            if (selector === '.tab-button') {
+                return allElements.filter(element => element.classList.contains('tab-button'));
             }
 
             return [];
@@ -244,6 +255,35 @@ describe('StakingModalNew zap cleanup', () => {
 
         expect(activeButton.classList.contains('active')).toBe(false);
         expect(inactiveButton.classList.contains('active')).toBe(false);
+    });
+
+    it('renders modal tabs with hideable labels and accessible names', async () => {
+        const StakingModalNew = await loadStakingModalClass();
+        const modalContainer = document.registerElement(createElement({ id: 'modal-container' }));
+
+        new StakingModalNew();
+
+        expect(modalContainer.innerHTML).toContain('class="modal-tabs" role="group"');
+        expect(modalContainer.innerHTML).toContain('aria-label="Create LP"');
+        expect(modalContainer.innerHTML).toContain('aria-pressed="true"');
+        expect(modalContainer.innerHTML).toContain('<span class="material-icons" aria-hidden="true">bolt</span>');
+        expect(modalContainer.innerHTML).toContain('<span class="tab-label">Create LP</span>');
+        expect(modalContainer.innerHTML).toContain('<span class="tab-label">Unstake</span>');
+    });
+
+    it('updates tab accessibility state when switching tabs', async () => {
+        const modal = await createLoadedModal();
+        const zapButton = document.registerElement(createElement({ classes: ['tab-button', 'active'] }));
+        const stakeButton = document.registerElement(createElement({ classes: ['tab-button'] }));
+        zapButton.dataset.tab = 'zap';
+        stakeButton.dataset.tab = 'stake';
+
+        modal.switchTab('stake');
+
+        expect(zapButton.classList.contains('active')).toBe(false);
+        expect(zapButton.getAttribute('aria-pressed')).toBe('false');
+        expect(stakeButton.classList.contains('active')).toBe(true);
+        expect(stakeButton.getAttribute('aria-pressed')).toBe('true');
     });
 
     it('startZapQuoteAutoRefresh stops instead of refreshing while zap is executing', async () => {

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -20,8 +20,6 @@ function createClassList(initialClasses = []) {
 }
 
 function createElement({ id = '', classes = [], value = '' } = {}) {
-    const attributes = new Map();
-
     return {
         id,
         value,
@@ -30,10 +28,6 @@ function createElement({ id = '', classes = [], value = '' } = {}) {
         innerHTML: '',
         classList: createClassList(classes),
         querySelector: vi.fn(() => null),
-        setAttribute: vi.fn((name, attributeValue) => {
-            attributes.set(name, String(attributeValue));
-        }),
-        getAttribute: vi.fn(name => attributes.get(name) || null),
         childNodes: []
     };
 }
@@ -52,10 +46,6 @@ function createDocumentMock() {
         querySelectorAll: vi.fn(selector => {
             if (selector === '.zap-percentage-btn') {
                 return allElements.filter(element => element.classList.contains('zap-percentage-btn'));
-            }
-
-            if (selector === '.tab-button') {
-                return allElements.filter(element => element.classList.contains('tab-button'));
             }
 
             return [];
@@ -263,27 +253,11 @@ describe('StakingModalNew zap cleanup', () => {
 
         new StakingModalNew();
 
-        expect(modalContainer.innerHTML).toContain('class="modal-tabs" role="group"');
+        expect(modalContainer.innerHTML).toContain('class="modal-tabs"');
         expect(modalContainer.innerHTML).toContain('aria-label="Create LP"');
-        expect(modalContainer.innerHTML).toContain('aria-pressed="true"');
         expect(modalContainer.innerHTML).toContain('<span class="material-icons" aria-hidden="true">bolt</span>');
         expect(modalContainer.innerHTML).toContain('<span class="tab-label">Create LP</span>');
         expect(modalContainer.innerHTML).toContain('<span class="tab-label">Unstake</span>');
-    });
-
-    it('updates tab accessibility state when switching tabs', async () => {
-        const modal = await createLoadedModal();
-        const zapButton = document.registerElement(createElement({ classes: ['tab-button', 'active'] }));
-        const stakeButton = document.registerElement(createElement({ classes: ['tab-button'] }));
-        zapButton.dataset.tab = 'zap';
-        stakeButton.dataset.tab = 'stake';
-
-        modal.switchTab('stake');
-
-        expect(zapButton.classList.contains('active')).toBe(false);
-        expect(zapButton.getAttribute('aria-pressed')).toBe('false');
-        expect(stakeButton.classList.contains('active')).toBe(true);
-        expect(stakeButton.getAttribute('aria-pressed')).toBe('true');
     });
 
     it('startZapQuoteAutoRefresh stops instead of refreshing while zap is executing', async () => {


### PR DESCRIPTION
## Summary

- Make staking modal action tabs a fixed four-column layout so narrow viewports do not depend on horizontal scrolling.
- Wrap tab labels so mobile CSS can hide them at very narrow widths while keeping accessible button names.
- Add regression coverage for the rendered modal tab labels.
<img width="396" height="857" alt="image" src="https://github.com/user-attachments/assets/664c263c-9a4f-4821-9c23-42cd44f16dca" />


## Why

Fixes #236. The previous mobile CSS attempted to hide non-icon spans, but the tab labels were plain text nodes, so the rule could not reliably control the narrow layout.

## Validation

- `npm test -- --run tests/staking-modal-new.test.js`
- `npm test`
- Playwright viewport check at 320, 360, 375, 390, 480, and 481px confirmed no tab overflow and 48px button heights.