### PR TITLE
Add footer support action

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -613,12 +613,13 @@ body {
         display: none;
     }
 
-    #staking-contract-link {
+    #staking-contract-link,
+    #footer-support-link {
         font-size: 0;
     }
 
-    #staking-contract-link::before {
-        content: "description";
+    #staking-contract-link::before,
+    #footer-support-link::before {
         display: block;
         font-family: "Material Icons";
         font-size: 17px;
@@ -626,6 +627,14 @@ body {
         width: 17px;
         height: 17px;
         text-align: center;
+    }
+
+    #staking-contract-link::before {
+        content: "description";
+    }
+
+    #footer-support-link::before {
+        content: "support_agent";
     }
 
     .social-links {

--- a/index.html
+++ b/index.html
@@ -141,6 +141,9 @@
                     <a id="staking-contract-link" href="#" target="_blank" rel="noopener noreferrer" class="footer-link-anchor" hidden>
                         Contract
                     </a>
+                    <a id="footer-support-link" href="https://liberdus.com/discord/help/" target="_blank" rel="noopener noreferrer" class="footer-link-anchor" title="Get support on Discord" aria-label="Get support on Discord">
+                        Support
+                    </a>
                 </div>
                 <div class="social-links">
                     <a href="https://github.com/Liberdus/lib-lp-staking-frontend" target="_blank" rel="noopener" class="social-link" title="Visit our GitHub">

--- a/tests/notification-manager-new.test.js
+++ b/tests/notification-manager-new.test.js
@@ -198,6 +198,7 @@ describe('footer support link', () => {
         expect(discordUrl).toBe('https://liberdus.com/discord/');
         expect(discordHelpUrl).toBe('https://liberdus.com/discord/help/');
         expect(index).toContain(`id="discord-support-link" href="${discordUrl}"`);
+        expect(index).toContain(`id="footer-support-link" href="${discordHelpUrl}"`);
         expect(index).toContain('class="social-link-icon"');
         expect(index.match(/class="social-link-icon"/g)).toHaveLength(4);
         expect(index).not.toContain('<span class="material-icons">code</span>');


### PR DESCRIPTION
## What changed
- Added a Support footer action next to the existing Contract action.
- Pointed the footer Support link to `https://liberdus.com/discord/help/`.
- Updated compact mobile footer styling so Contract and Support render as icon-only actions.
- Extended the footer support link test coverage for the configured help URL.

## Why
Users need a clear support path from the footer while keeping the existing social Discord icon as the general community link.

## Validation
- `npm test` - 7 test files passed, 78 tests passed.

Closes #241