### PR TITLE
Prevent duplicate active toasts from stacking

### DIFF
--- a/js/core/notification-manager-new.js
+++ b/js/core/notification-manager-new.js
@@ -35,6 +35,12 @@ class NotificationManagerNew {
             supportAction = type === 'error'
         } = normalizedOptions;
 
+        const duplicateKey = this.getDuplicateKey(message, type, title);
+        const existingNotification = this.findActiveNotification(duplicateKey);
+        if (existingNotification) {
+            return existingNotification.element;
+        }
+
         const notification = this.createNotification(message, type, { title, persistent, showProgress, onClick, supportAction });
         this.container.appendChild(notification);
 
@@ -62,10 +68,32 @@ class NotificationManagerNew {
             element: notification,
             type,
             message,
+            title,
+            duplicateKey,
             timestamp: Date.now()
         });
 
         return notification;
+    }
+
+    getDuplicateKey(message, type, title) {
+        return JSON.stringify({
+            type: String(type || 'info'),
+            title: title == null ? '' : String(title),
+            message: message == null ? '' : String(message)
+        });
+    }
+
+    findActiveNotification(duplicateKey) {
+        this.pruneNotifications();
+        return this.notifications.find(notification =>
+            notification.duplicateKey === duplicateKey &&
+            notification.element?.parentNode
+        );
+    }
+
+    pruneNotifications() {
+        this.notifications = this.notifications.filter(notification => notification.element?.parentNode);
     }
 
     createNotification(message, type, options = {}) {
@@ -168,6 +196,7 @@ class NotificationManagerNew {
             if (notification.parentNode) {
                 notification.parentNode.removeChild(notification);
             }
+            this.pruneNotifications();
         }, 300);
     }
 

--- a/js/core/notification-manager-new.js
+++ b/js/core/notification-manager-new.js
@@ -36,7 +36,9 @@ class NotificationManagerNew {
         } = normalizedOptions;
 
         const duplicateKey = this.getDuplicateKey(message, type, title);
-        const existingNotification = this.findActiveNotification(duplicateKey);
+        this.pruneNotifications();
+
+        const existingNotification = this.notifications.find(notification => notification.duplicateKey === duplicateKey);
         if (existingNotification) {
             return existingNotification.element;
         }
@@ -68,7 +70,6 @@ class NotificationManagerNew {
             element: notification,
             type,
             message,
-            title,
             duplicateKey,
             timestamp: Date.now()
         });
@@ -82,14 +83,6 @@ class NotificationManagerNew {
             title: title == null ? '' : String(title),
             message: message == null ? '' : String(message)
         });
-    }
-
-    findActiveNotification(duplicateKey) {
-        this.pruneNotifications();
-        return this.notifications.find(notification =>
-            notification.duplicateKey === duplicateKey &&
-            notification.element?.parentNode
-        );
     }
 
     pruneNotifications() {

--- a/tests/notification-manager-new.test.js
+++ b/tests/notification-manager-new.test.js
@@ -114,6 +114,7 @@ async function loadNotificationManager() {
 
 describe('NotificationManagerNew support actions', () => {
     afterEach(() => {
+        vi.useRealTimers();
         vi.restoreAllMocks();
         delete globalThis.CONFIG;
         delete globalThis.NotificationManagerNew;
@@ -185,6 +186,47 @@ describe('NotificationManagerNew support actions', () => {
         expect(message.textContent).toBe(unsafeMessage);
         expect(message.children).toHaveLength(0);
         expect(notification.querySelector('img')).toBeNull();
+    });
+
+    it('does not stack duplicate active toasts', async () => {
+        const NotificationManagerNew = await loadNotificationManager();
+        const manager = new NotificationManagerNew();
+
+        const first = manager.error('Something failed', { title: 'Wallet error' });
+        const second = manager.error('Something failed', { title: 'Wallet error' });
+
+        expect(second).toBe(first);
+        expect(manager.container.querySelectorAll('.notification')).toHaveLength(1);
+        expect(manager.notifications).toHaveLength(1);
+    });
+
+    it('keeps different toast types, messages, and titles separate', async () => {
+        const NotificationManagerNew = await loadNotificationManager();
+        const manager = new NotificationManagerNew();
+
+        manager.error('Something failed', { title: 'Wallet error' });
+        manager.warning('Something failed', { title: 'Wallet error' });
+        manager.error('A different failure', { title: 'Wallet error' });
+        manager.error('Something failed', { title: 'Network error' });
+
+        expect(manager.container.querySelectorAll('.notification')).toHaveLength(4);
+        expect(manager.notifications).toHaveLength(4);
+    });
+
+    it('allows the same toast after the active one is dismissed', async () => {
+        vi.useFakeTimers();
+        const NotificationManagerNew = await loadNotificationManager();
+        const manager = new NotificationManagerNew();
+
+        const first = manager.error('Something failed');
+        manager.remove(first);
+        vi.advanceTimersByTime(300);
+
+        const second = manager.error('Something failed');
+
+        expect(second).not.toBe(first);
+        expect(manager.container.querySelectorAll('.notification')).toHaveLength(1);
+        expect(manager.notifications).toHaveLength(1);
     });
 });
 


### PR DESCRIPTION
## Summary
- Prevent NotificationManagerNew from adding a duplicate active toast when type, title, and message match an existing visible notification.
- Keep distinct toast types, titles, and messages as separate notifications.
- Prune dismissed notifications so the same feedback can appear again after the active toast is removed.

## Why
Repeated actions could stack identical persistent error toasts, especially wallet-not-connected style feedback from staking table actions. Centralizing duplicate suppression in the notification manager keeps callers simple and avoids repeated custom checks.

## Validation
- `npm test -- tests/notification-manager-new.test.js`
- `npm test`

Fixes #245