### PR TITLE
Add guided V2 remove liquidity flow

### DIFF
--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -37,7 +37,8 @@
     box-shadow: var(--shadow-8);
     width: 90%;
     max-width: 600px;
-    max-height: 90vh;
+    max-height: 92vh;
+    max-height: 92dvh;
     overflow: hidden;
     transform: scale(0.9) translateY(20px);
     transition: transform 0.3s ease;
@@ -858,6 +859,46 @@
     font-size: 12px;
 }
 
+.remove-liquidity-preview-list .zap-quote-row dt[title] {
+    position: relative;
+    cursor: help;
+    text-decoration: underline dotted;
+    text-underline-offset: 3px;
+}
+
+.remove-liquidity-preview-list .zap-quote-row dt[title]:focus {
+    outline: none;
+    color: var(--primary-main);
+}
+
+.remove-liquidity-preview-list .zap-quote-row dt[title]:focus-visible {
+    outline: 2px solid var(--primary-main);
+    outline-offset: 3px;
+    border-radius: 3px;
+}
+
+.remove-liquidity-preview-list .zap-quote-row dt[title]:focus::after,
+.remove-liquidity-preview-list .zap-quote-row dt[title]:active::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    left: 0;
+    bottom: calc(100% + 8px);
+    z-index: var(--z-tooltip, 1070);
+    width: max-content;
+    max-width: min(260px, 70vw);
+    padding: 8px 10px;
+    border: 1px solid var(--divider);
+    border-radius: var(--border-radius);
+    background: var(--background-paper);
+    color: var(--text-primary);
+    box-shadow: var(--shadow-4);
+    font-size: 12px;
+    font-weight: var(--font-weight-normal);
+    line-height: 1.35;
+    white-space: normal;
+    text-decoration: none;
+}
+
 .zap-quote-row dd {
     min-width: 0;
     margin: 0;
@@ -971,7 +1012,8 @@
     .modal-content {
         width: 95%;
         margin: var(--spacing-2);
-        max-height: calc(100vh - 120px);
+        max-height: calc(100vh - 32px);
+        max-height: calc(100dvh - 32px);
         overflow-y: auto;
     }
 

--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -644,6 +644,8 @@
 
 .remove-liquidity-meta-row .remove-liquidity-checkbox-label {
     flex: 0 0 auto;
+    grid-column: 2;
+    justify-self: end;
     margin: 0;
     white-space: nowrap;
 }

--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -621,6 +621,28 @@
     justify-content: flex-start;
 }
 
+.remove-liquidity-amount-group {
+    margin-bottom: 0;
+}
+
+.remove-liquidity-meta-row {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-1);
+    margin-top: 6px;
+}
+
+.remove-liquidity-meta-row .lp-usd-estimate {
+    margin-top: 0;
+}
+
+.remove-liquidity-meta-row .remove-liquidity-checkbox-label {
+    flex: 0 0 auto;
+    margin-left: auto;
+    margin-bottom: 0;
+    white-space: nowrap;
+}
+
 .remove-liquidity-section {
     margin-top: calc(var(--spacing-2) * -1);
 }

--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -643,6 +643,10 @@
     white-space: nowrap;
 }
 
+.remove-liquidity-amount-group .zap-balance-error {
+    margin-bottom: var(--spacing-2);
+}
+
 .remove-liquidity-section {
     margin-top: calc(var(--spacing-2) * -1);
 }

--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -655,10 +655,15 @@
     grid-column: 1 / -1;
     margin-top: 0;
     margin-bottom: var(--spacing-2);
+    min-height: 16px;
+}
+
+.remove-liquidity-meta-row .zap-balance-error-empty {
+    visibility: hidden;
 }
 
 .remove-liquidity-section {
-    margin-top: calc(var(--spacing-2) * -1);
+    margin-top: 0;
 }
 
 .remove-liquidity-settings-summary {
@@ -1087,5 +1092,20 @@
 
     .tab-label {
         display: none;
+    }
+
+    .remove-liquidity-meta-row .remove-liquidity-checkbox-label {
+        gap: 6px;
+        font-size: 13px;
+    }
+
+    .remove-liquidity-meta-row .checkmark {
+        width: 18px;
+        height: 18px;
+    }
+
+    .remove-liquidity-meta-row .checkbox-label input[type="checkbox"]:checked + .checkmark::after {
+        left: 5px;
+        top: 1px;
     }
 }

--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -632,6 +632,7 @@
     column-gap: var(--spacing-2);
     row-gap: 4px;
     margin-top: 6px;
+    min-height: 24px;
 }
 
 .remove-liquidity-meta-row .lp-usd-estimate {
@@ -639,10 +640,6 @@
     align-items: center;
     margin-top: 0;
     min-height: 24px;
-}
-
-.remove-liquidity-meta-row .lp-usd-estimate-empty {
-    visibility: hidden;
 }
 
 .remove-liquidity-meta-row .remove-liquidity-checkbox-label {

--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -923,6 +923,15 @@
     font-size: var(--font-size);
 }
 
+.remove-liquidity-action-btn,
+.remove-liquidity-action-btn:not(:disabled):hover {
+    box-shadow: none;
+}
+
+.remove-liquidity-action-btn:disabled {
+    opacity: 0.5;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
     .modal-content {

--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -106,7 +106,7 @@
 /* Modal Tabs */
 .modal-tabs {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(5, minmax(0, 1fr));
     border-bottom: 1px solid var(--divider);
 }
 

--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -616,6 +616,73 @@
     padding: 0 var(--spacing-1);
 }
 
+.remove-liquidity-checkbox-label {
+    justify-content: flex-start;
+}
+
+.remove-liquidity-section {
+    margin-top: calc(var(--spacing-2) * -1);
+}
+
+.remove-liquidity-settings {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(120px, 160px);
+    gap: var(--spacing-2);
+    align-items: start;
+}
+
+.remove-liquidity-slippage-row {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(58px, 1fr)) minmax(88px, 1fr);
+    gap: var(--spacing-1);
+    align-items: center;
+}
+
+.remove-liquidity-slippage-btn {
+    min-height: 36px;
+    padding: 0 var(--spacing-1);
+    border: 1px solid var(--divider);
+    border-radius: var(--border-radius);
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 13px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.remove-liquidity-slippage-btn:hover {
+    border-color: var(--primary-main);
+    color: var(--primary-main);
+}
+
+.remove-liquidity-slippage-btn.active {
+    background: var(--primary-main);
+    border-color: var(--primary-main);
+    color: white;
+}
+
+.remove-liquidity-custom-slippage {
+    min-height: 36px;
+    padding: 0 var(--spacing-1);
+}
+
+.remove-liquidity-deadline-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: var(--spacing-1);
+    align-items: center;
+}
+
+.remove-liquidity-deadline-unit {
+    color: var(--text-secondary);
+    font-size: 13px;
+    white-space: nowrap;
+}
+
+.remove-liquidity-preview-list {
+    min-height: 158px;
+}
+
 .zap-quote-card {
     margin-top: 10px;
     margin-bottom: 10px;
@@ -623,6 +690,10 @@
     background: var(--action-hover);
     border: 1px solid var(--divider);
     border-radius: var(--border-radius);
+}
+
+.remove-liquidity-preview-card {
+    margin-top: 0;
 }
 
 .zap-empty-state {
@@ -889,6 +960,15 @@
 
     .zap-custom-token-row {
         grid-template-columns: 1fr;
+    }
+
+    .remove-liquidity-settings,
+    .remove-liquidity-slippage-row {
+        grid-template-columns: 1fr;
+    }
+
+    .remove-liquidity-deadline-row {
+        grid-template-columns: minmax(0, 1fr) auto;
     }
 }
 

--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -626,24 +626,34 @@
 }
 
 .remove-liquidity-meta-row {
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
-    gap: var(--spacing-1);
+    column-gap: var(--spacing-2);
+    row-gap: 4px;
     margin-top: 6px;
 }
 
 .remove-liquidity-meta-row .lp-usd-estimate {
+    display: flex;
+    align-items: center;
     margin-top: 0;
+    min-height: 24px;
+}
+
+.remove-liquidity-meta-row .lp-usd-estimate-empty {
+    visibility: hidden;
 }
 
 .remove-liquidity-meta-row .remove-liquidity-checkbox-label {
     flex: 0 0 auto;
-    margin-left: auto;
-    margin-bottom: 0;
+    margin: 0;
     white-space: nowrap;
 }
 
-.remove-liquidity-amount-group .zap-balance-error {
+.remove-liquidity-meta-row .zap-balance-error {
+    grid-column: 1 / -1;
+    margin-top: 0;
     margin-bottom: var(--spacing-2);
 }
 

--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -1050,9 +1050,16 @@
         grid-template-columns: 1fr;
     }
 
-    .remove-liquidity-settings-panel,
-    .remove-liquidity-slippage-row {
+    .remove-liquidity-settings-panel {
         grid-template-columns: 1fr;
+    }
+
+    .remove-liquidity-slippage-row {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .remove-liquidity-custom-slippage {
+        grid-column: 1 / -1;
     }
 
     .remove-liquidity-deadline-row {

--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -594,6 +594,14 @@
     margin-bottom: var(--spacing-2);
 }
 
+.custom-slippage-error {
+    min-height: 16px;
+    line-height: 16px;
+    margin-top: var(--spacing-1);
+    margin-bottom: 0;
+    overflow-wrap: anywhere;
+}
+
 .zap-balance-error {
     margin-top: 4px;
     margin-bottom: 0;

--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -654,8 +654,6 @@
 .remove-liquidity-settings-label {
     color: var(--text-secondary);
     font-weight: var(--font-weight-normal);
-    text-decoration: underline dotted;
-    text-underline-offset: 3px;
 }
 
 .remove-liquidity-settings-panel {
@@ -859,26 +857,31 @@
     font-size: 12px;
 }
 
-.remove-liquidity-preview-list .zap-quote-row dt[title] {
+.remove-liquidity-preview-list .zap-quote-row dt[data-tooltip],
+.remove-liquidity-settings-panel .form-label[data-tooltip] {
     position: relative;
     cursor: help;
     text-decoration: underline dotted;
     text-underline-offset: 3px;
 }
 
-.remove-liquidity-preview-list .zap-quote-row dt[title]:focus {
+.remove-liquidity-preview-list .zap-quote-row dt[data-tooltip]:focus,
+.remove-liquidity-settings-panel .form-label[data-tooltip]:focus {
     outline: none;
     color: var(--primary-main);
 }
 
-.remove-liquidity-preview-list .zap-quote-row dt[title]:focus-visible {
+.remove-liquidity-preview-list .zap-quote-row dt[data-tooltip]:focus-visible,
+.remove-liquidity-settings-panel .form-label[data-tooltip]:focus-visible {
     outline: 2px solid var(--primary-main);
     outline-offset: 3px;
     border-radius: 3px;
 }
 
-.remove-liquidity-preview-list .zap-quote-row dt[title]:focus::after,
-.remove-liquidity-preview-list .zap-quote-row dt[title]:active::after {
+.remove-liquidity-preview-list .zap-quote-row dt[data-tooltip]:focus::after,
+.remove-liquidity-preview-list .zap-quote-row dt[data-tooltip]:active::after,
+.remove-liquidity-settings-panel .form-label[data-tooltip]:focus::after,
+.remove-liquidity-settings-panel .form-label[data-tooltip]:active::after {
     content: attr(data-tooltip);
     position: absolute;
     left: 0;

--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -624,11 +624,45 @@
     margin-top: calc(var(--spacing-2) * -1);
 }
 
-.remove-liquidity-settings {
+.remove-liquidity-settings-summary {
+    margin-bottom: var(--spacing-1);
+}
+
+.remove-liquidity-settings-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    min-height: 30px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: var(--font-weight-semibold);
+    cursor: pointer;
+}
+
+.remove-liquidity-settings-toggle:hover {
+    color: var(--primary-main);
+}
+
+.remove-liquidity-settings-toggle .material-icons {
+    font-size: 17px;
+}
+
+.remove-liquidity-settings-label {
+    color: var(--text-secondary);
+    font-weight: var(--font-weight-normal);
+    text-decoration: underline dotted;
+    text-underline-offset: 3px;
+}
+
+.remove-liquidity-settings-panel {
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(120px, 160px);
     gap: var(--spacing-2);
     align-items: start;
+    margin-bottom: var(--spacing-2);
 }
 
 .remove-liquidity-slippage-row {
@@ -680,7 +714,7 @@
 }
 
 .remove-liquidity-preview-list {
-    min-height: 158px;
+    min-height: 74px;
 }
 
 .zap-quote-card {
@@ -971,7 +1005,7 @@
         grid-template-columns: 1fr;
     }
 
-    .remove-liquidity-settings,
+    .remove-liquidity-settings-panel,
     .remove-liquidity-slippage-row {
         grid-template-columns: 1fr;
     }

--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -671,29 +671,6 @@
     align-items: center;
 }
 
-.remove-liquidity-slippage-btn {
-    min-height: 36px;
-    padding: 0 var(--spacing-1);
-    border: 1px solid var(--divider);
-    border-radius: var(--border-radius);
-    background: transparent;
-    color: var(--text-secondary);
-    font-size: 13px;
-    cursor: pointer;
-    transition: all 0.2s;
-}
-
-.remove-liquidity-slippage-btn:hover {
-    border-color: var(--primary-main);
-    color: var(--primary-main);
-}
-
-.remove-liquidity-slippage-btn.active {
-    background: var(--primary-main);
-    border-color: var(--primary-main);
-    color: white;
-}
-
 .remove-liquidity-custom-slippage {
     min-height: 36px;
     padding: 0 var(--spacing-1);

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -1738,13 +1738,25 @@ class StakingModalNew {
             && (this.isNativeZapToken(address) || (!!wrappedNativeAddress && normalizedAddress === wrappedNativeAddress));
     }
 
-    getRemoveLiquidityActionTokenAmount(token, outputToken) {
+    parseZapUsdValue(value) {
+        const parsed = Number(String(value ?? '').replace(/[$,]/g, ''));
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    getRemoveLiquidityActionTokenCandidate(token, outputToken) {
         if (!token?.amount || !this.isRemoveLiquidityOutputTokenAddress(token.address, outputToken)) {
             return null;
         }
 
         const amount = String(token.amount);
-        return /^\d+$/.test(amount) ? amount : null;
+        if (!/^\d+$/.test(amount)) {
+            return null;
+        }
+
+        return {
+            amount,
+            amountUsd: this.parseZapUsdValue(token.amountUsd ?? token.amount_usd)
+        };
     }
 
     getRemoveLiquidityActionOutputAmount(outputToken) {
@@ -1754,11 +1766,22 @@ class StakingModalNew {
             return null;
         }
 
-        const amounts = [];
+        const finalUsdEntry = this.getRemoveLiquidityQuoteSummaryEntry([
+            'zapDetails.finalAmountUsd',
+            'amountOutUsd',
+            'receivedUsd',
+            'routeSummary.amountOutUsd'
+        ], null);
+        const finalUsd = this.parseZapUsdValue(finalUsdEntry.value);
+        if (finalUsd === null) {
+            return null;
+        }
+
+        const candidates = [];
         const addTokenAmount = token => {
-            const amount = this.getRemoveLiquidityActionTokenAmount(token, outputToken);
-            if (amount) {
-                amounts.push(amount);
+            const candidate = this.getRemoveLiquidityActionTokenCandidate(token, outputToken);
+            if (candidate) {
+                candidates.push(candidate);
             }
         };
         const addTokens = tokens => {
@@ -1783,11 +1806,11 @@ class StakingModalNew {
             addTokens(action?.refund?.tokens);
         });
 
-        if (!amounts.length) {
-            return null;
-        }
-
-        return amounts.reduce((total, amount) => total + BigInt(amount), 0n).toString();
+        const tolerance = Math.max(0.01, Math.abs(finalUsd) * 0.02);
+        const finalCandidate = candidates.find(candidate =>
+            candidate.amountUsd !== null && Math.abs(candidate.amountUsd - finalUsd) <= tolerance
+        );
+        return finalCandidate?.amount || null;
     }
 
     getRemoveLiquidityEstimatedOutputEntry(outputToken, fallback = 'N/A') {

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -933,7 +933,7 @@ class StakingModalNew {
     setRemoveLiquidityDeadlineInput(value) {
         const digitsOnly = String(value ?? '').replace(/[^0-9]/g, '');
         if (!digitsOnly) {
-            this.removeLiquidityDeadlineMinutes = 1;
+            this.removeLiquidityDeadlineMinutes = window.CONFIG?.KYBER_ZAP?.DEFAULT_DEADLINE_MINUTES || 20;
             this.updateRemoveLiquidityPreviewPanel();
             return '';
         }

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -863,7 +863,15 @@ class StakingModalNew {
 
         const balanceError = this.getRemoveLiquidityBalanceError();
         errorElement.textContent = balanceError;
-        errorElement.hidden = !balanceError;
+        errorElement.hidden = false;
+        errorElement.classList.toggle('zap-balance-error-empty', !balanceError);
+        if (errorElement.setAttribute && errorElement.removeAttribute) {
+            if (balanceError) {
+                errorElement.removeAttribute('aria-hidden');
+            } else {
+                errorElement.setAttribute('aria-hidden', 'true');
+            }
+        }
     }
 
     getRemoveLiquidityCustomSlippageError(value = this.removeLiquidityCustomSlippage) {
@@ -3250,6 +3258,8 @@ class StakingModalNew {
         const activeRemoveLiquidityPercentage = [25, 50, 75, 100].find(percentage =>
             Math.abs(removeLiquidityPercentage - percentage) < 0.001
         );
+        const balanceErrorClass = balanceError ? '' : ' zap-balance-error-empty';
+        const balanceErrorAriaHidden = balanceError ? '' : ' aria-hidden="true"';
 
         return `
             <div class="balance-info">
@@ -3287,7 +3297,7 @@ class StakingModalNew {
                         <span class="checkmark"></span>
                         Convert to one preferred token
                     </label>
-                    <div id="remove-liquidity-balance-error" class="zap-field-error zap-balance-error" aria-live="polite" ${balanceError ? '' : 'hidden'}>${this.escapeHtml(balanceError)}</div>
+                    <div id="remove-liquidity-balance-error" class="zap-field-error zap-balance-error${balanceErrorClass}" aria-live="polite"${balanceErrorAriaHidden}>${this.escapeHtml(balanceError)}</div>
                 </div>
             </div>
 

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -702,10 +702,12 @@ class StakingModalNew {
         return estimate ? ` <span class="lp-usd-estimate">(${this.escapeHtml(estimate)})</span>` : '';
     }
 
-    renderLpUsdEstimateElement(id, amount) {
+    renderLpUsdEstimateElement(id, amount, { preserveSpace = false } = {}) {
         const estimate = this.formatLpUsdEstimate(amount);
-        const hiddenAttribute = estimate ? '' : ' hidden';
-        return `<div id="${id}" class="lp-usd-estimate" aria-live="polite"${hiddenAttribute}>${this.escapeHtml(estimate)}</div>`;
+        const hiddenAttribute = estimate || preserveSpace ? '' : ' hidden';
+        const emptyClass = !estimate && preserveSpace ? ' lp-usd-estimate-empty' : '';
+        const ariaHiddenAttribute = !estimate && preserveSpace ? ' aria-hidden="true"' : '';
+        return `<div id="${id}" class="lp-usd-estimate${emptyClass}" aria-live="polite"${ariaHiddenAttribute}${hiddenAttribute}>${this.escapeHtml(estimate)}</div>`;
     }
 
     getZapLpAmountForUsdEstimate(amount) {
@@ -3275,7 +3277,7 @@ class StakingModalNew {
                     inputmode="decimal"
                 >
                 <div class="remove-liquidity-meta-row">
-                    ${this.renderLpUsdEstimateElement('remove-liquidity-usd-estimate', this.removeLiquidityAmount)}
+                    ${this.renderLpUsdEstimateElement('remove-liquidity-usd-estimate', this.removeLiquidityAmount, { preserveSpace: true })}
                     <label class="checkbox-label remove-liquidity-checkbox-label">
                         <input
                             type="checkbox"
@@ -3285,8 +3287,8 @@ class StakingModalNew {
                         <span class="checkmark"></span>
                         Convert to one preferred token
                     </label>
+                    <div id="remove-liquidity-balance-error" class="zap-field-error zap-balance-error" aria-live="polite" ${balanceError ? '' : 'hidden'}>${this.escapeHtml(balanceError)}</div>
                 </div>
-                <div id="remove-liquidity-balance-error" class="zap-field-error zap-balance-error" aria-live="polite" ${balanceError ? '' : 'hidden'}>${this.escapeHtml(balanceError)}</div>
             </div>
 
             ${this.renderRemoveLiquidityControls()}
@@ -3302,7 +3304,7 @@ class StakingModalNew {
     }
 
     updateRemoveLiquidityUsdEstimate() {
-        this.updateLpUsdEstimate('remove-liquidity-usd-estimate', this.removeLiquidityAmount);
+        this.updateLpUsdEstimate('remove-liquidity-usd-estimate', this.removeLiquidityAmount, { preserveSpace: true });
     }
 
     formatRemoveLiquidityTokenAmount(amount, token) {
@@ -3714,12 +3716,20 @@ class StakingModalNew {
         }
     }
 
-    updateLpUsdEstimate(elementId, amount) {
+    updateLpUsdEstimate(elementId, amount, { preserveSpace = false } = {}) {
         const estimateElement = document.getElementById(elementId);
         if (estimateElement) {
             const estimate = this.formatLpUsdEstimate(amount);
             estimateElement.textContent = estimate;
-            estimateElement.hidden = !estimate;
+            estimateElement.hidden = !estimate && !preserveSpace;
+            estimateElement.classList.toggle('lp-usd-estimate-empty', !estimate && preserveSpace);
+            if (estimateElement.setAttribute && estimateElement.removeAttribute) {
+                if (!estimate && preserveSpace) {
+                    estimateElement.setAttribute('aria-hidden', 'true');
+                } else {
+                    estimateElement.removeAttribute('aria-hidden');
+                }
+            }
         }
     }
 

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -882,11 +882,22 @@ class StakingModalNew {
             return null;
         }
 
-        const tokens = [preview.token0, preview.token1];
-        const fromToken = tokens.find(token => String(token.symbol || '').toUpperCase() === 'LIB');
-        const toToken = tokens.find(token => String(token.symbol || '').toUpperCase() === 'USDT');
+        const chainId = this.getRemoveLiquidityChainId();
+        const chainConfig = window.CONFIG?.DEX_REMOVE_LIQUIDITY?.[String(chainId)]
+            || window.CONFIG?.DEX_REMOVE_LIQUIDITY?.[Number(chainId)]
+            || null;
+        const conversionConfig = chainConfig?.libToUsdtConversion || null;
+        const fromAddress = this.normalizeAddress(conversionConfig?.fromToken);
+        const toAddress = this.normalizeAddress(conversionConfig?.toToken);
+        if (!fromAddress || !toAddress) {
+            return null;
+        }
 
-        if (!fromToken || !toToken || this.normalizeAddress(fromToken.address) === this.normalizeAddress(toToken.address)) {
+        const tokens = [preview.token0, preview.token1];
+        const fromToken = tokens.find(token => this.normalizeAddress(token?.address) === fromAddress);
+        const toToken = tokens.find(token => this.normalizeAddress(token?.address) === toAddress);
+
+        if (!fromToken || !toToken || fromAddress === toAddress) {
             return null;
         }
 
@@ -4036,19 +4047,17 @@ class StakingModalNew {
         this.pendingOperations.removeLiquidity = false;
         this.setActionPhase('removeLiquidity', 'idle');
 
-        const postConversionBalance = await service.getTokenBalance({
-            tokenAddress: conversion.fromToken.address,
-            owner: userAddress,
-            provider
-        });
-        const actualAmountIn = postConversionBalance.sub(preConversionBalance);
-        if (actualAmountIn.lte(0)) {
-            const error = new Error(`No ${conversion.fromToken.symbol} was received to convert.`);
-            error.removeLiquidityCompleted = true;
-            throw error;
-        }
-
         try {
+            const postConversionBalance = await service.getTokenBalance({
+                tokenAddress: conversion.fromToken.address,
+                owner: userAddress,
+                provider
+            });
+            const actualAmountIn = postConversionBalance.sub(preConversionBalance);
+            if (actualAmountIn.lte(0)) {
+                throw new Error(`No ${conversion.fromToken.symbol} was received to convert.`);
+            }
+
             await this.executeRemoveLiquidityConversion({
                 service,
                 preview,
@@ -4125,11 +4134,14 @@ class StakingModalNew {
             console.log('✅ Home page data refreshed after remove liquidity');
         } catch (error) {
             console.error('❌ Remove liquidity failed:', error);
-            const fallbackMessage = error?.removeLiquidityCompleted
-                ? 'Liquidity was removed, but LIB conversion failed. Your returned tokens remain in your wallet.'
-                : 'Remove liquidity failed. Your LP tokens remain in your wallet.';
-            const errorMessage = error?.userMessage?.message || error?.message || fallbackMessage;
-            window.notificationManager?.error(errorMessage, {title: error?.userMessage?.title});
+            const detailMessage = error?.userMessage?.message || error?.message || '';
+            const partialSuccessMessage = 'Liquidity was removed, but LIB conversion failed. Your returned tokens remain in your wallet.';
+            const fallbackMessage = 'Remove liquidity failed. Your LP tokens remain in your wallet.';
+            const errorMessage = error?.removeLiquidityCompleted
+                ? (detailMessage ? `${partialSuccessMessage} Details: ${detailMessage}` : partialSuccessMessage)
+                : (detailMessage || fallbackMessage);
+            const errorTitle = error?.userMessage?.title || (error?.removeLiquidityCompleted ? 'Conversion failed' : undefined);
+            window.notificationManager?.error(errorMessage, {title: errorTitle});
             await this.loadUserBalances().catch(loadError => {
                 console.warn('Unable to refresh balances after remove-liquidity failure:', loadError.message);
             });

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -4510,19 +4510,19 @@ class StakingModalNew {
             this.setActionPhase('approveRemoveLiquidity', 'userApproval');
             window.notificationManager?.info('Approving router to spend LP tokens...');
 
-            await window.contractManager.executeTransactionOnce(async () => {
-                const tx = await service.approveIfNeeded({
-                    lpTokenAddress,
-                    spender: preview.adapter.routerAddress,
-                    liquidityRaw,
-                    signer
-                });
-                if (!tx) {
-                    throw new Error('Router allowance is already sufficient.');
-                }
-                console.log(`✅ Remove-liquidity approval sent: ${tx.hash}`);
-                return tx;
-            }, 'approveRemoveLiquidity');
+            const approvalTx = await service.approveIfNeeded({
+                lpTokenAddress,
+                spender: preview.adapter.routerAddress,
+                liquidityRaw,
+                signer
+            });
+
+            if (approvalTx) {
+                await window.contractManager.executeTransactionOnce(async () => {
+                    console.log(`✅ Remove-liquidity approval sent: ${approvalTx.hash}`);
+                    return approvalTx;
+                }, 'approveRemoveLiquidity');
+            }
 
             this.pendingOperations.approveRemoveLiquidity = false;
             this.setActionPhase('approveRemoveLiquidity', 'idle');

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -3320,7 +3320,7 @@ class StakingModalNew {
                             ${slippageOptions.map(option => `
                                 <button
                                     type="button"
-                                    class="remove-liquidity-slippage-btn ${this.removeLiquiditySlippageBps === option && !this.removeLiquidityCustomSlippage ? 'active' : ''}"
+                                    class="zap-slippage-btn remove-liquidity-slippage-btn ${this.removeLiquiditySlippageBps === option && !this.removeLiquidityCustomSlippage ? 'active' : ''}"
                                     data-slippage="${option}"
                                 >
                                     ${(option / 100).toFixed(option < 10 ? 2 : 1)}%
@@ -3328,7 +3328,7 @@ class StakingModalNew {
                             `).join('')}
                             <button
                                 type="button"
-                                class="remove-liquidity-slippage-btn ${this.isRemoveLiquidityCustomSlippageActive() ? 'active' : ''}"
+                                class="zap-slippage-btn remove-liquidity-slippage-btn ${this.isRemoveLiquidityCustomSlippageActive() ? 'active' : ''}"
                                 data-slippage="custom"
                             >
                                 Custom
@@ -3558,28 +3558,7 @@ class StakingModalNew {
                 )
             );
 
-            return `
-                <div class="${cardClass}">
-                    <div class="zap-quote-header">
-                        <div class="zap-route-summary">${this.escapeHtml(summary)}</div>
-                        <div class="zap-refresh-controls">
-                            <button
-                                type="button"
-                                class="zap-refresh-btn"
-                                onclick="safeModalFetchRemoveLiquidityPreview()"
-                                title="Refresh Kyber zap-out preview"
-                                aria-label="Refresh Kyber zap-out preview"
-                                ${!this.canFetchRemoveLiquidityPreview() || isLoading ? 'disabled' : ''}
-                            >
-                                <span class="material-icons">sync</span>
-                            </button>
-                        </div>
-                    </div>
-                    <dl class="zap-quote-list remove-liquidity-preview-list">
-                        ${rows.join('')}
-                    </dl>
-                </div>
-            `;
+            return this.renderRemoveLiquidityPreviewCard(cardClass, summary, rows, isLoading, 'Refresh Kyber zap-out preview');
         }
 
         let summary = this.removeLiquidityAmount
@@ -3634,6 +3613,10 @@ class StakingModalNew {
             )
         ];
 
+        return this.renderRemoveLiquidityPreviewCard(cardClass, summary, rows, isLoading, 'Refresh remove-liquidity preview');
+    }
+
+    renderRemoveLiquidityPreviewCard(cardClass, summary, rows, isLoading, refreshLabel) {
         return `
             <div class="${cardClass}">
                 <div class="zap-quote-header">
@@ -3643,8 +3626,8 @@ class StakingModalNew {
                             type="button"
                             class="zap-refresh-btn"
                             onclick="safeModalFetchRemoveLiquidityPreview()"
-                            title="Refresh remove-liquidity preview"
-                            aria-label="Refresh remove-liquidity preview"
+                            title="${refreshLabel}"
+                            aria-label="${refreshLabel}"
                             ${!this.canFetchRemoveLiquidityPreview() || isLoading ? 'disabled' : ''}
                         >
                             <span class="material-icons">sync</span>
@@ -4375,6 +4358,7 @@ class StakingModalNew {
     }
 
     async approveRemoveLiquidityZapOutIfNeeded(lpTokenAddress, routerAddress, liquidityRaw) {
+        const service = this.getRemoveLiquidityService();
         const provider = window.contractManager?.provider || window.walletManager?.provider;
         const signer = window.contractManager?.signer;
         if (!provider || !signer) {
@@ -4382,13 +4366,12 @@ class StakingModalNew {
         }
 
         const userAddress = await signer.getAddress();
-        const erc20Abi = [
-            'function allowance(address owner,address spender) view returns (uint256)',
-            'function approve(address spender,uint256 amount) returns (bool)'
-        ];
-        const lpReadContract = new window.ethers.Contract(lpTokenAddress, erc20Abi, provider);
-        const allowance = await lpReadContract.allowance(userAddress, routerAddress);
-
+        const allowance = await service.getAllowance({
+            lpTokenAddress,
+            owner: userAddress,
+            spender: routerAddress,
+            provider
+        });
         if (allowance.gte(liquidityRaw)) {
             return null;
         }
@@ -4397,6 +4380,7 @@ class StakingModalNew {
         this.setActionPhase('approveRemoveLiquidityZapOut', 'userApproval');
         window.notificationManager?.info('Approving Kyber to spend LP tokens...');
 
+        const erc20Abi = ['function approve(address spender,uint256 amount) returns (bool)'];
         const lpWithSigner = new window.ethers.Contract(lpTokenAddress, erc20Abi, signer);
         const result = await window.contractManager.executeTransactionOnce(async () => {
             const tx = await lpWithSigner.approve(routerAddress, liquidityRaw);

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -3268,8 +3268,11 @@ class StakingModalNew {
         }
 
         try {
-            const slippageBps = BigInt(Math.trunc(Number(this.removeLiquiditySlippageBps) || 0));
-            const minAmount = (BigInt(valueText) * (10000n - slippageBps)) / 10000n;
+            const service = this.getRemoveLiquidityService();
+            const minAmount = service.calculateMinAmount(
+                service.toBigNumber(valueText),
+                this.removeLiquiditySlippageBps
+            );
             return this.formatZapDisplayAmount(minAmount.toString(), token.decimals ?? 18, token.symbol || '');
         } catch (error) {
             return fallback;

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -1069,6 +1069,12 @@ class StakingModalNew {
                     slippageBps: this.removeLiquiditySlippageBps,
                     platform: this.currentPair?.platform
                 });
+                this.logRemoveLiquidityZapOutFeeDebug({
+                    payload,
+                    outputToken,
+                    tokenOutAddress,
+                    liquidityRaw
+                });
 
                 preview = {
                     ...payload,
@@ -1976,6 +1982,22 @@ class StakingModalNew {
         return this.formatZapDisplayAmount(value, decimals, symbol);
     }
 
+    formatZapFeeDetailsDisplay(feeDetails) {
+        const details = Array.isArray(feeDetails) ? feeDetails : (feeDetails ? [feeDetails] : []);
+        if (!details.length) {
+            return 'N/A';
+        }
+
+        const nonZeroDetails = details.filter(detail => !this.isZeroZapAmount(detail?.amount));
+        if (!nonZeroDetails.length) {
+            return 'None';
+        }
+
+        return nonZeroDetails
+            .map(detail => this.formatZapFeeDisplay(detail.amount, detail.decimals, detail.symbol))
+            .join(' + ');
+    }
+
     getZapTokenByAddress(address) {
         if (!address) {
             return null;
@@ -1992,7 +2014,7 @@ class StakingModalNew {
         }) || null;
     }
 
-    getKyberProtocolFeeDetails(data, fallbackToken = null, tokenResolver = () => null) {
+    getKyberProtocolFeeDetailsList(data, fallbackToken = null, tokenResolver = () => null) {
         const protocolFeeSources = [];
         const addProtocolFeeSource = (source) => {
             if (source && typeof source === 'object') {
@@ -2010,39 +2032,55 @@ class StakingModalNew {
         }
 
         for (const source of protocolFeeSources) {
-            const tokenFee = Array.isArray(source?.tokens)
-                ? (source.tokens.find(token => !this.isZeroZapAmount(token?.amount)) || source.tokens[0])
-                : null;
-            const amount = tokenFee?.amount ?? source?.amount ?? null;
+            if (Array.isArray(source?.tokens) && source.tokens.length) {
+                const tokenDetails = source.tokens
+                    .filter(token => token?.amount !== null && token?.amount !== undefined)
+                    .map(token => {
+                        const knownToken = tokenResolver(token?.address);
+                        return {
+                            amount: token.amount,
+                            symbol: token?.symbol || knownToken?.symbol || this.formatAddress(token?.address) || '',
+                            decimals: Number(token?.decimals ?? knownToken?.decimals ?? 18) || 18
+                        };
+                    });
 
-            if (amount !== null && amount !== undefined) {
-                const knownToken = tokenResolver(tokenFee?.address);
-                return {
-                    amount,
-                    symbol: tokenFee?.symbol || knownToken?.symbol || fallbackToken?.symbol || '',
-                    decimals: Number(tokenFee?.decimals ?? knownToken?.decimals ?? fallbackToken?.decimals ?? 18) || 18
-                };
+                if (tokenDetails.length) {
+                    return tokenDetails;
+                }
+            }
+
+            if (source?.amount !== null && source?.amount !== undefined) {
+                return [{
+                    amount: source.amount,
+                    symbol: fallbackToken?.symbol || '',
+                    decimals: fallbackToken?.decimals ?? 18
+                }];
             }
         }
 
         const fallbackAmount = this.getRouteSummaryEntry(data, ['zapDetails.feeAmount', 'fee'], null).value;
         if (fallbackAmount !== null && fallbackAmount !== undefined) {
-            return {
+            return [{
                 amount: fallbackAmount,
                 symbol: fallbackToken?.symbol || '',
                 decimals: fallbackToken?.decimals ?? 18
-            };
+            }];
         }
 
         if (data?.protocolFee !== null && data?.protocolFee !== undefined && typeof data.protocolFee !== 'object') {
-            return {
+            return [{
                 amount: data.protocolFee,
                 symbol: fallbackToken?.symbol || '',
                 decimals: fallbackToken?.decimals ?? 18
-            };
+            }];
         }
 
         return null;
+    }
+
+    getKyberProtocolFeeDetails(data, fallbackToken = null, tokenResolver = () => null) {
+        const feeDetails = this.getKyberProtocolFeeDetailsList(data, fallbackToken, tokenResolver);
+        return Array.isArray(feeDetails) ? feeDetails[0] || null : feeDetails;
     }
 
     getZapProtocolFeeDetails(data = this.getZapRouteData()) {
@@ -2054,11 +2092,105 @@ class StakingModalNew {
     }
 
     getRemoveLiquidityProtocolFeeDetails(data = this.getRemoveLiquidityRouteData()) {
-        return this.getKyberProtocolFeeDetails(
+        return this.getKyberProtocolFeeDetailsList(
             data,
             this.removeLiquiditySelectedOutputToken,
             address => this.getRemoveLiquidityOutputTokenByAddress(address)
         );
+    }
+
+    getKyberProtocolFeeSources(data) {
+        const protocolFeeSources = [];
+        const addProtocolFeeSource = (path, source) => {
+            if (source && typeof source === 'object') {
+                protocolFeeSources.push({ path, source });
+            }
+        };
+
+        addProtocolFeeSource('zapDetails.protocolFee', data?.zapDetails?.protocolFee);
+        addProtocolFeeSource('protocolFee', data?.protocolFee);
+
+        if (Array.isArray(data?.zapDetails?.actions)) {
+            data.zapDetails.actions.forEach((action, index) => {
+                addProtocolFeeSource(`zapDetails.actions[${index}].protocolFee`, action?.protocolFee);
+            });
+        }
+
+        return protocolFeeSources;
+    }
+
+    getKyberZapActionDebugSummary(data) {
+        const actions = Array.isArray(data?.zapDetails?.actions) ? data.zapDetails.actions : [];
+        const summarizeToken = token => token ? {
+            address: token.address ?? null,
+            symbol: token.symbol ?? null,
+            decimals: token.decimals ?? null,
+            amount: token.amount ?? null,
+            amountUsd: token.amountUsd ?? token.amount_usd ?? null
+        } : null;
+        const summarizeTokens = tokens => Array.isArray(tokens)
+            ? tokens.map(summarizeToken).filter(Boolean)
+            : [];
+        const summarizeSwap = swap => ({
+            tokenIn: summarizeToken(swap?.tokenIn),
+            tokenOut: summarizeToken(swap?.tokenOut)
+        });
+
+        return actions.map((action, index) => ({
+            index,
+            type: action?.type ?? null,
+            keys: action && typeof action === 'object' ? Object.keys(action) : [],
+            removeLiquidityTokens: summarizeTokens(action?.removeLiquidity?.tokens),
+            removeLiquidityToken0: summarizeToken(action?.removeLiquidity?.token0),
+            removeLiquidityToken1: summarizeToken(action?.removeLiquidity?.token1),
+            protocolFeeTokens: summarizeTokens(action?.protocolFee?.tokens),
+            aggregatorSwaps: Array.isArray(action?.aggregatorSwap?.swaps)
+                ? action.aggregatorSwap.swaps.map(summarizeSwap)
+                : [],
+            poolSwaps: Array.isArray(action?.poolSwap?.swaps)
+                ? action.poolSwap.swaps.map(summarizeSwap)
+                : [],
+            refundTokens: summarizeTokens(action?.refund?.tokens)
+        }));
+    }
+
+    logRemoveLiquidityZapOutFeeDebug({ payload, outputToken, tokenOutAddress, liquidityRaw }) {
+        const data = this.getKyberZapService().getRouteData(payload);
+        const feeSources = this.getKyberProtocolFeeSources(data);
+        const protocolFeeTokenRows = feeSources.flatMap(({ path, source }) => (
+            Array.isArray(source?.tokens)
+                ? source.tokens.map(token => ({
+                    path,
+                    address: token?.address ?? null,
+                    symbol: token?.symbol ?? null,
+                    decimals: token?.decimals ?? null,
+                    amount: token?.amount ?? null,
+                    amountUsd: token?.amountUsd ?? token?.amount_usd ?? null
+                }))
+                : [{
+                    path,
+                    address: null,
+                    symbol: null,
+                    decimals: null,
+                    amount: source?.amount ?? null,
+                    amountUsd: null
+                }]
+        ));
+
+        console.info('[Kyber zap-out fee debug]', {
+            selectedOutputToken: outputToken ? {
+                address: outputToken.address,
+                symbol: outputToken.symbol,
+                decimals: outputToken.decimals
+            } : null,
+            tokenOutAddress,
+            liquidityRaw: liquidityRaw?.toString?.() || String(liquidityRaw || ''),
+            displayedFeeDetails: this.getRemoveLiquidityProtocolFeeDetails(data),
+            protocolFeeTokenRows,
+            actionSummary: this.getKyberZapActionDebugSummary(data),
+            routeKeys: data && typeof data === 'object' ? Object.keys(data) : [],
+            zapDetailsKeys: data?.zapDetails && typeof data.zapDetails === 'object' ? Object.keys(data.zapDetails) : []
+        });
     }
 
     formatZapBalanceDisplay(balance, token) {
@@ -3302,7 +3434,7 @@ class StakingModalNew {
     }
 
     renderRemoveLiquidityControls() {
-        const slippageOptions = [5, 10, 50, 100];
+        const slippageOptions = [10, 50, 100];
         const slippageDisplay = `${(Number(this.removeLiquiditySlippageBps) / 100).toFixed(2)}%`;
         const settingsPanel = this.removeLiquiditySettingsOpen ? `
                 <div class="remove-liquidity-settings-panel">
@@ -3517,8 +3649,7 @@ class StakingModalNew {
                     ? pendingValue
                     : this.formatRemoveLiquidityMinOutputAmount(outputEntry.value, outputToken, pendingValue);
                 priceImpactDisplay = priceImpactEntry.value === pendingValue ? pendingValue : this.formatZapPercent(priceImpactEntry);
-                const feeDetails = this.getRemoveLiquidityProtocolFeeDetails(data);
-                feeDisplay = feeDetails ? this.formatZapFeeDisplay(feeDetails.amount, feeDetails.decimals, feeDetails.symbol) : 'N/A';
+                feeDisplay = this.formatZapFeeDetailsDisplay(this.getRemoveLiquidityProtocolFeeDetails(data));
                 summary = `Kyber zap-out to ${outputSymbol}`;
             }
 
@@ -3916,7 +4047,7 @@ class StakingModalNew {
                 ? lpAmountDisplay
                 : `${lpAmountDisplay} (${lpUsdEstimate})`;
             const feeDetails = this.getZapProtocolFeeDetails(data);
-            feeDisplay = feeDetails ? this.formatZapFeeDisplay(feeDetails.amount, feeDetails.decimals, feeDetails.symbol) : 'N/A';
+            feeDisplay = this.formatZapFeeDetailsDisplay(feeDetails);
             const priceImpact = this.getZapQuoteSummaryEntry([
                 'zapDetails.priceImpact',
                 'zapDetails.priceImpactPcm',
@@ -4036,6 +4167,7 @@ class StakingModalNew {
             this.updateSlider('remove-liquidity');
 
             this.updateRemoveLiquidityUsdEstimate();
+            this.updateRemoveLiquidityBalanceError();
             this.resetRemoveLiquidityPreview();
             this.debounceRemoveLiquidityPreview();
             this.updateButtonStates();
@@ -4097,6 +4229,7 @@ class StakingModalNew {
             const input = document.getElementById('remove-liquidity-amount-input');
             if (input) input.value = amount;
             this.updateRemoveLiquidityUsdEstimate();
+            this.updateRemoveLiquidityBalanceError();
             this.resetRemoveLiquidityPreview();
             this.debounceRemoveLiquidityPreview();
             this.updateButtonStates();

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -1751,8 +1751,7 @@ class StakingModalNew {
         return this.getZapQuoteSummaryEntry(paths, fallback).value;
     }
 
-    getZapQuoteSummaryEntry(paths, fallback = 'N/A') {
-        const data = this.getZapRouteData();
+    getRouteSummaryEntry(data, paths, fallback = 'N/A') {
         for (const path of paths) {
             const value = path.split('.').reduce((current, key) => current?.[key], data);
             if (value !== undefined && value !== null && value !== '') {
@@ -1762,15 +1761,12 @@ class StakingModalNew {
         return { value: fallback, path: null };
     }
 
+    getZapQuoteSummaryEntry(paths, fallback = 'N/A') {
+        return this.getRouteSummaryEntry(this.getZapRouteData(), paths, fallback);
+    }
+
     getRemoveLiquidityQuoteSummaryEntry(paths, fallback = 'N/A') {
-        const data = this.getRemoveLiquidityRouteData();
-        for (const path of paths) {
-            const value = path.split('.').reduce((current, key) => current?.[key], data);
-            if (value !== undefined && value !== null && value !== '') {
-                return { value, path };
-            }
-        }
-        return { value: fallback, path: null };
+        return this.getRouteSummaryEntry(this.getRemoveLiquidityRouteData(), paths, fallback);
     }
 
     isRemoveLiquidityOutputTokenAddress(address, outputToken = this.removeLiquiditySelectedOutputToken) {
@@ -1788,6 +1784,16 @@ class StakingModalNew {
         const wrappedNativeAddress = service.normalizeAddress(this.getKyberZapNetworkConfig()?.WRAPPED_NATIVE_TOKEN_ADDRESS);
         return this.isNativeZapToken(outputToken.address)
             && (this.isNativeZapToken(address) || (!!wrappedNativeAddress && normalizedAddress === wrappedNativeAddress));
+    }
+
+    getRemoveLiquidityOutputTokenByAddress(address) {
+        if (!address) {
+            return null;
+        }
+
+        return this.removeLiquidityOutputTokens.find(token =>
+            this.isRemoveLiquidityOutputTokenAddress(address, token)
+        ) || null;
     }
 
     parseZapUsdValue(value) {
@@ -1986,7 +1992,7 @@ class StakingModalNew {
         }) || null;
     }
 
-    getZapProtocolFeeDetails(data = this.getZapRouteData()) {
+    getKyberProtocolFeeDetails(data, fallbackToken = null, tokenResolver = () => null) {
         const protocolFeeSources = [];
         const addProtocolFeeSource = (source) => {
             if (source && typeof source === 'object') {
@@ -2010,33 +2016,49 @@ class StakingModalNew {
             const amount = tokenFee?.amount ?? source?.amount ?? null;
 
             if (amount !== null && amount !== undefined) {
-                const knownToken = this.getZapTokenByAddress(tokenFee?.address);
+                const knownToken = tokenResolver(tokenFee?.address);
                 return {
                     amount,
-                    symbol: tokenFee?.symbol || knownToken?.symbol || this.zapSelectedToken?.symbol || '',
-                    decimals: Number(tokenFee?.decimals ?? knownToken?.decimals ?? this.zapSelectedToken?.decimals ?? 18) || 18
+                    symbol: tokenFee?.symbol || knownToken?.symbol || fallbackToken?.symbol || '',
+                    decimals: Number(tokenFee?.decimals ?? knownToken?.decimals ?? fallbackToken?.decimals ?? 18) || 18
                 };
             }
         }
 
-        const fallbackAmount = this.getZapQuoteSummaryValue(['zapDetails.feeAmount', 'fee'], null);
+        const fallbackAmount = this.getRouteSummaryEntry(data, ['zapDetails.feeAmount', 'fee'], null).value;
         if (fallbackAmount !== null && fallbackAmount !== undefined) {
             return {
                 amount: fallbackAmount,
-                symbol: this.zapSelectedToken?.symbol || '',
-                decimals: this.zapSelectedToken?.decimals ?? 18
+                symbol: fallbackToken?.symbol || '',
+                decimals: fallbackToken?.decimals ?? 18
             };
         }
 
         if (data?.protocolFee !== null && data?.protocolFee !== undefined && typeof data.protocolFee !== 'object') {
             return {
                 amount: data.protocolFee,
-                symbol: this.zapSelectedToken?.symbol || '',
-                decimals: this.zapSelectedToken?.decimals ?? 18
+                symbol: fallbackToken?.symbol || '',
+                decimals: fallbackToken?.decimals ?? 18
             };
         }
 
         return null;
+    }
+
+    getZapProtocolFeeDetails(data = this.getZapRouteData()) {
+        return this.getKyberProtocolFeeDetails(
+            data,
+            this.zapSelectedToken,
+            address => this.getZapTokenByAddress(address)
+        );
+    }
+
+    getRemoveLiquidityProtocolFeeDetails(data = this.getRemoveLiquidityRouteData()) {
+        return this.getKyberProtocolFeeDetails(
+            data,
+            this.removeLiquiditySelectedOutputToken,
+            address => this.getRemoveLiquidityOutputTokenByAddress(address)
+        );
     }
 
     formatZapBalanceDisplay(balance, token) {
@@ -3473,12 +3495,14 @@ class StakingModalNew {
             let estimatedOutput = pendingValue;
             let minimumReceivedDisplay = pendingValue;
             let priceImpactDisplay = pendingValue;
+            let feeDisplay = pendingValue;
 
             if (isLoading) {
                 summary = 'Loading Kyber zap-out route...';
             } else if (isError) {
                 summary = balanceError || this.removeLiquidityPreviewError || 'Unable to fetch a Kyber zap-out preview.';
             } else if (hasPreview) {
+                const data = this.getRemoveLiquidityRouteData();
                 const outputEntry = this.getRemoveLiquidityEstimatedOutputEntry(outputToken, pendingValue);
                 const priceImpactEntry = this.getRemoveLiquidityQuoteSummaryEntry([
                     'zapDetails.priceImpact',
@@ -3493,6 +3517,8 @@ class StakingModalNew {
                     ? pendingValue
                     : this.formatRemoveLiquidityMinOutputAmount(outputEntry.value, outputToken, pendingValue);
                 priceImpactDisplay = priceImpactEntry.value === pendingValue ? pendingValue : this.formatZapPercent(priceImpactEntry);
+                const feeDetails = this.getRemoveLiquidityProtocolFeeDetails(data);
+                feeDisplay = feeDetails ? this.formatZapFeeDisplay(feeDetails.amount, feeDetails.decimals, feeDetails.symbol) : 'N/A';
                 summary = `Kyber zap-out to ${outputSymbol}`;
             }
 
@@ -3517,6 +3543,12 @@ class StakingModalNew {
                     minimumReceivedDisplay,
                     '',
                     'Transaction reverts if the final output is below this value after max slippage.'
+                ),
+                this.renderZapQuoteRow(
+                    'Kyber Zap Fee',
+                    feeDisplay,
+                    '',
+                    'Fee reported by the Kyber zap-out route, if one is included.'
                 ),
                 this.renderZapQuoteRow(
                     'Price impact',

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -1738,25 +1738,25 @@ class StakingModalNew {
             && (this.isNativeZapToken(address) || (!!wrappedNativeAddress && normalizedAddress === wrappedNativeAddress));
     }
 
-    getZapActionTokenAmount(token, outputToken) {
-        if (!token || !this.isRemoveLiquidityOutputTokenAddress(token.address, outputToken)) {
+    getRemoveLiquidityActionTokenAmount(token, outputToken) {
+        if (!token?.amount || !this.isRemoveLiquidityOutputTokenAddress(token.address, outputToken)) {
             return null;
         }
 
-        const amount = token.amount ?? token.amountRaw ?? token.value ?? null;
-        return amount === undefined || amount === null || amount === '' ? null : String(amount);
+        const amount = String(token.amount);
+        return /^\d+$/.test(amount) ? amount : null;
     }
 
-    collectRemoveLiquidityOutputAmounts(outputToken = this.removeLiquiditySelectedOutputToken) {
+    getRemoveLiquidityActionOutputAmount(outputToken) {
         const data = this.getRemoveLiquidityRouteData();
         const actions = data?.zapDetails?.actions;
         if (!Array.isArray(actions)) {
-            return [];
+            return null;
         }
 
         const amounts = [];
         const addTokenAmount = token => {
-            const amount = this.getZapActionTokenAmount(token, outputToken);
+            const amount = this.getRemoveLiquidityActionTokenAmount(token, outputToken);
             if (amount) {
                 amounts.push(amount);
             }
@@ -1768,39 +1768,26 @@ class StakingModalNew {
         };
         const addSwapOutputs = swapAction => {
             if (Array.isArray(swapAction?.swaps)) {
-                swapAction.swaps.forEach(swap => addTokenAmount(swap?.tokenOut || swap?.token_out));
+                swapAction.swaps.forEach(swap => addTokenAmount(swap?.tokenOut));
             }
         };
 
         actions.forEach(action => {
-            const removeLiquidity = action?.removeLiquidity || action?.remove_liquidity;
+            const removeLiquidity = action?.removeLiquidity;
             addTokens(removeLiquidity?.tokens);
             addTokenAmount(removeLiquidity?.token0);
             addTokenAmount(removeLiquidity?.token1);
 
-            addSwapOutputs(action?.aggregatorSwap || action?.aggregator_swap);
-            addSwapOutputs(action?.poolSwap || action?.pool_swap);
-            addTokens((action?.refund || action?.refundAction || action?.refund_action)?.tokens);
+            addSwapOutputs(action?.aggregatorSwap);
+            addSwapOutputs(action?.poolSwap);
+            addTokens(action?.refund?.tokens);
         });
 
-        return amounts;
-    }
-
-    sumZapRawAmounts(amounts) {
         if (!amounts.length) {
             return null;
         }
 
-        if (amounts.every(amount => /^\d+$/.test(String(amount)))) {
-            return amounts.reduce((total, amount) => total + BigInt(amount), 0n).toString();
-        }
-
-        const numericAmounts = amounts.map(Number);
-        if (numericAmounts.every(Number.isFinite)) {
-            return numericAmounts.reduce((total, amount) => total + amount, 0).toString();
-        }
-
-        return amounts[0];
+        return amounts.reduce((total, amount) => total + BigInt(amount), 0n).toString();
     }
 
     getRemoveLiquidityEstimatedOutputEntry(outputToken, fallback = 'N/A') {
@@ -1815,7 +1802,7 @@ class StakingModalNew {
             return directEntry;
         }
 
-        const actionAmount = this.sumZapRawAmounts(this.collectRemoveLiquidityOutputAmounts(outputToken));
+        const actionAmount = this.getRemoveLiquidityActionOutputAmount(outputToken);
         return actionAmount
             ? { value: actionAmount, path: 'zapDetails.actions' }
             : { value: fallback, path: null };

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -1491,10 +1491,7 @@ class StakingModalNew {
         this.zapCustomSlippageError = this.getZapCustomSlippageError(sanitizedValue);
 
         if (this.zapCustomSlippageError) {
-            this.resetZapQuoteState({
-                status: 'error',
-                error: this.zapCustomSlippageError
-            });
+            this.resetZapQuoteState();
             this.stopZapQuoteAutoRefresh();
             this.updateZapQuotePanel();
             this.updateZapButton();

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -3356,7 +3356,7 @@ class StakingModalNew {
                             title="Maximum output movement allowed before the transaction reverts."
                         >Max slippage:</span>
                         <strong>${slippageDisplay}</strong>
-                        <span class="material-icons" aria-hidden="true">${this.removeLiquiditySettingsOpen ? 'expand_less' : 'expand_more'}</span>
+                        <span class="material-icons" aria-hidden="true">settings</span>
                     </button>
                 </div>
                 ${settingsPanel}
@@ -3811,7 +3811,10 @@ class StakingModalNew {
     }
 
     renderZapQuoteRow(label, value, riskClass = '', title = '') {
-        const titleAttribute = title ? ` title="${this.escapeHtml(title)}"` : '';
+        const escapedTitle = this.escapeHtml(title);
+        const titleAttribute = title
+            ? ` title="${escapedTitle}" data-tooltip="${escapedTitle}" tabindex="0" role="button" aria-label="${this.escapeHtml(`${label}: ${title}`)}"`
+            : '';
         return `
                     <div class="zap-quote-row${riskClass ? ` ${riskClass}` : ''}">
                         <dt${titleAttribute}>${this.escapeHtml(label)}</dt>

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -816,6 +816,15 @@ class StakingModalNew {
         this.updateRemoveLiquidityButton();
     }
 
+    getRemoveLiquidityPreviewErrorMessage(error) {
+        const message = error?.message || String(error || '');
+        if (/remove liquidity\s*=\s*\d+\s*>\s*position liquidity\s*=\s*0/i.test(message)) {
+            return 'Refresh your balance or try a smaller amount.';
+        }
+
+        return message || 'Unable to preview remove liquidity.';
+    }
+
     getRemoveLiquidityAmountRaw() {
         if (!this.removeLiquidityAmount || parseFloat(this.removeLiquidityAmount) <= 0) {
             return null;
@@ -1056,7 +1065,7 @@ class StakingModalNew {
             console.error('Failed to preview remove liquidity:', error);
             this.removeLiquidityPreview = null;
             this.removeLiquidityPreviewStatus = 'error';
-            this.removeLiquidityPreviewError = error.message || 'Unable to preview remove liquidity.';
+            this.removeLiquidityPreviewError = this.getRemoveLiquidityPreviewErrorMessage(error);
         } finally {
             if (requestId === this.removeLiquidityPreviewRequestId) {
                 this.updateRemoveLiquidityPreviewPanel();

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -47,6 +47,7 @@ class StakingModalNew {
         // V2 remove-liquidity state
         this.removeLiquidityService = window.V2RemoveLiquidityService ? new window.V2RemoveLiquidityService() : null;
         this.removeLiquidityEnabled = false;
+        this.removeLiquidityAmount = '';
         this.removeLiquidityPreview = null;
         this.removeLiquidityPreviewStatus = 'idle';
         this.removeLiquidityPreviewError = '';
@@ -154,8 +155,12 @@ class StakingModalNew {
             this.updateStakeButton();
         }
 
-        if (action === 'unstake' || action === 'approveRemoveLiquidity' || action === 'removeLiquidity') {
+        if (action === 'unstake') {
             this.updateUnstakeButton();
+        }
+
+        if (action === 'approveRemoveLiquidity' || action === 'removeLiquidity') {
+            this.updateRemoveLiquidityButton();
         }
 
         if (action === 'claim') {
@@ -249,6 +254,10 @@ class StakingModalNew {
                             <span class="material-icons" aria-hidden="true">redeem</span>
                             <span class="tab-label">Claim</span>
                         </button>
+                        <button class="tab-button" aria-label="Remove LP" data-tab="remove-liquidity">
+                            <span class="material-icons" aria-hidden="true">swap_horiz</span>
+                            <span class="tab-label">Remove LP</span>
+                        </button>
                     </div>
                     
                     <div class="modal-body">
@@ -329,6 +338,16 @@ class StakingModalNew {
                 this.unstakeAmount = sanitizedValue;
                 this.updateSlider('unstake');
                 this.updateUnstakeUsdEstimate();
+            }
+
+            if (e.target.id === 'remove-liquidity-amount-input') {
+                const sanitizedValue = this.applyDecimalLimit(e.target.value, this.userBalanceDecimals);
+                if (sanitizedValue !== e.target.value) {
+                    e.target.value = sanitizedValue;
+                }
+                this.removeLiquidityAmount = sanitizedValue;
+                this.updateSlider('remove-liquidity');
+                this.updateRemoveLiquidityUsdEstimate();
                 this.resetRemoveLiquidityPreview();
                 this.debounceRemoveLiquidityPreview();
             }
@@ -472,6 +491,7 @@ class StakingModalNew {
         // Reset form inputs
         this.stakeAmount = '';
         this.unstakeAmount = '';
+        this.removeLiquidityAmount = '';
         this.zapInputAmount = '';
         this.zapQuote = null;
         this.zapQuoteStatus = 'idle';
@@ -487,6 +507,7 @@ class StakingModalNew {
         this.zapQuoteRequestId += 1;
         this.stopZapQuoteAutoRefresh();
         this.removeLiquidityEnabled = false;
+        this.removeLiquidityAmount = '';
         this.removeLiquidityPreview = null;
         this.removeLiquidityPreviewStatus = 'idle';
         this.removeLiquidityPreviewError = '';
@@ -538,7 +559,7 @@ class StakingModalNew {
      */
     async show(pair, initialTab = 0) {
         // Convert numeric tab index to string tab name
-        const tabNames = ['stake', 'unstake', 'claim', 'zap'];
+        const tabNames = ['stake', 'unstake', 'claim', 'zap', 'remove-liquidity'];
         const tabName = tabNames[initialTab] || 'stake';
 
         console.log(`🎯 Opening modal for ${pair.name}, tab: ${tabName} (index: ${initialTab})`);
@@ -744,11 +765,11 @@ class StakingModalNew {
     }
 
     getRemoveLiquidityAmountRaw() {
-        if (!this.unstakeAmount || parseFloat(this.unstakeAmount) <= 0) {
+        if (!this.removeLiquidityAmount || parseFloat(this.removeLiquidityAmount) <= 0) {
             return null;
         }
 
-        return window.ethers.utils.parseUnits(this.unstakeAmount.toString(), this.userStakedDecimals);
+        return window.ethers.utils.parseUnits(this.removeLiquidityAmount.toString(), this.userBalanceDecimals);
     }
 
     getRemoveLiquidityCustomSlippageError(value = this.removeLiquidityCustomSlippage) {
@@ -837,8 +858,8 @@ class StakingModalNew {
     canFetchRemoveLiquidityPreview() {
         return this.removeLiquidityEnabled
             && !!this.currentPair
-            && !!this.unstakeAmount
-            && parseFloat(this.unstakeAmount) > 0
+            && !!this.removeLiquidityAmount
+            && parseFloat(this.removeLiquidityAmount) > 0
             && !this.hasInvalidRemoveLiquidityCustomSlippage();
     }
 
@@ -2164,51 +2185,77 @@ class StakingModalNew {
         const unstakeUnits = window.ethers.utils.parseUnits(this.unstakeAmount || '0', this.userStakedDecimals);
         const hasSufficientStaked = stakedRaw.gte(unstakeUnits);
         const unstakePhase = this.actionPhases?.unstake || 'idle';
-        const approveRemoveLiquidityPhase = this.actionPhases?.approveRemoveLiquidity || 'idle';
-        const removeLiquidityPhase = this.actionPhases?.removeLiquidity || 'idle';
-        const activeRemoveLiquidityPhase = approveRemoveLiquidityPhase !== 'idle'
-            ? { action: 'approveRemoveLiquidity', phase: approveRemoveLiquidityPhase }
-            : removeLiquidityPhase !== 'idle'
-                ? { action: 'removeLiquidity', phase: removeLiquidityPhase }
-                : null;
-        const hasValidRemoveLiquidityPreview = !this.removeLiquidityEnabled
-            || (this.removeLiquidityPreviewStatus === 'ready' && this.removeLiquidityPreview?.supported);
 
-        if (unstakePhase !== 'idle' || activeRemoveLiquidityPhase) {
+        if (unstakePhase !== 'idle') {
             unstakeButton.disabled = true;
             if (buttonIcon) buttonIcon.textContent = 'hourglass_empty';
             if (buttonText) {
-                let phaseLabel = this.getPhaseLabel(unstakePhase) || ' Processing Transaction...';
-                if (activeRemoveLiquidityPhase?.action === 'approveRemoveLiquidity') {
-                    phaseLabel = activeRemoveLiquidityPhase.phase === 'userApproval'
-                        ? ' Approve Router...'
-                        : ' Confirming Approval...';
-                } else if (activeRemoveLiquidityPhase?.action === 'removeLiquidity') {
-                    phaseLabel = activeRemoveLiquidityPhase.phase === 'userApproval'
-                        ? ' Remove Liquidity...'
-                        : ' Removing Liquidity...';
-                }
+                const phaseLabel = this.getPhaseLabel(unstakePhase) || ' Processing Transaction...';
                 buttonText.textContent = phaseLabel;
             }
             return;
         }
 
         const shouldDisable = this.isExecutingUnstake
-            || this.isExecutingRemoveLiquidity
             || !hasAmount
-            || !hasSufficientStaked
-            || !hasValidRemoveLiquidityPreview;
+            || !hasSufficientStaked;
         unstakeButton.disabled = shouldDisable;
         if (!hasSufficientStaked && hasAmount) {
             unstakeButton.title = 'Insufficient staked balance';
-        } else if (this.removeLiquidityEnabled && !hasValidRemoveLiquidityPreview) {
-            unstakeButton.title = this.removeLiquidityPreviewError || 'Wait for a supported remove-liquidity preview.';
         } else {
-            unstakeButton.title = this.removeLiquidityEnabled ? 'Unstake and remove liquidity' : 'Unstake LP Tokens';
+            unstakeButton.title = 'Unstake LP Tokens';
         }
 
-        if (buttonIcon) buttonIcon.textContent = this.removeLiquidityEnabled ? 'swap_horiz' : 'remove';
-        if (buttonText) buttonText.textContent = this.removeLiquidityEnabled ? ' Unstake + Remove Liquidity' : ' Unstake LP Tokens';
+        if (buttonIcon) buttonIcon.textContent = 'remove';
+        if (buttonText) buttonText.textContent = ' Unstake LP Tokens';
+    }
+
+    updateRemoveLiquidityButton() {
+        const removeButton = document.querySelector('.modal-actions .btn-primary[onclick*="safeModalExecuteRemoveLiquidity"]');
+        if (!removeButton) return;
+
+        const buttonIcon = removeButton.querySelector('.material-icons');
+        const buttonText = removeButton.childNodes[removeButton.childNodes.length - 1];
+        const amount = parseFloat(this.removeLiquidityAmount) || 0;
+        const hasAmount = amount > 0;
+        const balanceRaw = this.userBalanceRaw || window.ethers.BigNumber.from(0);
+        const removeUnits = window.ethers.utils.parseUnits(this.removeLiquidityAmount || '0', this.userBalanceDecimals);
+        const hasSufficientBalance = balanceRaw.gte(removeUnits);
+        const hasValidPreview = this.removeLiquidityEnabled
+            && this.removeLiquidityPreviewStatus === 'ready'
+            && this.removeLiquidityPreview?.supported;
+        const approvePhase = this.actionPhases?.approveRemoveLiquidity || 'idle';
+        const removePhase = this.actionPhases?.removeLiquidity || 'idle';
+        const activePhase = approvePhase !== 'idle' ? approvePhase : removePhase;
+
+        if (activePhase !== 'idle') {
+            removeButton.disabled = true;
+            if (buttonIcon) buttonIcon.textContent = 'hourglass_empty';
+            if (buttonText) {
+                buttonText.textContent = approvePhase !== 'idle'
+                    ? (approvePhase === 'userApproval' ? ' Approve Router...' : ' Confirming Approval...')
+                    : (removePhase === 'userApproval' ? ' Remove Liquidity...' : ' Removing Liquidity...');
+            }
+            return;
+        }
+
+        const shouldDisable = this.isExecutingRemoveLiquidity
+            || !hasAmount
+            || !hasSufficientBalance
+            || !hasValidPreview;
+        removeButton.disabled = shouldDisable;
+        if (!hasSufficientBalance && hasAmount) {
+            removeButton.title = 'Insufficient LP token balance';
+        } else if (!this.removeLiquidityEnabled) {
+            removeButton.title = 'Confirm the remove-liquidity details first';
+        } else if (!hasValidPreview) {
+            removeButton.title = this.removeLiquidityPreviewError || 'Wait for a supported remove-liquidity preview.';
+        } else {
+            removeButton.title = 'Remove LP liquidity';
+        }
+
+        if (buttonIcon) buttonIcon.textContent = 'swap_horiz';
+        if (buttonText) buttonText.textContent = ' Remove LP Liquidity';
     }
 
     /**
@@ -2405,6 +2452,7 @@ class StakingModalNew {
         // Clear state
         this.stakeAmount = '';
         this.unstakeAmount = '';
+        this.removeLiquidityAmount = '';
         this.zapInputAmount = '';
         this.zapQuote = null;
         this.zapQuoteStatus = 'idle';
@@ -2418,6 +2466,7 @@ class StakingModalNew {
         this.stopZapQuoteAutoRefresh();
         this.clearZapQuoteRateLimitTimer();
         this.removeLiquidityEnabled = false;
+        this.removeLiquidityAmount = '';
         this.removeLiquidityPreview = null;
         this.removeLiquidityPreviewStatus = 'idle';
         this.removeLiquidityPreviewError = '';
@@ -2429,8 +2478,8 @@ class StakingModalNew {
         this.needsApproval = false;
         this.resetActionStates(false);
         
-        // Clear DOM inputs and sliders for both stake and unstake
-        ['stake', 'unstake'].forEach(type => {
+        // Clear DOM inputs and sliders for amount-based tabs
+        ['stake', 'unstake', 'remove-liquidity'].forEach(type => {
             const input = document.getElementById(`${type}-amount-input`);
             const slider = document.getElementById(`${type}-slider`);
             if (input) input.value = '';
@@ -2438,6 +2487,7 @@ class StakingModalNew {
         });
         this.updateStakeUsdEstimate();
         this.updateUnstakeUsdEstimate();
+        this.updateRemoveLiquidityUsdEstimate();
 
         const zapInput = document.getElementById('zap-amount-input');
         if (zapInput) zapInput.value = '';
@@ -2503,6 +2553,9 @@ class StakingModalNew {
             case 'claim':
                 tabContent.innerHTML = this.renderClaimTab();
                 break;
+            case 'remove-liquidity':
+                tabContent.innerHTML = this.renderRemoveLiquidityTab();
+                break;
             case 'zap':
                 tabContent.innerHTML = this.renderZapTab();
                 break;
@@ -2516,6 +2569,7 @@ class StakingModalNew {
         // Update button states when input changes
         const stakeInput = document.getElementById('stake-amount-input');
         const unstakeInput = document.getElementById('unstake-amount-input');
+        const removeLiquidityInput = document.getElementById('remove-liquidity-amount-input');
 
         if (stakeInput) {
             stakeInput.addEventListener('input', () => {
@@ -2538,6 +2592,18 @@ class StakingModalNew {
                 }
                 this.unstakeAmount = sanitizedValue;
                 this.updateUnstakeUsdEstimate();
+                this.updateButtonStates();
+            });
+        }
+
+        if (removeLiquidityInput) {
+            removeLiquidityInput.addEventListener('input', () => {
+                const sanitizedValue = this.applyDecimalLimit(removeLiquidityInput.value, this.userBalanceDecimals);
+                if (sanitizedValue !== removeLiquidityInput.value) {
+                    removeLiquidityInput.value = sanitizedValue;
+                }
+                this.removeLiquidityAmount = sanitizedValue;
+                this.updateRemoveLiquidityUsdEstimate();
                 this.resetRemoveLiquidityPreview();
                 this.debounceRemoveLiquidityPreview();
                 this.updateButtonStates();
@@ -2552,6 +2618,7 @@ class StakingModalNew {
         this.updateStakeButton();
         this.updateUnstakeButton();
         this.updateClaimButton();
+        this.updateRemoveLiquidityButton();
         this.updateZapButton();
     }
 
@@ -2696,20 +2763,6 @@ class StakingModalNew {
                 </label>
             </div>
 
-            <div class="form-group">
-                <label class="checkbox-label remove-liquidity-checkbox-label">
-                    <input
-                        type="checkbox"
-                        id="remove-liquidity-checkbox"
-                        ${this.removeLiquidityEnabled ? 'checked' : ''}
-                    >
-                    <span class="checkmark"></span>
-                    Also remove liquidity and return pair tokens
-                </label>
-            </div>
-
-            ${this.removeLiquidityEnabled ? this.renderRemoveLiquidityControls() : ''}
-
             <div class="modal-actions">
                 <button class="btn btn-secondary" onclick="safeModalClose()">Cancel</button>
                 <button class="btn btn-primary" onclick="safeModalExecuteUnstake()" ${!this.unstakeAmount || parseFloat(this.unstakeAmount) === 0 ? 'disabled' : ''}>
@@ -2722,6 +2775,72 @@ class StakingModalNew {
 
     updateUnstakeUsdEstimate() {
         this.updateLpUsdEstimate('unstake-usd-estimate', this.unstakeAmount);
+    }
+
+    renderRemoveLiquidityTab() {
+        return `
+            <div class="balance-info">
+                <span class="balance-label">Available LP Tokens:</span>
+                <span class="balance-value">${this.userBalance} LP${this.renderInlineLpUsdEstimate(this.userBalance)}</span>
+            </div>
+
+            <div class="form-group">
+                <label class="form-label">Amount of LP to Remove</label>
+                <input
+                    type="number"
+                    id="remove-liquidity-amount-input"
+                    class="form-input"
+                    placeholder="0.00"
+                    value="${this.removeLiquidityAmount}"
+                    min="0"
+                    inputmode="decimal"
+                >
+                ${this.renderLpUsdEstimateElement('remove-liquidity-usd-estimate', this.removeLiquidityAmount)}
+                <div class="slider-container">
+                    <input
+                        type="range"
+                        class="slider amount-slider"
+                        id="remove-liquidity-slider"
+                        min="0"
+                        max="100"
+                        value="0"
+                        data-type="remove-liquidity"
+                    >
+                </div>
+                <div class="percentage-buttons">
+                    <button class="percentage-btn" data-percentage="25">25%</button>
+                    <button class="percentage-btn" data-percentage="50">50%</button>
+                    <button class="percentage-btn" data-percentage="75">75%</button>
+                    <button class="percentage-btn" data-percentage="100">MAX</button>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label class="checkbox-label remove-liquidity-checkbox-label">
+                    <input
+                        type="checkbox"
+                        id="remove-liquidity-checkbox"
+                        ${this.removeLiquidityEnabled ? 'checked' : ''}
+                    >
+                    <span class="checkmark"></span>
+                    Remove liquidity and return pair tokens
+                </label>
+            </div>
+
+            ${this.removeLiquidityEnabled ? this.renderRemoveLiquidityControls() : ''}
+
+            <div class="modal-actions">
+                <button class="btn btn-secondary" onclick="safeModalClose()">Cancel</button>
+                <button class="btn btn-primary" onclick="safeModalExecuteRemoveLiquidity()" ${!this.removeLiquidityAmount || parseFloat(this.removeLiquidityAmount) === 0 ? 'disabled' : ''}>
+                    <span class="material-icons">swap_horiz</span>
+                    Remove LP Liquidity
+                </button>
+            </div>
+        `;
+    }
+
+    updateRemoveLiquidityUsdEstimate() {
+        this.updateLpUsdEstimate('remove-liquidity-usd-estimate', this.removeLiquidityAmount);
     }
 
     formatRemoveLiquidityTokenAmount(amount, token) {
@@ -2808,7 +2927,7 @@ class StakingModalNew {
             isError ? 'zap-quote-error' : '',
             !hasPreview && !isLoading && !isError ? 'zap-quote-placeholder' : ''
         ].filter(Boolean).join(' ');
-        let summary = this.unstakeAmount
+        let summary = this.removeLiquidityAmount
             ? 'Checking remove liquidity support...'
             : 'Enter an amount to preview pair token outputs.';
         let dexDisplay = pendingValue;
@@ -3203,10 +3322,14 @@ class StakingModalNew {
         
         // For 100% (MAX), use the exact original value to preserve precision
         if (percentage === 100) {
-            amount = this.currentTab === 'stake' ? this.userBalance : this.userStaked;
+            amount = this.currentTab === 'stake' || this.currentTab === 'remove-liquidity'
+                ? this.userBalance
+                : this.userStaked;
         } else {
             // For other percentages, calculate the amount
-            const maxAmount = this.currentTab === 'stake' ? parseFloat(this.userBalance) : parseFloat(this.userStaked);
+            const maxAmount = this.currentTab === 'stake' || this.currentTab === 'remove-liquidity'
+                ? parseFloat(this.userBalance)
+                : parseFloat(this.userStaked);
             amount = (maxAmount * percentage / 100).toFixed(6);
         }
 
@@ -3232,6 +3355,14 @@ class StakingModalNew {
 
             // Update button states
             this.updateUnstakeUsdEstimate();
+            this.updateButtonStates();
+        } else if (this.currentTab === 'remove-liquidity') {
+            this.removeLiquidityAmount = amount;
+            const input = document.getElementById('remove-liquidity-amount-input');
+            if (input) input.value = amount;
+            this.updateSlider('remove-liquidity');
+
+            this.updateRemoveLiquidityUsdEstimate();
             this.resetRemoveLiquidityPreview();
             this.debounceRemoveLiquidityPreview();
             this.updateButtonStates();
@@ -3247,8 +3378,14 @@ class StakingModalNew {
         const slider = document.getElementById(`${type}-slider`);
         if (!slider) return;
 
-        const amount = parseFloat(type === 'stake' ? this.stakeAmount : this.unstakeAmount) || 0;
-        const maxAmount = parseFloat(type === 'stake' ? this.userBalance : this.userStaked) || 1;
+        const amount = parseFloat(
+            type === 'stake'
+                ? this.stakeAmount
+                : type === 'remove-liquidity'
+                    ? this.removeLiquidityAmount
+                    : this.unstakeAmount
+        ) || 0;
+        const maxAmount = parseFloat(type === 'stake' || type === 'remove-liquidity' ? this.userBalance : this.userStaked) || 1;
         const percentage = maxAmount > 0 ? (amount / maxAmount) * 100 : 0;
 
         slider.value = percentage;
@@ -3262,10 +3399,10 @@ class StakingModalNew {
         // For 100% (MAX), use the exact original value to preserve precision
         // This prevents rounding issues when slider is dragged to max
         if (percentage === 100) {
-            amount = type === 'stake' ? this.userBalance : this.userStaked;
+            amount = type === 'stake' || type === 'remove-liquidity' ? this.userBalance : this.userStaked;
         } else {
             // For other percentages, calculate the amount
-            const maxAmount = parseFloat(type === 'stake' ? this.userBalance : this.userStaked) || 0;
+            const maxAmount = parseFloat(type === 'stake' || type === 'remove-liquidity' ? this.userBalance : this.userStaked) || 0;
             amount = (maxAmount * percentage / 100).toFixed(6);
         }
 
@@ -3281,6 +3418,12 @@ class StakingModalNew {
             const input = document.getElementById('unstake-amount-input');
             if (input) input.value = amount;
             this.updateUnstakeUsdEstimate();
+            this.updateButtonStates();
+        } else if (type === 'remove-liquidity') {
+            this.removeLiquidityAmount = amount;
+            const input = document.getElementById('remove-liquidity-amount-input');
+            if (input) input.value = amount;
+            this.updateRemoveLiquidityUsdEstimate();
             this.resetRemoveLiquidityPreview();
             this.debounceRemoveLiquidityPreview();
             this.updateButtonStates();
@@ -3556,7 +3699,7 @@ class StakingModalNew {
         }
     }
 
-    async executeRemoveLiquidityAfterUnstake(lpTokenAddress, liquidityRaw) {
+    async executeRemoveLiquidityTransaction(lpTokenAddress, liquidityRaw) {
         const service = this.getRemoveLiquidityService();
         const provider = window.contractManager?.provider || window.walletManager?.provider;
 
@@ -3585,7 +3728,7 @@ class StakingModalNew {
             provider
         });
         if (lpBalance.lt(liquidityRaw)) {
-            throw new Error('The unstaked LP balance is not available yet. Your LP tokens remain in your wallet.');
+            throw new Error('Insufficient LP token balance.');
         }
 
         const allowance = await service.getAllowance({
@@ -3598,7 +3741,7 @@ class StakingModalNew {
         if (allowance.lt(liquidityRaw)) {
             this.pendingOperations.approveRemoveLiquidity = true;
             this.setActionPhase('approveRemoveLiquidity', 'userApproval');
-            window.notificationManager?.info('Approving router to spend unstaked LP tokens...');
+            window.notificationManager?.info('Approving router to spend LP tokens...');
 
             await window.contractManager.executeTransactionOnce(async () => {
                 const tx = await service.approveIfNeeded({
@@ -3640,6 +3783,81 @@ class StakingModalNew {
         }, 'removeLiquidity');
     }
 
+    async executeRemoveLiquidity() {
+        if (this.isExecutingRemoveLiquidity) {
+            console.log('⚠️ Remove liquidity already in progress, ignoring duplicate call');
+            return;
+        }
+
+        if (!this.removeLiquidityAmount || parseFloat(this.removeLiquidityAmount) === 0) return;
+
+        try {
+            this.isExecutingRemoveLiquidity = true;
+            this.updateRemoveLiquidityButton();
+
+            if (!window.contractManager || !window.contractManager.isReady()) {
+                window.notificationManager?.error('Contract manager not ready. Please connect your wallet first.');
+                return;
+            }
+
+            const slippageError = this.getRemoveLiquidityCustomSlippageError();
+            if (slippageError) {
+                this.updateRemoveLiquidityPreviewPanel();
+                this.updateRemoveLiquidityButton();
+                window.notificationManager?.error(slippageError);
+                return;
+            }
+
+            if (!this.removeLiquidityEnabled) {
+                window.notificationManager?.error('Confirm the remove-liquidity details before continuing.');
+                return;
+            }
+
+            if (!this.removeLiquidityPreview?.supported) {
+                await this.fetchRemoveLiquidityPreview({ force: true });
+            }
+
+            if (!this.removeLiquidityPreview?.supported) {
+                window.notificationManager?.error(this.removeLiquidityPreviewError || 'Remove liquidity is not supported for this pool.');
+                return;
+            }
+
+            window.notificationManager?.info('Removing LP liquidity...');
+            const lpTokenAddress = this.currentPair.lpToken || this.currentPair.address;
+            const liquidityRaw = this.getRemoveLiquidityAmountRaw();
+            await this.executeRemoveLiquidityTransaction(lpTokenAddress, liquidityRaw);
+            window.notificationManager?.success('Liquidity removed successfully!');
+
+            this.clearInputs();
+            this.close();
+
+            console.log('⏳ Waiting for blockchain state to update...');
+            await new Promise(resolve => setTimeout(resolve, 2000));
+
+            console.log('🔄 Refreshing home page data after remove liquidity...');
+            if (window.homePage?.refreshData) {
+                await window.homePage.refreshData();
+            } else if (window.homePage?.loadData) {
+                await window.homePage.loadData();
+            }
+            console.log('✅ Home page data refreshed after remove liquidity');
+        } catch (error) {
+            console.error('❌ Remove liquidity failed:', error);
+            const errorMessage = error?.userMessage?.message || error?.message || 'Remove liquidity failed. Your LP tokens remain in your wallet.';
+            window.notificationManager?.error(errorMessage, {title: error?.userMessage?.title});
+            await this.loadUserBalances().catch(loadError => {
+                console.warn('Unable to refresh balances after remove-liquidity failure:', loadError.message);
+            });
+        } finally {
+            this.pendingOperations.approveRemoveLiquidity = false;
+            this.pendingOperations.removeLiquidity = false;
+            this.setActionPhase('approveRemoveLiquidity', 'idle');
+            this.setActionPhase('removeLiquidity', 'idle');
+            this.isExecutingRemoveLiquidity = false;
+            this.updateRemoveLiquidityButton();
+        }
+    }
+
     async executeUnstake() {
         // Guard against multiple simultaneous executions
         if (this.isExecutingUnstake) {
@@ -3649,12 +3867,9 @@ class StakingModalNew {
 
         if (!this.unstakeAmount || parseFloat(this.unstakeAmount) === 0) return;
 
-        let unstakeSucceeded = false;
-
         try {
             // Set execution guard
             this.isExecutingUnstake = true;
-            this.isExecutingRemoveLiquidity = this.removeLiquidityEnabled;
             this.updateUnstakeButton();
             console.log('🔒 Unstake execution started, guard enabled');
 
@@ -3666,31 +3881,11 @@ class StakingModalNew {
                 return;
             }
 
-            if (this.removeLiquidityEnabled) {
-                const slippageError = this.getRemoveLiquidityCustomSlippageError();
-                if (slippageError) {
-                    this.updateRemoveLiquidityPreviewPanel();
-                    this.updateUnstakeButton();
-                    window.notificationManager?.error(slippageError);
-                    return;
-                }
-
-                if (!this.removeLiquidityPreview?.supported) {
-                    await this.fetchRemoveLiquidityPreview({ force: true });
-                }
-
-                if (!this.removeLiquidityPreview?.supported) {
-                    window.notificationManager?.error(this.removeLiquidityPreviewError || 'Remove liquidity is not supported for this pool.');
-                    return;
-                }
-            }
-
             if (window.notificationManager) {
-                window.notificationManager.info(this.removeLiquidityEnabled ? 'Unstaking LP tokens before removing liquidity...' : 'Unstaking LP tokens...');
+                window.notificationManager.info('Unstaking LP tokens...');
             }
 
             const lpTokenAddress = this.currentPair.lpToken || this.currentPair.address;
-            const liquidityRaw = this.getRemoveLiquidityAmountRaw();
 
             // Execute real unstaking transaction
             this.pendingOperations.unstake = true;
@@ -3708,19 +3903,12 @@ class StakingModalNew {
             if (!result.success) {
                 throw result.error;
             }
-            unstakeSucceeded = true;
 
             if (window.notificationManager) {
-                window.notificationManager.success(this.removeLiquidityEnabled ? 'LP tokens unstaked. Continue in your wallet to remove liquidity.' : 'LP tokens unstaked successfully!');
+                window.notificationManager.success('LP tokens unstaked successfully!');
             }
 
             console.log('✅ Unstaking transaction successful:', result.hash);
-
-            if (this.removeLiquidityEnabled) {
-                await this.loadUserBalances();
-                await this.executeRemoveLiquidityAfterUnstake(lpTokenAddress, liquidityRaw);
-                window.notificationManager?.success('Liquidity removed successfully!');
-            }
             
             // Clear inputs after successful transaction
             this.clearInputs();
@@ -3743,30 +3931,13 @@ class StakingModalNew {
 
         } catch (error) {
             console.error('❌ Unstaking failed:', error);
-            const fallbackMessage = unstakeSucceeded && this.removeLiquidityEnabled
-                ? 'LP tokens were unstaked, but liquidity removal did not complete. Your LP tokens remain in your wallet.'
-                : 'Unstaking failed. Please try again.';
-            const errorMessage = error?.userMessage?.message || error?.message || '';
-            const message = unstakeSucceeded && this.removeLiquidityEnabled
-                ? `${fallbackMessage}${errorMessage ? ` ${errorMessage}` : ''}`
-                : (errorMessage || fallbackMessage);
-            window.notificationManager.error(message, {title: error?.userMessage?.title});
-            if (unstakeSucceeded && this.removeLiquidityEnabled) {
-                await this.loadUserBalances().catch(loadError => {
-                    console.warn('Unable to refresh balances after partial unstake flow:', loadError.message);
-                });
-                this.updateUnstakeButton();
-            }
+            const errorMessage = error?.userMessage?.message || error?.message || 'Unstaking failed. Please try again.';
+            window.notificationManager.error(errorMessage, {title: error?.userMessage?.title});
         } finally {
             // Always release the guard
             this.pendingOperations.unstake = false;
-            this.pendingOperations.approveRemoveLiquidity = false;
-            this.pendingOperations.removeLiquidity = false;
             this.setActionPhase('unstake', 'idle');
-            this.setActionPhase('approveRemoveLiquidity', 'idle');
-            this.setActionPhase('removeLiquidity', 'idle');
             this.isExecutingUnstake = false;
-            this.isExecutingRemoveLiquidity = false;
             this.updateUnstakeButton();
             console.log('🔓 Unstake execution finished, guard released');
         }
@@ -3950,6 +4121,19 @@ window.safeModalExecuteClaim = function() {
         }
     } catch (error) {
         console.error('❌ Error executing claim:', error);
+    }
+};
+
+window.safeModalExecuteRemoveLiquidity = function() {
+    try {
+        const modal = window.stakingModal || window.stakingModalNew || window.getStakingModal();
+        if (modal && typeof modal.executeRemoveLiquidity === 'function') {
+            modal.executeRemoveLiquidity();
+        } else {
+            console.warn('⚠️ Modal executeRemoveLiquidity method not available');
+        }
+    } catch (error) {
+        console.error('❌ Error executing remove liquidity:', error);
     }
 };
 

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -938,10 +938,7 @@ class StakingModalNew {
         this.updateRemoveLiquiditySlippageButtonState();
 
         if (this.removeLiquidityCustomSlippageError) {
-            this.resetRemoveLiquidityPreview({
-                status: 'error',
-                error: this.removeLiquidityCustomSlippageError
-            });
+            this.resetRemoveLiquidityPreview();
             return sanitizedValue;
         }
 

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -3508,6 +3508,10 @@ class StakingModalNew {
             let minimumReceivedDisplay = pendingValue;
             let priceImpactDisplay = pendingValue;
             let feeDisplay = pendingValue;
+            let priceImpactRiskClass = '';
+            let slippageDisplay = `${(Number(this.removeLiquiditySlippageBps) / 100).toFixed(2)}%`;
+            let slippageRiskClass = this.isHighZapSlippage(this.removeLiquiditySlippageBps) ? 'zap-risk-high' : '';
+            const warningMessages = [];
 
             if (isLoading) {
                 summary = 'Loading Kyber zap-out route...';
@@ -3531,6 +3535,16 @@ class StakingModalNew {
                     ? pendingValue
                     : this.formatRemoveLiquidityMinOutputAmount(outputEntry.value, outputToken, pendingValue);
                 priceImpactDisplay = priceImpactEntry.value === pendingValue ? pendingValue : this.formatZapPercent(priceImpactEntry);
+                priceImpactRiskClass = this.isHighZapPriceImpact(priceImpactEntry.value, priceImpactEntry.path) ? 'zap-risk-high' : '';
+                if (priceImpactRiskClass) {
+                    warningMessages.push('High price impact. You may receive significantly less LP value than expected.');
+                }
+                const suggestedSlippage = data?.suggestedSlippage || data?.slippage || this.removeLiquiditySlippageBps;
+                slippageDisplay = `${(Number(suggestedSlippage) / 100).toFixed(2)}%`;
+                slippageRiskClass = this.isHighZapSlippage(suggestedSlippage) ? 'zap-risk-high' : '';
+                if (slippageRiskClass) {
+                    warningMessages.push('High slippage tolerance. This transaction may execute at a much worse rate.');
+                }
                 feeDisplay = this.formatZapFeeDetailsDisplay(this.getRemoveLiquidityProtocolFeeDetails(data));
                 summary = `Kyber zap-out to ${outputSymbol}`;
             }
@@ -3566,12 +3580,18 @@ class StakingModalNew {
                 this.renderZapQuoteRow(
                     'Price impact',
                     priceImpactDisplay,
-                    '',
+                    priceImpactRiskClass,
                     'Estimated effect of the route on execution price.'
+                ),
+                this.renderZapQuoteRow(
+                    'Slippage',
+                    slippageDisplay,
+                    slippageRiskClass,
+                    'Maximum output movement allowed before the transaction reverts.'
                 )
             );
 
-            return this.renderRemoveLiquidityPreviewCard(cardClass, summary, rows, isLoading, 'Refresh Kyber zap-out preview');
+            return this.renderRemoveLiquidityPreviewCard(cardClass, summary, rows, isLoading, 'Refresh Kyber zap-out preview', warningMessages);
         }
 
         let summary = this.removeLiquidityAmount
@@ -3623,7 +3643,7 @@ class StakingModalNew {
         return this.renderRemoveLiquidityPreviewCard(cardClass, summary, rows, isLoading, 'Refresh remove-liquidity preview');
     }
 
-    renderRemoveLiquidityPreviewCard(cardClass, summary, rows, isLoading, refreshLabel) {
+    renderRemoveLiquidityPreviewCard(cardClass, summary, rows, isLoading, refreshLabel, warningMessages = []) {
         return `
             <div class="${cardClass}">
                 <div class="zap-quote-header">
@@ -3644,6 +3664,14 @@ class StakingModalNew {
                 <dl class="zap-quote-list remove-liquidity-preview-list">
                     ${rows.join('')}
                 </dl>
+                ${warningMessages.length ? `
+                    <div class="zap-risk-warning" role="alert">
+                        <span class="material-icons" aria-hidden="true">warning</span>
+                        <div>
+                            ${warningMessages.map(message => `<div>${this.escapeHtml(message)}</div>`).join('')}
+                        </div>
+                    </div>
+                ` : ''}
             </div>
         `;
     }

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -855,12 +855,15 @@ class StakingModalNew {
         return String(parsed);
     }
 
-    canFetchRemoveLiquidityPreview({ requireDetailsOpen = true } = {}) {
-        return (!requireDetailsOpen || this.removeLiquidityEnabled)
-            && !!this.currentPair
+    canPrepareRemoveLiquidityPreview() {
+        return !!this.currentPair
             && !!this.removeLiquidityAmount
             && parseFloat(this.removeLiquidityAmount) > 0
             && !this.hasInvalidRemoveLiquidityCustomSlippage();
+    }
+
+    canFetchRemoveLiquidityPreview() {
+        return this.removeLiquidityEnabled && this.canPrepareRemoveLiquidityPreview();
     }
 
     debounceRemoveLiquidityPreview(delay = 400) {
@@ -877,8 +880,8 @@ class StakingModalNew {
         }, delay);
     }
 
-    async fetchRemoveLiquidityPreview({ force = false, requireDetailsOpen = true } = {}) {
-        if (!this.canFetchRemoveLiquidityPreview({ requireDetailsOpen })) {
+    async fetchRemoveLiquidityPreview({ force = false } = {}) {
+        if (!this.canPrepareRemoveLiquidityPreview()) {
             this.updateRemoveLiquidityPreviewPanel();
             this.updateRemoveLiquidityButton();
             return;
@@ -2223,7 +2226,7 @@ class StakingModalNew {
         const hasSufficientBalance = balanceRaw.gte(removeUnits);
         const hasValidPreview = this.removeLiquidityPreviewStatus === 'ready'
             && this.removeLiquidityPreview?.supported;
-        const needsOpenPreview = this.removeLiquidityEnabled;
+        const shouldWaitForOpenPreview = this.removeLiquidityEnabled && !hasValidPreview;
         const approvePhase = this.actionPhases?.approveRemoveLiquidity || 'idle';
         const removePhase = this.actionPhases?.removeLiquidity || 'idle';
         const activePhase = approvePhase !== 'idle' ? approvePhase : removePhase;
@@ -2242,11 +2245,11 @@ class StakingModalNew {
         const shouldDisable = this.isExecutingRemoveLiquidity
             || !hasAmount
             || !hasSufficientBalance
-            || (needsOpenPreview && !hasValidPreview);
+            || shouldWaitForOpenPreview;
         removeButton.disabled = shouldDisable;
         if (!hasSufficientBalance && hasAmount) {
             removeButton.title = 'Insufficient LP token balance';
-        } else if (needsOpenPreview && !hasValidPreview) {
+        } else if (shouldWaitForOpenPreview) {
             removeButton.title = this.removeLiquidityPreviewError || 'Wait for a supported remove-liquidity preview.';
         } else {
             removeButton.title = 'Remove LP liquidity';
@@ -3706,7 +3709,7 @@ class StakingModalNew {
         const userAddress = await signer.getAddress();
 
         if (!this.removeLiquidityPreview?.supported) {
-            await this.fetchRemoveLiquidityPreview({ force: true, requireDetailsOpen: false });
+            await this.fetchRemoveLiquidityPreview({ force: true });
         }
 
         const preview = this.removeLiquidityPreview;
@@ -3807,7 +3810,7 @@ class StakingModalNew {
             }
 
             if (!this.removeLiquidityPreview?.supported) {
-                await this.fetchRemoveLiquidityPreview({ force: true, requireDetailsOpen: false });
+                await this.fetchRemoveLiquidityPreview({ force: true });
             }
 
             if (!this.removeLiquidityPreview?.supported) {

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -3632,6 +3632,9 @@ class StakingModalNew {
         let token1Display = pendingValue;
         let token0MinDisplay = pendingValue;
         let token1MinDisplay = pendingValue;
+        const slippageDisplay = `${(Number(this.removeLiquiditySlippageBps) / 100).toFixed(2)}%`;
+        const slippageRiskClass = this.isHighZapSlippage(this.removeLiquiditySlippageBps) ? 'zap-risk-high' : '';
+        const warningMessages = [];
         if (isLoading) {
             summary = 'Loading LP reserves...';
         } else if (isError) {
@@ -3647,6 +3650,9 @@ class StakingModalNew {
             token0MinDisplay = this.formatRemoveLiquidityTokenAmount(preview.token0.minAmount, preview.token0);
             token1MinDisplay = this.formatRemoveLiquidityTokenAmount(preview.token1.minAmount, preview.token1);
             summary = `${preview.token0.symbol} + ${preview.token1.symbol} via ${dexDisplay}`;
+            if (slippageRiskClass) {
+                warningMessages.push('High slippage tolerance. This transaction may execute at a much worse rate.');
+            }
         }
 
         const estimatedPairDisplay = hasPreview
@@ -3667,10 +3673,16 @@ class StakingModalNew {
                 minimumPairDisplay,
                 '',
                 'Transaction reverts if either token output is below this value after max slippage.'
+            ),
+            this.renderZapQuoteRow(
+                'Slippage',
+                slippageDisplay,
+                slippageRiskClass,
+                'Maximum output movement allowed before the transaction reverts.'
             )
         ];
 
-        return this.renderRemoveLiquidityPreviewCard(cardClass, summary, rows, isLoading, 'Refresh remove-liquidity preview');
+        return this.renderRemoveLiquidityPreviewCard(cardClass, summary, rows, isLoading, 'Refresh remove-liquidity preview', warningMessages);
     }
 
     renderRemoveLiquidityPreviewCard(cardClass, summary, rows, isLoading, refreshLabel, warningMessages = []) {

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -299,8 +299,8 @@ class StakingModalNew {
             }
 
             // Percentage buttons
-            if (e.target.closest('.percentage-btn')) {
-                const percentage = parseInt(e.target.closest('.percentage-btn').dataset.percentage);
+            if (e.target.closest('.percentage-btn, .remove-liquidity-percentage-btn')) {
+                const percentage = parseInt(e.target.closest('.percentage-btn, .remove-liquidity-percentage-btn').dataset.percentage);
                 this.setPercentage(percentage);
             }
 
@@ -3255,8 +3255,16 @@ class StakingModalNew {
                 <span class="balance-value">${this.userBalance} LP${this.renderInlineLpUsdEstimate(this.userBalance)}</span>
             </div>
 
-            <div class="form-group">
-                <label class="form-label">Amount of LP to Remove</label>
+            <div class="form-group remove-liquidity-amount-group">
+                <div class="zap-label-row zap-amount-label-row">
+                    <label class="form-label">Amount of LP to Remove</label>
+                    <div class="zap-percentage-buttons">
+                        <button type="button" class="zap-percentage-btn remove-liquidity-percentage-btn${activeRemoveLiquidityPercentage === 25 ? ' active' : ''}" data-percentage="25">25%</button>
+                        <button type="button" class="zap-percentage-btn remove-liquidity-percentage-btn${activeRemoveLiquidityPercentage === 50 ? ' active' : ''}" data-percentage="50">50%</button>
+                        <button type="button" class="zap-percentage-btn remove-liquidity-percentage-btn${activeRemoveLiquidityPercentage === 75 ? ' active' : ''}" data-percentage="75">75%</button>
+                        <button type="button" class="zap-percentage-btn remove-liquidity-percentage-btn${activeRemoveLiquidityPercentage === 100 ? ' active' : ''}" data-percentage="100">MAX</button>
+                    </div>
+                </div>
                 <input
                     type="number"
                     id="remove-liquidity-amount-input"
@@ -3266,37 +3274,19 @@ class StakingModalNew {
                     min="0"
                     inputmode="decimal"
                 >
-                ${this.renderLpUsdEstimateElement('remove-liquidity-usd-estimate', this.removeLiquidityAmount)}
+                <div class="remove-liquidity-meta-row">
+                    ${this.renderLpUsdEstimateElement('remove-liquidity-usd-estimate', this.removeLiquidityAmount)}
+                    <label class="checkbox-label remove-liquidity-checkbox-label">
+                        <input
+                            type="checkbox"
+                            id="remove-liquidity-checkbox"
+                            ${this.removeLiquidityZapOutEnabled ? 'checked' : ''}
+                        >
+                        <span class="checkmark"></span>
+                        Convert to one preferred token
+                    </label>
+                </div>
                 <div id="remove-liquidity-balance-error" class="zap-field-error zap-balance-error" aria-live="polite" ${balanceError ? '' : 'hidden'}>${this.escapeHtml(balanceError)}</div>
-                <div class="slider-container">
-                    <input
-                        type="range"
-                        class="slider amount-slider"
-                        id="remove-liquidity-slider"
-                        min="0"
-                        max="100"
-                        value="${removeLiquidityPercentage}"
-                        data-type="remove-liquidity"
-                    >
-                </div>
-                <div class="percentage-buttons">
-                    <button class="percentage-btn${activeRemoveLiquidityPercentage === 25 ? ' active' : ''}" data-percentage="25">25%</button>
-                    <button class="percentage-btn${activeRemoveLiquidityPercentage === 50 ? ' active' : ''}" data-percentage="50">50%</button>
-                    <button class="percentage-btn${activeRemoveLiquidityPercentage === 75 ? ' active' : ''}" data-percentage="75">75%</button>
-                    <button class="percentage-btn${activeRemoveLiquidityPercentage === 100 ? ' active' : ''}" data-percentage="100">MAX</button>
-                </div>
-            </div>
-
-            <div class="form-group">
-                <label class="checkbox-label remove-liquidity-checkbox-label">
-                    <input
-                        type="checkbox"
-                        id="remove-liquidity-checkbox"
-                        ${this.removeLiquidityZapOutEnabled ? 'checked' : ''}
-                    >
-                    <span class="checkmark"></span>
-                    Convert to one preferred token
-                </label>
             </div>
 
             ${this.renderRemoveLiquidityControls()}
@@ -4102,7 +4092,7 @@ class StakingModalNew {
         }
 
         // Update percentage button states
-        document.querySelectorAll('.percentage-btn').forEach(btn => {
+        document.querySelectorAll('.percentage-btn, .remove-liquidity-percentage-btn').forEach(btn => {
             btn.classList.toggle('active', parseInt(btn.dataset.percentage) === percentage);
         });
     }

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -855,8 +855,8 @@ class StakingModalNew {
         return String(parsed);
     }
 
-    canFetchRemoveLiquidityPreview() {
-        return this.removeLiquidityEnabled
+    canFetchRemoveLiquidityPreview({ requireDetailsOpen = true } = {}) {
+        return (!requireDetailsOpen || this.removeLiquidityEnabled)
             && !!this.currentPair
             && !!this.removeLiquidityAmount
             && parseFloat(this.removeLiquidityAmount) > 0
@@ -877,8 +877,8 @@ class StakingModalNew {
         }, delay);
     }
 
-    async fetchRemoveLiquidityPreview({ force = false } = {}) {
-        if (!this.canFetchRemoveLiquidityPreview()) {
+    async fetchRemoveLiquidityPreview({ force = false, requireDetailsOpen = true } = {}) {
+        if (!this.canFetchRemoveLiquidityPreview({ requireDetailsOpen })) {
             this.updateRemoveLiquidityPreviewPanel();
             this.updateRemoveLiquidityButton();
             return;
@@ -2221,9 +2221,9 @@ class StakingModalNew {
         const balanceRaw = this.userBalanceRaw || window.ethers.BigNumber.from(0);
         const removeUnits = window.ethers.utils.parseUnits(this.removeLiquidityAmount || '0', this.userBalanceDecimals);
         const hasSufficientBalance = balanceRaw.gte(removeUnits);
-        const hasValidPreview = this.removeLiquidityEnabled
-            && this.removeLiquidityPreviewStatus === 'ready'
+        const hasValidPreview = this.removeLiquidityPreviewStatus === 'ready'
             && this.removeLiquidityPreview?.supported;
+        const needsOpenPreview = this.removeLiquidityEnabled;
         const approvePhase = this.actionPhases?.approveRemoveLiquidity || 'idle';
         const removePhase = this.actionPhases?.removeLiquidity || 'idle';
         const activePhase = approvePhase !== 'idle' ? approvePhase : removePhase;
@@ -2242,13 +2242,11 @@ class StakingModalNew {
         const shouldDisable = this.isExecutingRemoveLiquidity
             || !hasAmount
             || !hasSufficientBalance
-            || !hasValidPreview;
+            || (needsOpenPreview && !hasValidPreview);
         removeButton.disabled = shouldDisable;
         if (!hasSufficientBalance && hasAmount) {
             removeButton.title = 'Insufficient LP token balance';
-        } else if (!this.removeLiquidityEnabled) {
-            removeButton.title = 'Confirm the remove-liquidity details first';
-        } else if (!hasValidPreview) {
+        } else if (needsOpenPreview && !hasValidPreview) {
             removeButton.title = this.removeLiquidityPreviewError || 'Wait for a supported remove-liquidity preview.';
         } else {
             removeButton.title = 'Remove LP liquidity';
@@ -2823,7 +2821,7 @@ class StakingModalNew {
                         ${this.removeLiquidityEnabled ? 'checked' : ''}
                     >
                     <span class="checkmark"></span>
-                    Remove liquidity and return pair tokens
+                    Show pair-token return preview and settings
                 </label>
             </div>
 
@@ -3708,7 +3706,7 @@ class StakingModalNew {
         const userAddress = await signer.getAddress();
 
         if (!this.removeLiquidityPreview?.supported) {
-            await this.fetchRemoveLiquidityPreview({ force: true });
+            await this.fetchRemoveLiquidityPreview({ force: true, requireDetailsOpen: false });
         }
 
         const preview = this.removeLiquidityPreview;
@@ -3808,13 +3806,8 @@ class StakingModalNew {
                 return;
             }
 
-            if (!this.removeLiquidityEnabled) {
-                window.notificationManager?.error('Confirm the remove-liquidity details before continuing.');
-                return;
-            }
-
             if (!this.removeLiquidityPreview?.supported) {
-                await this.fetchRemoveLiquidityPreview({ force: true });
+                await this.fetchRemoveLiquidityPreview({ force: true, requireDetailsOpen: false });
             }
 
             if (!this.removeLiquidityPreview?.supported) {

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -44,6 +44,19 @@ class StakingModalNew {
         this.zapCustomTokenAddress = '';
         this.zapCustomTokenError = '';
 
+        // V2 remove-liquidity state
+        this.removeLiquidityService = window.V2RemoveLiquidityService ? new window.V2RemoveLiquidityService() : null;
+        this.removeLiquidityEnabled = false;
+        this.removeLiquidityPreview = null;
+        this.removeLiquidityPreviewStatus = 'idle';
+        this.removeLiquidityPreviewError = '';
+        this.removeLiquiditySlippageBps = window.CONFIG?.KYBER_ZAP?.DEFAULT_SLIPPAGE_BPS || 50;
+        this.removeLiquidityCustomSlippage = '';
+        this.removeLiquidityCustomSlippageError = '';
+        this.removeLiquidityDeadlineMinutes = window.CONFIG?.KYBER_ZAP?.DEFAULT_DEADLINE_MINUTES || 20;
+        this.removeLiquidityPreviewDebounceTimer = null;
+        this.removeLiquidityPreviewRequestId = 0;
+
         // Approval state
         this.needsApproval = false;
         this.isApproved = false;
@@ -56,7 +69,9 @@ class StakingModalNew {
             unstake: 'idle',
             claim: 'idle',
             approveZap: 'idle',
-            zap: 'idle'
+            zap: 'idle',
+            approveRemoveLiquidity: 'idle',
+            removeLiquidity: 'idle'
         };
         this.pendingOperations = {
             approve: false,
@@ -64,7 +79,9 @@ class StakingModalNew {
             unstake: false,
             claim: false,
             approveZap: false,
-            zap: false
+            zap: false,
+            approveRemoveLiquidity: false,
+            removeLiquidity: false
         };
 
         // Execution guards
@@ -72,6 +89,7 @@ class StakingModalNew {
         this.isExecutingUnstake = false;
         this.isExecutingClaim = false;
         this.isExecutingZap = false;
+        this.isExecutingRemoveLiquidity = false;
 
         // Claim rewards on unstake
         this.claimRewardsOnUnstake = true;
@@ -102,6 +120,10 @@ class StakingModalNew {
                 return 'approveZap';
             case 'zapIntoLP':
                 return 'zap';
+            case 'approveRemoveLiquidity':
+                return 'approveRemoveLiquidity';
+            case 'removeLiquidity':
+                return 'removeLiquidity';
             default:
                 return null;
         }
@@ -132,7 +154,7 @@ class StakingModalNew {
             this.updateStakeButton();
         }
 
-        if (action === 'unstake') {
+        if (action === 'unstake' || action === 'approveRemoveLiquidity' || action === 'removeLiquidity') {
             this.updateUnstakeButton();
         }
 
@@ -260,6 +282,11 @@ class StakingModalNew {
                 this.setZapSlippage(button.dataset.slippage);
             }
 
+            if (e.target.closest('.remove-liquidity-slippage-btn')) {
+                const button = e.target.closest('.remove-liquidity-slippage-btn');
+                this.setRemoveLiquiditySlippage(button.dataset.slippage);
+            }
+
             if (e.target.closest('.zap-percentage-btn')) {
                 const button = e.target.closest('.zap-percentage-btn');
                 this.setZapAmountPercentage(parseInt(button.dataset.percentage, 10));
@@ -302,6 +329,8 @@ class StakingModalNew {
                 this.unstakeAmount = sanitizedValue;
                 this.updateSlider('unstake');
                 this.updateUnstakeUsdEstimate();
+                this.resetRemoveLiquidityPreview();
+                this.debounceRemoveLiquidityPreview();
             }
 
             if (e.target.classList.contains('amount-slider')) {
@@ -333,6 +362,20 @@ class StakingModalNew {
                 this.zapCustomTokenAddress = e.target.value.trim();
                 this.zapCustomTokenError = '';
             }
+
+            if (e.target.id === 'remove-liquidity-custom-slippage-input') {
+                const sanitizedValue = this.setRemoveLiquidityCustomSlippageInput(e.target.value);
+                if (sanitizedValue !== e.target.value) {
+                    e.target.value = sanitizedValue;
+                }
+            }
+
+            if (e.target.id === 'remove-liquidity-deadline-input') {
+                const sanitizedValue = this.setRemoveLiquidityDeadlineInput(e.target.value);
+                if (sanitizedValue !== e.target.value) {
+                    e.target.value = sanitizedValue;
+                }
+            }
         });
 
         // Checkbox changes
@@ -340,6 +383,13 @@ class StakingModalNew {
             if (e.target.id === 'claim-rewards-checkbox') {
                 this.claimRewardsOnUnstake = e.target.checked;
                 console.log('Claim rewards on unstake:', this.claimRewardsOnUnstake);
+            }
+
+            if (e.target.id === 'remove-liquidity-checkbox') {
+                this.removeLiquidityEnabled = e.target.checked;
+                this.resetRemoveLiquidityPreview();
+                this.renderTabContent();
+                this.debounceRemoveLiquidityPreview(0);
             }
         });
 
@@ -436,6 +486,14 @@ class StakingModalNew {
         this.zapCustomSlippageError = '';
         this.zapQuoteRequestId += 1;
         this.stopZapQuoteAutoRefresh();
+        this.removeLiquidityEnabled = false;
+        this.removeLiquidityPreview = null;
+        this.removeLiquidityPreviewStatus = 'idle';
+        this.removeLiquidityPreviewError = '';
+        this.removeLiquidityCustomSlippage = '';
+        this.removeLiquidityCustomSlippageError = '';
+        this.removeLiquidityPreviewRequestId += 1;
+        this.clearRemoveLiquidityPreviewDebounce();
 
         // Reset transaction progress state
         this.resetActionStates(false);
@@ -445,6 +503,7 @@ class StakingModalNew {
         this.isExecutingUnstake = false;
         this.isExecutingClaim = false;
         this.isExecutingZap = false;
+        this.isExecutingRemoveLiquidity = false;
 
         // Update pair info
         this.updatePairInfo();
@@ -619,6 +678,11 @@ class StakingModalNew {
             .replace(/'/g, '&#039;');
     }
 
+    formatAddress(address) {
+        const value = String(address || '');
+        return value.length > 12 ? `${value.slice(0, 6)}...${value.slice(-4)}` : value;
+    }
+
     isNativeZapToken(address) {
         return this.getKyberZapService().isNativeToken(address);
     }
@@ -641,6 +705,226 @@ class StakingModalNew {
 
     getKyberZapNetworkConfig() {
         return this.getKyberZapService().getNetworkConfig();
+    }
+
+    getRemoveLiquidityService() {
+        if (!this.removeLiquidityService && window.V2RemoveLiquidityService) {
+            this.removeLiquidityService = new window.V2RemoveLiquidityService();
+        }
+
+        if (!this.removeLiquidityService) {
+            throw new Error('Remove liquidity service is not available.');
+        }
+
+        return this.removeLiquidityService;
+    }
+
+    getRemoveLiquidityChainId() {
+        const chainId = window.networkSelector?.getCurrentChainId?.()
+            ?? window.contractManager?.getCurrentChainIdSafe?.();
+        const parsed = typeof chainId === 'string' ? Number(chainId) : chainId;
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    clearRemoveLiquidityPreviewDebounce() {
+        if (this.removeLiquidityPreviewDebounceTimer) {
+            clearTimeout(this.removeLiquidityPreviewDebounceTimer);
+            this.removeLiquidityPreviewDebounceTimer = null;
+        }
+    }
+
+    resetRemoveLiquidityPreview({ status = 'idle', error = '' } = {}) {
+        this.removeLiquidityPreview = null;
+        this.removeLiquidityPreviewStatus = status;
+        this.removeLiquidityPreviewError = error;
+        this.removeLiquidityPreviewRequestId += 1;
+        this.clearRemoveLiquidityPreviewDebounce();
+        this.updateRemoveLiquidityPreviewPanel();
+        this.updateUnstakeButton();
+    }
+
+    getRemoveLiquidityAmountRaw() {
+        if (!this.unstakeAmount || parseFloat(this.unstakeAmount) <= 0) {
+            return null;
+        }
+
+        return window.ethers.utils.parseUnits(this.unstakeAmount.toString(), this.userStakedDecimals);
+    }
+
+    getRemoveLiquidityCustomSlippageError(value = this.removeLiquidityCustomSlippage) {
+        if (!value) {
+            return '';
+        }
+
+        const numericValue = Number(value);
+        if (!Number.isFinite(numericValue) || numericValue <= 0 || numericValue > 100) {
+            return 'Enter a custom slippage between 0.01% and 100%.';
+        }
+
+        return '';
+    }
+
+    hasInvalidRemoveLiquidityCustomSlippage() {
+        return !!this.getRemoveLiquidityCustomSlippageError();
+    }
+
+    isRemoveLiquidityCustomSlippageActive() {
+        return !!this.removeLiquidityCustomSlippage && !this.hasInvalidRemoveLiquidityCustomSlippage();
+    }
+
+    setRemoveLiquiditySlippage(value) {
+        if (value === 'custom') {
+            const customInput = document.getElementById('remove-liquidity-custom-slippage-input');
+            if (customInput) customInput.focus();
+            return;
+        }
+
+        const parsed = parseInt(value, 10);
+        if (Number.isFinite(parsed) && parsed >= 0) {
+            this.removeLiquiditySlippageBps = parsed;
+            this.removeLiquidityCustomSlippage = '';
+            this.removeLiquidityCustomSlippageError = '';
+            this.resetRemoveLiquidityPreview();
+            this.renderTabContent();
+            this.debounceRemoveLiquidityPreview(0);
+        }
+    }
+
+    setRemoveLiquidityCustomSlippageInput(value) {
+        const sanitizedValue = this.applyDecimalLimit(String(value ?? ''), 2);
+        this.removeLiquidityCustomSlippage = sanitizedValue;
+        this.removeLiquidityCustomSlippageError = this.getRemoveLiquidityCustomSlippageError(sanitizedValue);
+
+        if (this.removeLiquidityCustomSlippageError) {
+            this.resetRemoveLiquidityPreview({
+                status: 'error',
+                error: this.removeLiquidityCustomSlippageError
+            });
+            return sanitizedValue;
+        }
+
+        if (!sanitizedValue) {
+            this.removeLiquidityPreviewError = '';
+            if (this.removeLiquidityPreviewStatus === 'error' && !this.removeLiquidityPreview) {
+                this.removeLiquidityPreviewStatus = 'idle';
+            }
+            this.updateRemoveLiquidityPreviewPanel();
+            this.debounceRemoveLiquidityPreview();
+            this.updateUnstakeButton();
+            return sanitizedValue;
+        }
+
+        this.removeLiquiditySlippageBps = Math.round(Number(sanitizedValue) * 100);
+        this.resetRemoveLiquidityPreview();
+        this.debounceRemoveLiquidityPreview();
+        return sanitizedValue;
+    }
+
+    setRemoveLiquidityDeadlineInput(value) {
+        const digitsOnly = String(value ?? '').replace(/[^0-9]/g, '');
+        if (!digitsOnly) {
+            this.removeLiquidityDeadlineMinutes = 1;
+            this.updateRemoveLiquidityPreviewPanel();
+            return '';
+        }
+
+        const parsed = Math.min(4320, Math.max(1, parseInt(digitsOnly, 10)));
+        this.removeLiquidityDeadlineMinutes = parsed;
+        this.updateRemoveLiquidityPreviewPanel();
+        return String(parsed);
+    }
+
+    canFetchRemoveLiquidityPreview() {
+        return this.removeLiquidityEnabled
+            && !!this.currentPair
+            && !!this.unstakeAmount
+            && parseFloat(this.unstakeAmount) > 0
+            && !this.hasInvalidRemoveLiquidityCustomSlippage();
+    }
+
+    debounceRemoveLiquidityPreview(delay = 400) {
+        this.clearRemoveLiquidityPreviewDebounce();
+
+        if (!this.canFetchRemoveLiquidityPreview()) {
+            this.updateRemoveLiquidityPreviewPanel();
+            this.updateUnstakeButton();
+            return;
+        }
+
+        this.removeLiquidityPreviewDebounceTimer = setTimeout(() => {
+            this.fetchRemoveLiquidityPreview();
+        }, delay);
+    }
+
+    async fetchRemoveLiquidityPreview({ force = false } = {}) {
+        if (!this.canFetchRemoveLiquidityPreview()) {
+            this.updateRemoveLiquidityPreviewPanel();
+            this.updateUnstakeButton();
+            return;
+        }
+
+        if (!force && this.removeLiquidityPreviewStatus === 'ready' && this.removeLiquidityPreview?.supported) {
+            this.updateRemoveLiquidityPreviewPanel();
+            this.updateUnstakeButton();
+            return;
+        }
+
+        const requestId = ++this.removeLiquidityPreviewRequestId;
+        this.clearRemoveLiquidityPreviewDebounce();
+
+        try {
+            const provider = window.contractManager?.provider || window.walletManager?.provider;
+            const chainId = this.getRemoveLiquidityChainId();
+            const lpTokenAddress = this.currentPair?.lpToken || this.currentPair?.address;
+            const liquidityRaw = this.getRemoveLiquidityAmountRaw();
+
+            if (!provider) {
+                throw new Error('Connect your wallet to preview remove liquidity.');
+            }
+            if (!liquidityRaw) {
+                throw new Error('Enter an LP amount to preview remove liquidity.');
+            }
+
+            this.removeLiquidityPreviewStatus = 'loading';
+            this.removeLiquidityPreviewError = '';
+            this.updateRemoveLiquidityPreviewPanel();
+            this.updateUnstakeButton();
+
+            const preview = await this.getRemoveLiquidityService().getPreview({
+                chainId,
+                lpTokenAddress,
+                liquidityRaw,
+                slippageBps: this.removeLiquiditySlippageBps,
+                provider
+            });
+
+            if (requestId !== this.removeLiquidityPreviewRequestId) {
+                return;
+            }
+
+            this.removeLiquidityPreview = preview;
+            if (preview.supported) {
+                this.removeLiquidityPreviewStatus = 'ready';
+                this.removeLiquidityPreviewError = '';
+            } else {
+                this.removeLiquidityPreviewStatus = 'error';
+                this.removeLiquidityPreviewError = preview.reason || 'Remove liquidity is not supported for this pool.';
+            }
+        } catch (error) {
+            if (requestId !== this.removeLiquidityPreviewRequestId) {
+                return;
+            }
+
+            console.error('Failed to preview remove liquidity:', error);
+            this.removeLiquidityPreview = null;
+            this.removeLiquidityPreviewStatus = 'error';
+            this.removeLiquidityPreviewError = error.message || 'Unable to preview remove liquidity.';
+        } finally {
+            if (requestId === this.removeLiquidityPreviewRequestId) {
+                this.updateRemoveLiquidityPreviewPanel();
+                this.updateUnstakeButton();
+            }
+        }
     }
 
     async getTokenMetadata(address) {
@@ -1880,25 +2164,51 @@ class StakingModalNew {
         const unstakeUnits = window.ethers.utils.parseUnits(this.unstakeAmount || '0', this.userStakedDecimals);
         const hasSufficientStaked = stakedRaw.gte(unstakeUnits);
         const unstakePhase = this.actionPhases?.unstake || 'idle';
+        const approveRemoveLiquidityPhase = this.actionPhases?.approveRemoveLiquidity || 'idle';
+        const removeLiquidityPhase = this.actionPhases?.removeLiquidity || 'idle';
+        const activeRemoveLiquidityPhase = approveRemoveLiquidityPhase !== 'idle'
+            ? { action: 'approveRemoveLiquidity', phase: approveRemoveLiquidityPhase }
+            : removeLiquidityPhase !== 'idle'
+                ? { action: 'removeLiquidity', phase: removeLiquidityPhase }
+                : null;
+        const hasValidRemoveLiquidityPreview = !this.removeLiquidityEnabled
+            || (this.removeLiquidityPreviewStatus === 'ready' && this.removeLiquidityPreview?.supported);
 
-        if (unstakePhase !== 'idle') {
+        if (unstakePhase !== 'idle' || activeRemoveLiquidityPhase) {
             unstakeButton.disabled = true;
             if (buttonIcon) buttonIcon.textContent = 'hourglass_empty';
             if (buttonText) {
-                const phaseLabel = this.getPhaseLabel(unstakePhase) || ' Processing Transaction...';
+                let phaseLabel = this.getPhaseLabel(unstakePhase) || ' Processing Transaction...';
+                if (activeRemoveLiquidityPhase?.action === 'approveRemoveLiquidity') {
+                    phaseLabel = activeRemoveLiquidityPhase.phase === 'userApproval'
+                        ? ' Approve Router...'
+                        : ' Confirming Approval...';
+                } else if (activeRemoveLiquidityPhase?.action === 'removeLiquidity') {
+                    phaseLabel = activeRemoveLiquidityPhase.phase === 'userApproval'
+                        ? ' Remove Liquidity...'
+                        : ' Removing Liquidity...';
+                }
                 buttonText.textContent = phaseLabel;
             }
             return;
         }
 
-        const shouldDisable = this.isExecutingUnstake || !hasAmount || !hasSufficientStaked;
+        const shouldDisable = this.isExecutingUnstake
+            || this.isExecutingRemoveLiquidity
+            || !hasAmount
+            || !hasSufficientStaked
+            || !hasValidRemoveLiquidityPreview;
         unstakeButton.disabled = shouldDisable;
-        unstakeButton.title = (!hasSufficientStaked && hasAmount)
-            ? 'Insufficient staked balance'
-            : 'Unstake LP Tokens';
+        if (!hasSufficientStaked && hasAmount) {
+            unstakeButton.title = 'Insufficient staked balance';
+        } else if (this.removeLiquidityEnabled && !hasValidRemoveLiquidityPreview) {
+            unstakeButton.title = this.removeLiquidityPreviewError || 'Wait for a supported remove-liquidity preview.';
+        } else {
+            unstakeButton.title = this.removeLiquidityEnabled ? 'Unstake and remove liquidity' : 'Unstake LP Tokens';
+        }
 
-        if (buttonIcon) buttonIcon.textContent = 'remove';
-        if (buttonText) buttonText.textContent = ' Unstake LP Tokens';
+        if (buttonIcon) buttonIcon.textContent = this.removeLiquidityEnabled ? 'swap_horiz' : 'remove';
+        if (buttonText) buttonText.textContent = this.removeLiquidityEnabled ? ' Unstake + Remove Liquidity' : ' Unstake LP Tokens';
     }
 
     /**
@@ -2107,6 +2417,14 @@ class StakingModalNew {
         this.zapQuoteRequestId += 1;
         this.stopZapQuoteAutoRefresh();
         this.clearZapQuoteRateLimitTimer();
+        this.removeLiquidityEnabled = false;
+        this.removeLiquidityPreview = null;
+        this.removeLiquidityPreviewStatus = 'idle';
+        this.removeLiquidityPreviewError = '';
+        this.removeLiquidityCustomSlippage = '';
+        this.removeLiquidityCustomSlippageError = '';
+        this.removeLiquidityPreviewRequestId += 1;
+        this.clearRemoveLiquidityPreviewDebounce();
         this.isApproved = false;
         this.needsApproval = false;
         this.resetActionStates(false);
@@ -2220,6 +2538,8 @@ class StakingModalNew {
                 }
                 this.unstakeAmount = sanitizedValue;
                 this.updateUnstakeUsdEstimate();
+                this.resetRemoveLiquidityPreview();
+                this.debounceRemoveLiquidityPreview();
                 this.updateButtonStates();
             });
         }
@@ -2376,6 +2696,20 @@ class StakingModalNew {
                 </label>
             </div>
 
+            <div class="form-group">
+                <label class="checkbox-label remove-liquidity-checkbox-label">
+                    <input
+                        type="checkbox"
+                        id="remove-liquidity-checkbox"
+                        ${this.removeLiquidityEnabled ? 'checked' : ''}
+                    >
+                    <span class="checkmark"></span>
+                    Also remove liquidity and return pair tokens
+                </label>
+            </div>
+
+            ${this.removeLiquidityEnabled ? this.renderRemoveLiquidityControls() : ''}
+
             <div class="modal-actions">
                 <button class="btn btn-secondary" onclick="safeModalClose()">Cancel</button>
                 <button class="btn btn-primary" onclick="safeModalExecuteUnstake()" ${!this.unstakeAmount || parseFloat(this.unstakeAmount) === 0 ? 'disabled' : ''}>
@@ -2388,6 +2722,159 @@ class StakingModalNew {
 
     updateUnstakeUsdEstimate() {
         this.updateLpUsdEstimate('unstake-usd-estimate', this.unstakeAmount);
+    }
+
+    formatRemoveLiquidityTokenAmount(amount, token) {
+        if (!amount || !token) {
+            return '-';
+        }
+
+        return this.formatZapDisplayAmount(amount.raw ?? amount.formatted, token.decimals ?? 18, token.symbol || '');
+    }
+
+    renderRemoveLiquidityControls() {
+        const slippageOptions = [10, 50, 100];
+        return `
+            <div class="remove-liquidity-section">
+                <div class="remove-liquidity-settings">
+                    <div class="form-group">
+                        <label class="form-label">Slippage</label>
+                        <div class="remove-liquidity-slippage-row">
+                            ${slippageOptions.map(option => `
+                                <button
+                                    type="button"
+                                    class="remove-liquidity-slippage-btn ${this.removeLiquiditySlippageBps === option && !this.removeLiquidityCustomSlippage ? 'active' : ''}"
+                                    data-slippage="${option}"
+                                >
+                                    ${(option / 100).toFixed(1)}%
+                                </button>
+                            `).join('')}
+                            <button
+                                type="button"
+                                class="remove-liquidity-slippage-btn ${this.isRemoveLiquidityCustomSlippageActive() ? 'active' : ''}"
+                                data-slippage="custom"
+                            >
+                                Custom
+                            </button>
+                            <input
+                                type="number"
+                                id="remove-liquidity-custom-slippage-input"
+                                class="form-input remove-liquidity-custom-slippage"
+                                placeholder="${(this.removeLiquiditySlippageBps / 100).toFixed(2)}%"
+                                value="${this.escapeHtml(this.removeLiquidityCustomSlippage)}"
+                                min="0.01"
+                                max="100"
+                                step="0.01"
+                                aria-invalid="${this.removeLiquidityCustomSlippageError ? 'true' : 'false'}"
+                            >
+                        </div>
+                        ${this.removeLiquidityCustomSlippageError ? `<div class="zap-field-error">${this.escapeHtml(this.removeLiquidityCustomSlippageError)}</div>` : ''}
+                    </div>
+
+                    <div class="form-group">
+                        <label class="form-label" for="remove-liquidity-deadline-input">Deadline</label>
+                        <div class="remove-liquidity-deadline-row">
+                            <input
+                                type="number"
+                                id="remove-liquidity-deadline-input"
+                                class="form-input"
+                                value="${this.escapeHtml(this.removeLiquidityDeadlineMinutes)}"
+                                min="1"
+                                max="4320"
+                                step="1"
+                                inputmode="numeric"
+                            >
+                            <span class="remove-liquidity-deadline-unit">minutes</span>
+                        </div>
+                    </div>
+                </div>
+
+                <div id="remove-liquidity-preview-panel">
+                    ${this.renderRemoveLiquidityPreviewPanel()}
+                </div>
+            </div>
+        `;
+    }
+
+    renderRemoveLiquidityPreviewPanel() {
+        const isLoading = this.removeLiquidityPreviewStatus === 'loading';
+        const isError = this.removeLiquidityPreviewStatus === 'error';
+        const hasPreview = this.removeLiquidityPreviewStatus === 'ready' && this.removeLiquidityPreview?.supported;
+        const pendingValue = isLoading ? '...' : '-';
+        const cardClass = [
+            'zap-quote-card',
+            'remove-liquidity-preview-card',
+            isLoading ? 'zap-quote-loading' : '',
+            isError ? 'zap-quote-error' : '',
+            !hasPreview && !isLoading && !isError ? 'zap-quote-placeholder' : ''
+        ].filter(Boolean).join(' ');
+        let summary = this.unstakeAmount
+            ? 'Checking remove liquidity support...'
+            : 'Enter an amount to preview pair token outputs.';
+        let dexDisplay = pendingValue;
+        let token0Display = pendingValue;
+        let token1Display = pendingValue;
+        let token0MinDisplay = pendingValue;
+        let token1MinDisplay = pendingValue;
+        const slippageDisplay = `${(Number(this.removeLiquiditySlippageBps) / 100).toFixed(2)}%`;
+        const deadlineDisplay = `${Number(this.removeLiquidityDeadlineMinutes) || 20} min`;
+
+        if (isLoading) {
+            summary = 'Loading LP reserves...';
+        } else if (isError) {
+            summary = this.removeLiquidityPreviewError || 'Remove liquidity is not supported for this pool.';
+            dexDisplay = this.removeLiquidityPreview?.factoryAddress
+                ? `Unsupported factory ${this.formatAddress(this.removeLiquidityPreview.factoryAddress)}`
+                : 'Unsupported';
+        } else if (hasPreview) {
+            const preview = this.removeLiquidityPreview;
+            dexDisplay = preview.adapter?.name || 'V2 DEX';
+            token0Display = this.formatRemoveLiquidityTokenAmount(preview.token0.amount, preview.token0);
+            token1Display = this.formatRemoveLiquidityTokenAmount(preview.token1.amount, preview.token1);
+            token0MinDisplay = this.formatRemoveLiquidityTokenAmount(preview.token0.minAmount, preview.token0);
+            token1MinDisplay = this.formatRemoveLiquidityTokenAmount(preview.token1.minAmount, preview.token1);
+            summary = `${preview.token0.symbol} + ${preview.token1.symbol} via ${dexDisplay}`;
+        }
+
+        const rows = [
+            this.renderZapQuoteRow('DEX', dexDisplay),
+            this.renderZapQuoteRow('Estimated token0', token0Display),
+            this.renderZapQuoteRow('Estimated token1', token1Display),
+            this.renderZapQuoteRow('Minimum token0', token0MinDisplay),
+            this.renderZapQuoteRow('Minimum token1', token1MinDisplay),
+            this.renderZapQuoteRow('Slippage', slippageDisplay),
+            this.renderZapQuoteRow('Deadline', deadlineDisplay)
+        ].join('');
+
+        return `
+            <div class="${cardClass}">
+                <div class="zap-quote-header">
+                    <div class="zap-route-summary">${this.escapeHtml(summary)}</div>
+                    <div class="zap-refresh-controls">
+                        <button
+                            type="button"
+                            class="zap-refresh-btn"
+                            onclick="safeModalFetchRemoveLiquidityPreview()"
+                            title="Refresh remove-liquidity preview"
+                            aria-label="Refresh remove-liquidity preview"
+                            ${!this.canFetchRemoveLiquidityPreview() || isLoading ? 'disabled' : ''}
+                        >
+                            <span class="material-icons">sync</span>
+                        </button>
+                    </div>
+                </div>
+                <dl class="zap-quote-list remove-liquidity-preview-list">
+                    ${rows}
+                </dl>
+            </div>
+        `;
+    }
+
+    updateRemoveLiquidityPreviewPanel() {
+        const panel = document.getElementById('remove-liquidity-preview-panel');
+        if (panel) {
+            panel.innerHTML = this.renderRemoveLiquidityPreviewPanel();
+        }
     }
 
     updateLpUsdEstimate(elementId, amount) {
@@ -2745,6 +3232,8 @@ class StakingModalNew {
 
             // Update button states
             this.updateUnstakeUsdEstimate();
+            this.resetRemoveLiquidityPreview();
+            this.debounceRemoveLiquidityPreview();
             this.updateButtonStates();
         }
 
@@ -2792,6 +3281,8 @@ class StakingModalNew {
             const input = document.getElementById('unstake-amount-input');
             if (input) input.value = amount;
             this.updateUnstakeUsdEstimate();
+            this.resetRemoveLiquidityPreview();
+            this.debounceRemoveLiquidityPreview();
             this.updateButtonStates();
         }
     }
@@ -3065,6 +3556,90 @@ class StakingModalNew {
         }
     }
 
+    async executeRemoveLiquidityAfterUnstake(lpTokenAddress, liquidityRaw) {
+        const service = this.getRemoveLiquidityService();
+        const provider = window.contractManager?.provider || window.walletManager?.provider;
+
+        await window.contractManager.ensureSigner();
+        const signer = window.contractManager.signer;
+        const userAddress = await signer.getAddress();
+
+        if (!this.removeLiquidityPreview?.supported) {
+            await this.fetchRemoveLiquidityPreview({ force: true });
+        }
+
+        const preview = this.removeLiquidityPreview;
+        if (!preview?.supported) {
+            throw new Error(this.removeLiquidityPreviewError || 'Remove liquidity is not supported for this pool.');
+        }
+
+        await service.validateRouterFactory({
+            routerAddress: preview.adapter.routerAddress,
+            factoryAddress: preview.adapter.factoryAddress,
+            provider
+        });
+
+        const lpBalance = await service.getBalance({
+            lpTokenAddress,
+            owner: userAddress,
+            provider
+        });
+        if (lpBalance.lt(liquidityRaw)) {
+            throw new Error('The unstaked LP balance is not available yet. Your LP tokens remain in your wallet.');
+        }
+
+        const allowance = await service.getAllowance({
+            lpTokenAddress,
+            owner: userAddress,
+            spender: preview.adapter.routerAddress,
+            provider
+        });
+
+        if (allowance.lt(liquidityRaw)) {
+            this.pendingOperations.approveRemoveLiquidity = true;
+            this.setActionPhase('approveRemoveLiquidity', 'userApproval');
+            window.notificationManager?.info('Approving router to spend unstaked LP tokens...');
+
+            await window.contractManager.executeTransactionOnce(async () => {
+                const tx = await service.approveIfNeeded({
+                    lpTokenAddress,
+                    spender: preview.adapter.routerAddress,
+                    liquidityRaw,
+                    signer
+                });
+                if (!tx) {
+                    throw new Error('Router allowance is already sufficient.');
+                }
+                console.log(`✅ Remove-liquidity approval sent: ${tx.hash}`);
+                return tx;
+            }, 'approveRemoveLiquidity');
+
+            this.pendingOperations.approveRemoveLiquidity = false;
+            this.setActionPhase('approveRemoveLiquidity', 'idle');
+        }
+
+        const deadlineSeconds = Math.floor(Date.now() / 1000) + (Number(this.removeLiquidityDeadlineMinutes) || 20) * 60;
+        this.pendingOperations.removeLiquidity = true;
+        this.setActionPhase('removeLiquidity', 'userApproval');
+        window.notificationManager?.info('Removing liquidity...');
+
+        return await window.contractManager.executeTransactionOnce(async () => {
+            const tx = await service.removeLiquidity({
+                routerAddress: preview.adapter.routerAddress,
+                token0: preview.token0.address,
+                token1: preview.token1.address,
+                liquidityRaw,
+                amount0Min: preview.token0.minAmount.raw,
+                amount1Min: preview.token1.minAmount.raw,
+                recipient: userAddress,
+                deadline: deadlineSeconds,
+                signer
+            });
+            console.log(`✅ Remove liquidity transaction sent: ${tx.hash}`);
+            return tx;
+        }, 'removeLiquidity');
+    }
+
     async executeUnstake() {
         // Guard against multiple simultaneous executions
         if (this.isExecutingUnstake) {
@@ -3074,9 +3649,12 @@ class StakingModalNew {
 
         if (!this.unstakeAmount || parseFloat(this.unstakeAmount) === 0) return;
 
+        let unstakeSucceeded = false;
+
         try {
             // Set execution guard
             this.isExecutingUnstake = true;
+            this.isExecutingRemoveLiquidity = this.removeLiquidityEnabled;
             this.updateUnstakeButton();
             console.log('🔒 Unstake execution started, guard enabled');
 
@@ -3088,15 +3666,37 @@ class StakingModalNew {
                 return;
             }
 
-            if (window.notificationManager) {
-                window.notificationManager.info('Unstaking LP tokens...');
+            if (this.removeLiquidityEnabled) {
+                const slippageError = this.getRemoveLiquidityCustomSlippageError();
+                if (slippageError) {
+                    this.updateRemoveLiquidityPreviewPanel();
+                    this.updateUnstakeButton();
+                    window.notificationManager?.error(slippageError);
+                    return;
+                }
+
+                if (!this.removeLiquidityPreview?.supported) {
+                    await this.fetchRemoveLiquidityPreview({ force: true });
+                }
+
+                if (!this.removeLiquidityPreview?.supported) {
+                    window.notificationManager?.error(this.removeLiquidityPreviewError || 'Remove liquidity is not supported for this pool.');
+                    return;
+                }
             }
+
+            if (window.notificationManager) {
+                window.notificationManager.info(this.removeLiquidityEnabled ? 'Unstaking LP tokens before removing liquidity...' : 'Unstaking LP tokens...');
+            }
+
+            const lpTokenAddress = this.currentPair.lpToken || this.currentPair.address;
+            const liquidityRaw = this.getRemoveLiquidityAmountRaw();
 
             // Execute real unstaking transaction
             this.pendingOperations.unstake = true;
             this.setActionPhase('unstake', 'userApproval');
             const result = await window.contractManager.unstake(
-                this.currentPair.address,
+                lpTokenAddress,
                 this.unstakeAmount,
                 this.claimRewardsOnUnstake
             );
@@ -3108,12 +3708,19 @@ class StakingModalNew {
             if (!result.success) {
                 throw result.error;
             }
+            unstakeSucceeded = true;
 
             if (window.notificationManager) {
-                window.notificationManager.success('LP tokens unstaked successfully!');
+                window.notificationManager.success(this.removeLiquidityEnabled ? 'LP tokens unstaked. Continue in your wallet to remove liquidity.' : 'LP tokens unstaked successfully!');
             }
 
             console.log('✅ Unstaking transaction successful:', result.hash);
+
+            if (this.removeLiquidityEnabled) {
+                await this.loadUserBalances();
+                await this.executeRemoveLiquidityAfterUnstake(lpTokenAddress, liquidityRaw);
+                window.notificationManager?.success('Liquidity removed successfully!');
+            }
             
             // Clear inputs after successful transaction
             this.clearInputs();
@@ -3136,13 +3743,30 @@ class StakingModalNew {
 
         } catch (error) {
             console.error('❌ Unstaking failed:', error);
-            const errorMessage = error?.userMessage?.message || error?.message || 'Unstaking failed. Please try again.';
-            window.notificationManager.error(errorMessage, {title: error?.userMessage?.title});
+            const fallbackMessage = unstakeSucceeded && this.removeLiquidityEnabled
+                ? 'LP tokens were unstaked, but liquidity removal did not complete. Your LP tokens remain in your wallet.'
+                : 'Unstaking failed. Please try again.';
+            const errorMessage = error?.userMessage?.message || error?.message || '';
+            const message = unstakeSucceeded && this.removeLiquidityEnabled
+                ? `${fallbackMessage}${errorMessage ? ` ${errorMessage}` : ''}`
+                : (errorMessage || fallbackMessage);
+            window.notificationManager.error(message, {title: error?.userMessage?.title});
+            if (unstakeSucceeded && this.removeLiquidityEnabled) {
+                await this.loadUserBalances().catch(loadError => {
+                    console.warn('Unable to refresh balances after partial unstake flow:', loadError.message);
+                });
+                this.updateUnstakeButton();
+            }
         } finally {
             // Always release the guard
             this.pendingOperations.unstake = false;
+            this.pendingOperations.approveRemoveLiquidity = false;
+            this.pendingOperations.removeLiquidity = false;
             this.setActionPhase('unstake', 'idle');
+            this.setActionPhase('approveRemoveLiquidity', 'idle');
+            this.setActionPhase('removeLiquidity', 'idle');
             this.isExecutingUnstake = false;
+            this.isExecutingRemoveLiquidity = false;
             this.updateUnstakeButton();
             console.log('🔓 Unstake execution finished, guard released');
         }
@@ -3365,5 +3989,18 @@ window.safeModalAddZapCustomToken = function() {
         }
     } catch (error) {
         console.error('❌ Error adding custom zap token:', error);
+    }
+};
+
+window.safeModalFetchRemoveLiquidityPreview = function() {
+    try {
+        const modal = window.stakingModal || window.stakingModalNew || window.getStakingModal();
+        if (modal && typeof modal.fetchRemoveLiquidityPreview === 'function') {
+            modal.fetchRemoveLiquidityPreview({ force: true });
+        } else {
+            console.warn('⚠️ Modal fetchRemoveLiquidityPreview method not available');
+        }
+    } catch (error) {
+        console.error('❌ Error fetching remove-liquidity preview:', error);
     }
 };

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -890,15 +890,7 @@ class StakingModalNew {
             input.removeAttribute?.('aria-describedby');
         }
 
-        let errorElement = document.getElementById(errorId);
-        if (!errorElement && typeof document.createElement === 'function') {
-            errorElement = document.createElement('div');
-            errorElement.id = errorId;
-            errorElement.className = 'zap-field-error custom-slippage-error';
-            errorElement.setAttribute?.('aria-live', 'polite');
-            input.closest?.('.form-group')?.appendChild?.(errorElement);
-        }
-
+        const errorElement = document.getElementById(errorId);
         if (errorElement) {
             errorElement.textContent = errorMessage;
         }

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -3288,6 +3288,10 @@ class StakingModalNew {
                         <label
                             class="form-label"
                             title="Maximum output movement allowed before the transaction reverts."
+                            data-tooltip="Maximum output movement allowed before the transaction reverts."
+                            tabindex="0"
+                            role="button"
+                            aria-label="Max Slippage: Maximum output movement allowed before the transaction reverts."
                         >Max Slippage</label>
                         <div class="remove-liquidity-slippage-row">
                             ${slippageOptions.map(option => `
@@ -3326,6 +3330,10 @@ class StakingModalNew {
                             class="form-label"
                             for="remove-liquidity-deadline-input"
                             title="Latest time this transaction can execute before it reverts."
+                            data-tooltip="Latest time this transaction can execute before it reverts."
+                            tabindex="0"
+                            role="button"
+                            aria-label="Transaction time limit: Latest time this transaction can execute before it reverts."
                         >Transaction time limit</label>
                         <div class="remove-liquidity-deadline-row">
                             <input
@@ -3356,7 +3364,6 @@ class StakingModalNew {
                     >
                         <span
                             class="remove-liquidity-settings-label"
-                            title="Maximum output movement allowed before the transaction reverts."
                         >Max slippage:</span>
                         <strong>${slippageDisplay}</strong>
                         <span class="material-icons" aria-hidden="true">settings</span>

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -2831,7 +2831,7 @@ class StakingModalNew {
 
             <div class="modal-actions">
                 <button class="btn btn-secondary" onclick="safeModalClose()">Cancel</button>
-                <button class="btn btn-primary" onclick="safeModalExecuteRemoveLiquidity()" ${!this.removeLiquidityAmount || parseFloat(this.removeLiquidityAmount) === 0 ? 'disabled' : ''}>
+                <button class="btn btn-primary remove-liquidity-action-btn" onclick="safeModalExecuteRemoveLiquidity()" ${!this.removeLiquidityAmount || parseFloat(this.removeLiquidityAmount) === 0 ? 'disabled' : ''}>
                     <span class="material-icons">swap_horiz</span>
                     Remove LP Liquidity
                 </button>

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -690,21 +690,6 @@ class StakingModalNew {
         return window.Formatter?.formatCurrency?.(estimate) || `$${estimate.toFixed(2)}`;
     }
 
-    formatUsdNumber(value) {
-        const numericValue = Number(value);
-        if (!Number.isFinite(numericValue)) {
-            return String(value);
-        }
-
-        return window.Formatter?.formatCurrency?.(numericValue)?.replace(/^\$/, '')
-            || numericValue.toLocaleString(undefined, { maximumFractionDigits: 2 });
-    }
-
-    formatUsdDisplay(value) {
-        const formatted = this.formatUsdNumber(value);
-        return String(formatted).startsWith('$') ? formatted : `$${formatted}`;
-    }
-
     renderInlineLpUsdEstimate(amount) {
         const estimate = this.formatLpUsdEstimate(amount);
         return estimate ? ` <span class="lp-usd-estimate">(${this.escapeHtml(estimate)})</span>` : '';
@@ -1069,13 +1054,6 @@ class StakingModalNew {
                     slippageBps: this.removeLiquiditySlippageBps,
                     platform: this.currentPair?.platform
                 });
-                this.logRemoveLiquidityZapOutFeeDebug({
-                    payload,
-                    outputToken,
-                    tokenOutAddress,
-                    liquidityRaw
-                });
-
                 preview = {
                     ...payload,
                     supported: true,
@@ -2099,100 +2077,6 @@ class StakingModalNew {
         );
     }
 
-    getKyberProtocolFeeSources(data) {
-        const protocolFeeSources = [];
-        const addProtocolFeeSource = (path, source) => {
-            if (source && typeof source === 'object') {
-                protocolFeeSources.push({ path, source });
-            }
-        };
-
-        addProtocolFeeSource('zapDetails.protocolFee', data?.zapDetails?.protocolFee);
-        addProtocolFeeSource('protocolFee', data?.protocolFee);
-
-        if (Array.isArray(data?.zapDetails?.actions)) {
-            data.zapDetails.actions.forEach((action, index) => {
-                addProtocolFeeSource(`zapDetails.actions[${index}].protocolFee`, action?.protocolFee);
-            });
-        }
-
-        return protocolFeeSources;
-    }
-
-    getKyberZapActionDebugSummary(data) {
-        const actions = Array.isArray(data?.zapDetails?.actions) ? data.zapDetails.actions : [];
-        const summarizeToken = token => token ? {
-            address: token.address ?? null,
-            symbol: token.symbol ?? null,
-            decimals: token.decimals ?? null,
-            amount: token.amount ?? null,
-            amountUsd: token.amountUsd ?? token.amount_usd ?? null
-        } : null;
-        const summarizeTokens = tokens => Array.isArray(tokens)
-            ? tokens.map(summarizeToken).filter(Boolean)
-            : [];
-        const summarizeSwap = swap => ({
-            tokenIn: summarizeToken(swap?.tokenIn),
-            tokenOut: summarizeToken(swap?.tokenOut)
-        });
-
-        return actions.map((action, index) => ({
-            index,
-            type: action?.type ?? null,
-            keys: action && typeof action === 'object' ? Object.keys(action) : [],
-            removeLiquidityTokens: summarizeTokens(action?.removeLiquidity?.tokens),
-            removeLiquidityToken0: summarizeToken(action?.removeLiquidity?.token0),
-            removeLiquidityToken1: summarizeToken(action?.removeLiquidity?.token1),
-            protocolFeeTokens: summarizeTokens(action?.protocolFee?.tokens),
-            aggregatorSwaps: Array.isArray(action?.aggregatorSwap?.swaps)
-                ? action.aggregatorSwap.swaps.map(summarizeSwap)
-                : [],
-            poolSwaps: Array.isArray(action?.poolSwap?.swaps)
-                ? action.poolSwap.swaps.map(summarizeSwap)
-                : [],
-            refundTokens: summarizeTokens(action?.refund?.tokens)
-        }));
-    }
-
-    logRemoveLiquidityZapOutFeeDebug({ payload, outputToken, tokenOutAddress, liquidityRaw }) {
-        const data = this.getKyberZapService().getRouteData(payload);
-        const feeSources = this.getKyberProtocolFeeSources(data);
-        const protocolFeeTokenRows = feeSources.flatMap(({ path, source }) => (
-            Array.isArray(source?.tokens)
-                ? source.tokens.map(token => ({
-                    path,
-                    address: token?.address ?? null,
-                    symbol: token?.symbol ?? null,
-                    decimals: token?.decimals ?? null,
-                    amount: token?.amount ?? null,
-                    amountUsd: token?.amountUsd ?? token?.amount_usd ?? null
-                }))
-                : [{
-                    path,
-                    address: null,
-                    symbol: null,
-                    decimals: null,
-                    amount: source?.amount ?? null,
-                    amountUsd: null
-                }]
-        ));
-
-        console.info('[Kyber zap-out fee debug]', {
-            selectedOutputToken: outputToken ? {
-                address: outputToken.address,
-                symbol: outputToken.symbol,
-                decimals: outputToken.decimals
-            } : null,
-            tokenOutAddress,
-            liquidityRaw: liquidityRaw?.toString?.() || String(liquidityRaw || ''),
-            displayedFeeDetails: this.getRemoveLiquidityProtocolFeeDetails(data),
-            protocolFeeTokenRows,
-            actionSummary: this.getKyberZapActionDebugSummary(data),
-            routeKeys: data && typeof data === 'object' ? Object.keys(data) : [],
-            zapDetailsKeys: data?.zapDetails && typeof data.zapDetails === 'object' ? Object.keys(data.zapDetails) : []
-        });
-    }
-
     formatZapBalanceDisplay(balance, token) {
         if (!balance || !token) {
             return '';
@@ -3131,7 +3015,6 @@ class StakingModalNew {
         // Update button states when input changes
         const stakeInput = document.getElementById('stake-amount-input');
         const unstakeInput = document.getElementById('unstake-amount-input');
-        const removeLiquidityInput = document.getElementById('remove-liquidity-amount-input');
 
         if (stakeInput) {
             stakeInput.addEventListener('input', () => {
@@ -3154,20 +3037,6 @@ class StakingModalNew {
                 }
                 this.unstakeAmount = sanitizedValue;
                 this.updateUnstakeUsdEstimate();
-                this.updateButtonStates();
-            });
-        }
-
-        if (removeLiquidityInput) {
-            removeLiquidityInput.addEventListener('input', () => {
-                const sanitizedValue = this.applyDecimalLimit(removeLiquidityInput.value, this.userBalanceDecimals);
-                if (sanitizedValue !== removeLiquidityInput.value) {
-                    removeLiquidityInput.value = sanitizedValue;
-                }
-                this.removeLiquidityAmount = sanitizedValue;
-                this.updateRemoveLiquidityUsdEstimate();
-                this.resetRemoveLiquidityPreview();
-                this.debounceRemoveLiquidityPreview();
                 this.updateButtonStates();
             });
         }

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -891,15 +891,11 @@ class StakingModalNew {
         }
 
         let errorElement = document.getElementById(errorId);
-        if (!errorMessage) {
-            errorElement?.remove?.();
-            return;
-        }
-
         if (!errorElement && typeof document.createElement === 'function') {
             errorElement = document.createElement('div');
             errorElement.id = errorId;
-            errorElement.className = 'zap-field-error';
+            errorElement.className = 'zap-field-error custom-slippage-error';
+            errorElement.setAttribute?.('aria-live', 'polite');
             input.closest?.('.form-group')?.appendChild?.(errorElement);
         }
 
@@ -3411,7 +3407,7 @@ class StakingModalNew {
                                 ${this.removeLiquidityCustomSlippageError ? 'aria-describedby="remove-liquidity-custom-slippage-error"' : ''}
                             >
                         </div>
-                        ${this.removeLiquidityCustomSlippageError ? `<div id="remove-liquidity-custom-slippage-error" class="zap-field-error">${this.escapeHtml(this.removeLiquidityCustomSlippageError)}</div>` : ''}
+                        <div id="remove-liquidity-custom-slippage-error" class="zap-field-error custom-slippage-error" aria-live="polite">${this.escapeHtml(this.removeLiquidityCustomSlippageError)}</div>
                     </div>
 
                     <div class="form-group">
@@ -3926,7 +3922,7 @@ class StakingModalNew {
                         ${this.zapCustomSlippageError ? 'aria-describedby="zap-custom-slippage-error"' : ''}
                     >
                 </div>
-                ${this.zapCustomSlippageError ? `<div id="zap-custom-slippage-error" class="zap-field-error">${this.escapeHtml(this.zapCustomSlippageError)}</div>` : ''}
+                <div id="zap-custom-slippage-error" class="zap-field-error custom-slippage-error" aria-live="polite">${this.escapeHtml(this.zapCustomSlippageError)}</div>
             </div>
 
             <div id="zap-quote-panel">

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -761,7 +761,7 @@ class StakingModalNew {
         this.removeLiquidityPreviewRequestId += 1;
         this.clearRemoveLiquidityPreviewDebounce();
         this.updateRemoveLiquidityPreviewPanel();
-        this.updateUnstakeButton();
+        this.updateRemoveLiquidityButton();
     }
 
     getRemoveLiquidityAmountRaw() {
@@ -831,7 +831,7 @@ class StakingModalNew {
             }
             this.updateRemoveLiquidityPreviewPanel();
             this.debounceRemoveLiquidityPreview();
-            this.updateUnstakeButton();
+            this.updateRemoveLiquidityButton();
             return sanitizedValue;
         }
 
@@ -868,7 +868,7 @@ class StakingModalNew {
 
         if (!this.canFetchRemoveLiquidityPreview()) {
             this.updateRemoveLiquidityPreviewPanel();
-            this.updateUnstakeButton();
+            this.updateRemoveLiquidityButton();
             return;
         }
 
@@ -880,13 +880,13 @@ class StakingModalNew {
     async fetchRemoveLiquidityPreview({ force = false } = {}) {
         if (!this.canFetchRemoveLiquidityPreview()) {
             this.updateRemoveLiquidityPreviewPanel();
-            this.updateUnstakeButton();
+            this.updateRemoveLiquidityButton();
             return;
         }
 
         if (!force && this.removeLiquidityPreviewStatus === 'ready' && this.removeLiquidityPreview?.supported) {
             this.updateRemoveLiquidityPreviewPanel();
-            this.updateUnstakeButton();
+            this.updateRemoveLiquidityButton();
             return;
         }
 
@@ -909,7 +909,7 @@ class StakingModalNew {
             this.removeLiquidityPreviewStatus = 'loading';
             this.removeLiquidityPreviewError = '';
             this.updateRemoveLiquidityPreviewPanel();
-            this.updateUnstakeButton();
+            this.updateRemoveLiquidityButton();
 
             const preview = await this.getRemoveLiquidityService().getPreview({
                 chainId,
@@ -943,7 +943,7 @@ class StakingModalNew {
         } finally {
             if (requestId === this.removeLiquidityPreviewRequestId) {
                 this.updateRemoveLiquidityPreviewPanel();
-                this.updateUnstakeButton();
+                this.updateRemoveLiquidityButton();
             }
         }
     }

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -44,9 +44,9 @@ class StakingModalNew {
         this.zapCustomTokenAddress = '';
         this.zapCustomTokenError = '';
 
-        // V2 remove-liquidity state
+        // V2 remove-liquidity / Kyber zap-out state
         this.removeLiquidityService = window.V2RemoveLiquidityService ? new window.V2RemoveLiquidityService() : null;
-        this.convertLibToUsdtEnabled = false;
+        this.removeLiquidityZapOutEnabled = false;
         this.removeLiquidityAmount = '';
         this.removeLiquidityPreview = null;
         this.removeLiquidityPreviewStatus = 'idle';
@@ -57,6 +57,11 @@ class StakingModalNew {
         this.removeLiquidityDeadlineMinutes = window.CONFIG?.KYBER_ZAP?.DEFAULT_DEADLINE_MINUTES || 20;
         this.removeLiquidityPreviewDebounceTimer = null;
         this.removeLiquidityPreviewRequestId = 0;
+        this.removeLiquidityOutputTokenAddress = '';
+        this.removeLiquidityOutputTokens = [];
+        this.removeLiquiditySelectedOutputToken = null;
+        this.removeLiquidityCustomOutputTokenAddress = '';
+        this.removeLiquidityCustomOutputTokenError = '';
 
         // Approval state
         this.needsApproval = false;
@@ -73,8 +78,8 @@ class StakingModalNew {
             zap: 'idle',
             approveRemoveLiquidity: 'idle',
             removeLiquidity: 'idle',
-            approveRemoveLiquidityConversion: 'idle',
-            convertRemoveLiquidityToken: 'idle'
+            approveRemoveLiquidityZapOut: 'idle',
+            zapOutLP: 'idle'
         };
         this.pendingOperations = {
             approve: false,
@@ -85,8 +90,8 @@ class StakingModalNew {
             zap: false,
             approveRemoveLiquidity: false,
             removeLiquidity: false,
-            approveRemoveLiquidityConversion: false,
-            convertRemoveLiquidityToken: false
+            approveRemoveLiquidityZapOut: false,
+            zapOutLP: false
         };
 
         // Execution guards
@@ -129,10 +134,10 @@ class StakingModalNew {
                 return 'approveRemoveLiquidity';
             case 'removeLiquidity':
                 return 'removeLiquidity';
-            case 'approveRemoveLiquidityConversion':
-                return 'approveRemoveLiquidityConversion';
-            case 'convertRemoveLiquidityToken':
-                return 'convertRemoveLiquidityToken';
+            case 'approveRemoveLiquidityZapOut':
+                return 'approveRemoveLiquidityZapOut';
+            case 'zapOutLP':
+                return 'zapOutLP';
             default:
                 return null;
         }
@@ -169,8 +174,8 @@ class StakingModalNew {
 
         if (action === 'approveRemoveLiquidity'
             || action === 'removeLiquidity'
-            || action === 'approveRemoveLiquidityConversion'
-            || action === 'convertRemoveLiquidityToken') {
+            || action === 'approveRemoveLiquidityZapOut'
+            || action === 'zapOutLP') {
             this.updateRemoveLiquidityButton();
         }
 
@@ -307,18 +312,29 @@ class StakingModalNew {
                 this.setRemoveLiquiditySlippage(button.dataset.slippage);
             }
 
+            if (e.target.closest('.remove-liquidity-output-token-option')) {
+                const button = e.target.closest('.remove-liquidity-output-token-option');
+                this.setRemoveLiquidityOutputToken(button.dataset.tokenAddress);
+            }
+
             if (e.target.closest('.zap-percentage-btn')) {
                 const button = e.target.closest('.zap-percentage-btn');
                 this.setZapAmountPercentage(parseInt(button.dataset.percentage, 10));
             }
 
-            if (e.target.closest('.zap-token-option')) {
+            if (e.target.closest('.zap-token-option') && !e.target.closest('.remove-liquidity-output-token-picker')) {
                 const button = e.target.closest('.zap-token-option');
                 this.setZapInputToken(button.dataset.tokenAddress);
             }
 
             if (!e.target.closest('.zap-token-picker')) {
                 document.querySelectorAll('.zap-token-picker[open]').forEach(menu => {
+                    menu.open = false;
+                });
+            }
+
+            if (!e.target.closest('.remove-liquidity-output-token-picker')) {
+                document.querySelectorAll('.remove-liquidity-output-token-picker[open]').forEach(menu => {
                     menu.open = false;
                 });
             }
@@ -400,6 +416,11 @@ class StakingModalNew {
                 }
             }
 
+            if (e.target.id === 'remove-liquidity-custom-output-token-input') {
+                this.removeLiquidityCustomOutputTokenAddress = e.target.value.trim();
+                this.removeLiquidityCustomOutputTokenError = '';
+            }
+
             if (e.target.id === 'remove-liquidity-deadline-input') {
                 const sanitizedValue = this.setRemoveLiquidityDeadlineInput(e.target.value);
                 if (sanitizedValue !== e.target.value) {
@@ -416,7 +437,7 @@ class StakingModalNew {
             }
 
             if (e.target.id === 'remove-liquidity-checkbox') {
-                this.convertLibToUsdtEnabled = e.target.checked;
+                this.removeLiquidityZapOutEnabled = e.target.checked;
                 this.resetRemoveLiquidityPreview();
                 this.renderTabContent();
                 this.debounceRemoveLiquidityPreview(0);
@@ -663,6 +684,21 @@ class StakingModalNew {
         return window.Formatter?.formatCurrency?.(estimate) || `$${estimate.toFixed(2)}`;
     }
 
+    formatUsdNumber(value) {
+        const numericValue = Number(value);
+        if (!Number.isFinite(numericValue)) {
+            return String(value);
+        }
+
+        return window.Formatter?.formatCurrency?.(numericValue)?.replace(/^\$/, '')
+            || numericValue.toLocaleString(undefined, { maximumFractionDigits: 2 });
+    }
+
+    formatUsdDisplay(value) {
+        const formatted = this.formatUsdNumber(value);
+        return String(formatted).startsWith('$') ? formatted : `$${formatted}`;
+    }
+
     renderInlineLpUsdEstimate(amount) {
         const estimate = this.formatLpUsdEstimate(amount);
         return estimate ? ` <span class="lp-usd-estimate">(${this.escapeHtml(estimate)})</span>` : '';
@@ -757,13 +793,15 @@ class StakingModalNew {
     }
 
     resetRemoveLiquidityFormState() {
-        this.convertLibToUsdtEnabled = false;
+        this.removeLiquidityZapOutEnabled = false;
         this.removeLiquidityAmount = '';
         this.removeLiquidityPreview = null;
         this.removeLiquidityPreviewStatus = 'idle';
         this.removeLiquidityPreviewError = '';
         this.removeLiquidityCustomSlippage = '';
         this.removeLiquidityCustomSlippageError = '';
+        this.removeLiquidityCustomOutputTokenAddress = '';
+        this.removeLiquidityCustomOutputTokenError = '';
         this.removeLiquidityPreviewRequestId += 1;
         this.clearRemoveLiquidityPreviewDebounce();
     }
@@ -877,99 +915,33 @@ class StakingModalNew {
     }
 
     canFetchRemoveLiquidityPreview() {
-        return this.convertLibToUsdtEnabled && this.canPrepareRemoveLiquidityPreview();
+        return this.removeLiquidityZapOutEnabled
+            && this.canPrepareRemoveLiquidityPreview()
+            && !!this.removeLiquiditySelectedOutputToken;
     }
 
-    getRemoveLiquidityConversionTokens(preview = this.removeLiquidityPreview) {
-        if (!preview?.supported) {
-            return null;
+    getRemoveLiquidityOutputTokenAddressForKyber(token = this.removeLiquiditySelectedOutputToken) {
+        if (!token) {
+            return '';
         }
 
-        const chainConfig = window.CONFIG?.DEX_REMOVE_LIQUIDITY?.[String(this.getRemoveLiquidityChainId())] || null;
-        const conversionConfig = chainConfig?.libToUsdtConversion || null;
-        const fromAddress = this.normalizeAddress(conversionConfig?.fromToken);
-        const toAddress = this.normalizeAddress(conversionConfig?.toToken);
-        if (!fromAddress || !toAddress) {
-            return null;
+        if (this.isNativeZapToken(token.address)) {
+            return window.CONFIG?.KYBER_ZAP?.NATIVE_TOKEN_ADDRESS || token.address;
         }
 
-        const tokens = [preview.token0, preview.token1];
-        const fromToken = tokens.find(token => this.normalizeAddress(token?.address) === fromAddress);
-        const toToken = tokens.find(token => this.normalizeAddress(token?.address) === toAddress);
-
-        if (!fromToken || !toToken || fromAddress === toAddress) {
-            return null;
-        }
-
-        return {
-            fromToken,
-            toToken,
-            path: [fromToken.address, toToken.address]
-        };
+        return token.address;
     }
 
-    normalizeAddress(address) {
-        return String(address || '').toLowerCase();
+    getRemoveLiquidityRouteData() {
+        return this.getKyberZapService().getRouteData(this.removeLiquidityPreview);
     }
 
-    async addRemoveLiquidityConversionPreview(preview, provider) {
-        if (!this.convertLibToUsdtEnabled || !preview?.supported) {
-            return preview;
-        }
+    getRemoveLiquidityRouteEncoded() {
+        return this.getKyberZapService().getRouteEncoded(this.removeLiquidityPreview);
+    }
 
-        const conversion = this.getRemoveLiquidityConversionTokens(preview);
-        if (!conversion) {
-            return {
-                ...preview,
-                conversion: {
-                    supported: false,
-                    reason: 'LIB to USDT conversion is only available for LIB/USDT pools.'
-                }
-            };
-        }
-
-        const service = this.getRemoveLiquidityService();
-        const quote = await service.getSwapQuote({
-            routerAddress: preview.adapter.routerAddress,
-            amountIn: conversion.fromToken.amount.raw,
-            path: conversion.path,
-            provider
-        });
-        const amountOutMin = service.calculateMinAmount(quote.amountOut, this.removeLiquiditySlippageBps);
-        const returnedTargetAmount = window.ethers.BigNumber.from(conversion.toToken.amount.raw);
-        const returnedTargetMinAmount = window.ethers.BigNumber.from(conversion.toToken.minAmount.raw);
-        const finalAmount = returnedTargetAmount.add(quote.amountOut);
-        const finalMinAmount = returnedTargetMinAmount.add(amountOutMin);
-
-        return {
-            ...preview,
-            conversion: {
-                supported: true,
-                fromToken: conversion.fromToken,
-                toToken: conversion.toToken,
-                path: conversion.path,
-                amountIn: {
-                    raw: quote.amountIn.toString(),
-                    formatted: service.formatUnits(quote.amountIn, conversion.fromToken.decimals)
-                },
-                amountOut: {
-                    raw: quote.amountOut.toString(),
-                    formatted: service.formatUnits(quote.amountOut, conversion.toToken.decimals)
-                },
-                minAmountOut: {
-                    raw: amountOutMin.toString(),
-                    formatted: service.formatUnits(amountOutMin, conversion.toToken.decimals)
-                },
-                finalAmount: {
-                    raw: finalAmount.toString(),
-                    formatted: service.formatUnits(finalAmount, conversion.toToken.decimals)
-                },
-                finalMinAmount: {
-                    raw: finalMinAmount.toString(),
-                    formatted: service.formatUnits(finalMinAmount, conversion.toToken.decimals)
-                }
-            }
-        };
+    getRemoveLiquidityRouterAddress(source = null) {
+        return this.getKyberZapService().getRouterAddress(source || this.getRemoveLiquidityRouteData());
     }
 
     debounceRemoveLiquidityPreview(delay = 400) {
@@ -1020,28 +992,61 @@ class StakingModalNew {
             this.updateRemoveLiquidityPreviewPanel();
             this.updateRemoveLiquidityButton();
 
-            const basePreview = await this.getRemoveLiquidityService().getPreview({
-                chainId,
-                lpTokenAddress,
-                liquidityRaw,
-                slippageBps: this.removeLiquiditySlippageBps,
-                provider
-            });
-            const preview = await this.addRemoveLiquidityConversionPreview(basePreview, provider);
+            let preview;
+            if (this.removeLiquidityZapOutEnabled) {
+                const networkConfig = this.getKyberZapNetworkConfig();
+                const outputToken = this.removeLiquiditySelectedOutputToken;
+                const tokenOutAddress = this.getRemoveLiquidityOutputTokenAddressForKyber(outputToken);
+
+                if (!networkConfig) {
+                    throw new Error('Zap out is not available on this network.');
+                }
+                if (!window.walletManager?.address) {
+                    throw new Error('Connect your wallet to preview zap out.');
+                }
+                if (!outputToken || !tokenOutAddress) {
+                    throw new Error('Select an output token to preview zap out.');
+                }
+
+                const payload = await this.getKyberZapService().fetchOutQuote({
+                    networkConfig,
+                    lpTokenAddress,
+                    walletAddress: window.walletManager.address,
+                    tokenOutAddress,
+                    liquidityRaw,
+                    slippageBps: this.removeLiquiditySlippageBps,
+                    platform: this.currentPair?.platform
+                });
+
+                preview = {
+                    ...payload,
+                    supported: true,
+                    zapOut: true,
+                    outputToken,
+                    liquidityRaw: liquidityRaw.toString(),
+                    slippageBps: this.removeLiquiditySlippageBps
+                };
+            } else {
+                preview = await this.getRemoveLiquidityService().getPreview({
+                    chainId,
+                    lpTokenAddress,
+                    liquidityRaw,
+                    slippageBps: this.removeLiquiditySlippageBps,
+                    provider
+                });
+            }
 
             if (requestId !== this.removeLiquidityPreviewRequestId) {
                 return;
             }
 
             this.removeLiquidityPreview = preview;
-            if (preview.supported && (!this.convertLibToUsdtEnabled || preview.conversion?.supported)) {
+            if (preview.supported) {
                 this.removeLiquidityPreviewStatus = 'ready';
                 this.removeLiquidityPreviewError = '';
             } else {
                 this.removeLiquidityPreviewStatus = 'error';
-                this.removeLiquidityPreviewError = preview.conversion?.reason
-                    || preview.reason
-                    || 'Remove liquidity is not supported for this pool.';
+                this.removeLiquidityPreviewError = preview.reason || 'Remove liquidity is not supported for this pool.';
             }
         } catch (error) {
             if (requestId !== this.removeLiquidityPreviewRequestId) {
@@ -1139,8 +1144,22 @@ class StakingModalNew {
             this.zapInputTokenAddress = this.zapInputTokens[0]?.address || 'native';
         }
         this.zapSelectedToken = this.zapInputTokens.find(token => token.address === this.zapInputTokenAddress) || this.zapInputTokens[0] || null;
+        this.syncRemoveLiquidityOutputTokens();
 
         await this.loadZapTokenBalances();
+    }
+
+    syncRemoveLiquidityOutputTokens() {
+        this.removeLiquidityOutputTokens = this.sortZapInputTokens([...(this.zapInputTokens || [])]);
+
+        if (!this.removeLiquidityOutputTokens.some(token => token.address === this.removeLiquidityOutputTokenAddress)) {
+            const usdtToken = this.removeLiquidityOutputTokens.find(token => String(token.symbol || '').toUpperCase() === 'USDT');
+            this.removeLiquidityOutputTokenAddress = usdtToken?.address || this.removeLiquidityOutputTokens[0]?.address || '';
+        }
+
+        this.removeLiquiditySelectedOutputToken = this.removeLiquidityOutputTokens.find(token => token.address === this.removeLiquidityOutputTokenAddress)
+            || this.removeLiquidityOutputTokens[0]
+            || null;
     }
 
     async loadZapTokenBalances() {
@@ -1244,6 +1263,96 @@ class StakingModalNew {
             this.zapCustomTokenError = 'Unable to load token details.';
             this.renderTabContent();
         }
+    }
+
+    setRemoveLiquidityOutputToken(address) {
+        if (address === 'custom') {
+            this.removeLiquidityOutputTokenAddress = 'custom';
+            this.removeLiquiditySelectedOutputToken = null;
+            this.resetRemoveLiquidityPreview();
+            this.removeLiquidityCustomOutputTokenError = '';
+            this.renderTabContent();
+            return;
+        }
+
+        this.removeLiquidityOutputTokenAddress = address;
+        this.removeLiquiditySelectedOutputToken = this.removeLiquidityOutputTokens.find(token => token.address === address) || null;
+        this.resetRemoveLiquidityPreview();
+        this.renderTabContent();
+        this.debounceRemoveLiquidityPreview(0);
+    }
+
+    async addRemoveLiquidityCustomOutputToken() {
+        if (!window.ethers?.utils?.isAddress?.(this.removeLiquidityCustomOutputTokenAddress)) {
+            this.removeLiquidityCustomOutputTokenError = 'Enter a valid token address.';
+            this.renderTabContent();
+            return;
+        }
+
+        try {
+            this.removeLiquidityCustomOutputTokenError = '';
+            const address = window.ethers.utils.getAddress(this.removeLiquidityCustomOutputTokenAddress);
+            const metadata = await this.getTokenMetadata(address);
+            const token = {
+                address,
+                symbol: metadata?.symbol || 'TOKEN',
+                name: metadata?.name || 'Token',
+                decimals: metadata?.decimals ?? 18,
+                iconUrl: '',
+                custom: true
+            };
+
+            const existingIndex = this.removeLiquidityOutputTokens.findIndex(existing =>
+                String(existing.address).toLowerCase() === address.toLowerCase()
+            );
+
+            if (existingIndex >= 0) {
+                this.removeLiquidityOutputTokens[existingIndex] = { ...this.removeLiquidityOutputTokens[existingIndex], ...token };
+            } else {
+                this.removeLiquidityOutputTokens.push(token);
+            }
+            this.removeLiquidityOutputTokens = this.sortZapInputTokens(this.removeLiquidityOutputTokens);
+
+            this.removeLiquidityOutputTokenAddress = token.address;
+            this.removeLiquiditySelectedOutputToken = token;
+            this.resetRemoveLiquidityPreview();
+            this.renderTabContent();
+            this.debounceRemoveLiquidityPreview(0);
+            this.loadRemoveLiquidityCustomOutputTokenIcon(address).catch(error => {
+                console.warn('Unable to load custom remove-liquidity output token icon:', error.message);
+            });
+        } catch (error) {
+            console.error('Failed to add custom remove-liquidity output token:', error);
+            this.removeLiquidityCustomOutputTokenError = 'Unable to load token details.';
+            this.renderTabContent();
+        }
+    }
+
+    async loadRemoveLiquidityCustomOutputTokenIcon(address) {
+        const tokenIndex = this.removeLiquidityOutputTokens.findIndex(existing =>
+            String(existing.address).toLowerCase() === String(address).toLowerCase()
+        );
+        if (tokenIndex < 0) {
+            return false;
+        }
+
+        const marketMetadata = await this.getTokenMarketMetadata(address);
+        const imageUrl = this.getSafeZapTokenIconUrl(marketMetadata?.imageUrl);
+        if (!imageUrl) {
+            return false;
+        }
+
+        this.removeLiquidityOutputTokens[tokenIndex] = {
+            ...this.removeLiquidityOutputTokens[tokenIndex],
+            iconUrl: imageUrl
+        };
+
+        if (String(this.removeLiquidityOutputTokenAddress).toLowerCase() === String(address).toLowerCase()) {
+            this.removeLiquiditySelectedOutputToken = this.removeLiquidityOutputTokens[tokenIndex];
+        }
+
+        this.renderTabContent();
+        return true;
     }
 
     async loadZapCustomTokenIcon(address) {
@@ -1601,6 +1710,17 @@ class StakingModalNew {
         return { value: fallback, path: null };
     }
 
+    getRemoveLiquidityQuoteSummaryEntry(paths, fallback = 'N/A') {
+        const data = this.getRemoveLiquidityRouteData();
+        for (const path of paths) {
+            const value = path.split('.').reduce((current, key) => current?.[key], data);
+            if (value !== undefined && value !== null && value !== '') {
+                return { value, path };
+            }
+        }
+        return { value: fallback, path: null };
+    }
+
     getZapHighSlippageBps() {
         return window.CONFIG?.KYBER_ZAP?.HIGH_SLIPPAGE_BPS || 300;
     }
@@ -1927,11 +2047,12 @@ class StakingModalNew {
             iconOptions.iconUrl = options.iconUrl;
         }
         const iconHtml = this.renderZapTokenIcon(token, iconOptions);
+        const rowClass = options.rowClass || 'zap-token-option';
 
         return `
             <button
                 type="button"
-                class="zap-token-option ${isSelected ? 'active' : ''}"
+                class="${this.escapeHtml(rowClass)} ${isSelected ? 'active' : ''}"
                 data-token-address="${this.escapeHtml(address)}"
                 role="option"
                 aria-selected="${isSelected ? 'true' : 'false'}"
@@ -2335,21 +2456,18 @@ class StakingModalNew {
         const hasSufficientBalance = balanceRaw.gte(removeUnits);
         const hasValidPreview = this.removeLiquidityPreviewStatus === 'ready'
             && this.removeLiquidityPreview?.supported;
-        const hasSupportedConversion = !this.convertLibToUsdtEnabled
-            || this.removeLiquidityPreview?.conversion?.supported;
-        const shouldWaitForOpenPreview = this.convertLibToUsdtEnabled
-            && (!hasValidPreview || !hasSupportedConversion);
+        const shouldWaitForOpenPreview = this.removeLiquidityZapOutEnabled && !hasValidPreview;
         const approvePhase = this.actionPhases?.approveRemoveLiquidity || 'idle';
         const removePhase = this.actionPhases?.removeLiquidity || 'idle';
-        const approveConversionPhase = this.actionPhases?.approveRemoveLiquidityConversion || 'idle';
-        const convertPhase = this.actionPhases?.convertRemoveLiquidityToken || 'idle';
+        const approveZapOutPhase = this.actionPhases?.approveRemoveLiquidityZapOut || 'idle';
+        const zapOutPhase = this.actionPhases?.zapOutLP || 'idle';
         const activePhase = approvePhase !== 'idle'
             ? approvePhase
             : removePhase !== 'idle'
                 ? removePhase
-                : approveConversionPhase !== 'idle'
-                    ? approveConversionPhase
-                    : convertPhase;
+                : approveZapOutPhase !== 'idle'
+                    ? approveZapOutPhase
+                    : zapOutPhase;
 
         if (activePhase !== 'idle') {
             removeButton.disabled = true;
@@ -2359,10 +2477,10 @@ class StakingModalNew {
                     buttonText.textContent = approvePhase === 'userApproval' ? ' Approve LP...' : ' Confirming LP Approval...';
                 } else if (removePhase !== 'idle') {
                     buttonText.textContent = removePhase === 'userApproval' ? ' Remove Liquidity...' : ' Removing Liquidity...';
-                } else if (approveConversionPhase !== 'idle') {
-                    buttonText.textContent = approveConversionPhase === 'userApproval' ? ' Approve LIB...' : ' Confirming LIB Approval...';
+                } else if (approveZapOutPhase !== 'idle') {
+                    buttonText.textContent = approveZapOutPhase === 'userApproval' ? ' Approve LP...' : ' Confirming LP Approval...';
                 } else {
-                    buttonText.textContent = convertPhase === 'userApproval' ? ' Convert LIB...' : ' Converting LIB...';
+                    buttonText.textContent = zapOutPhase === 'userApproval' ? ' Zap Out...' : ' Zapping Out...';
                 }
             }
             return;
@@ -2376,17 +2494,17 @@ class StakingModalNew {
         if (!hasSufficientBalance && hasAmount) {
             removeButton.title = 'Insufficient LP token balance';
         } else if (shouldWaitForOpenPreview) {
-            removeButton.title = this.removeLiquidityPreviewError || 'Wait for a supported LIB to USDT conversion preview.';
+            removeButton.title = this.removeLiquidityPreviewError || 'Wait for a supported Kyber zap-out preview.';
         } else {
-            removeButton.title = this.convertLibToUsdtEnabled
-                ? 'Remove LP liquidity and convert LIB to USDT'
+            removeButton.title = this.removeLiquidityZapOutEnabled
+                ? 'Zap out LP liquidity to one token'
                 : 'Remove LP liquidity';
         }
 
         if (buttonIcon) buttonIcon.textContent = 'swap_horiz';
         if (buttonText) {
-            buttonText.textContent = this.convertLibToUsdtEnabled
-                ? ' Remove LP + Convert LIB'
+            buttonText.textContent = this.removeLiquidityZapOutEnabled
+                ? ' Zap Out LP'
                 : ' Remove LP Liquidity';
         }
     }
@@ -2944,20 +3062,20 @@ class StakingModalNew {
                     <input
                         type="checkbox"
                         id="remove-liquidity-checkbox"
-                        ${this.convertLibToUsdtEnabled ? 'checked' : ''}
+                        ${this.removeLiquidityZapOutEnabled ? 'checked' : ''}
                     >
                     <span class="checkmark"></span>
-                    Convert returned LIB to USDT after removing LP
+                    Zap out to one token with Kyber
                 </label>
             </div>
 
-            ${this.convertLibToUsdtEnabled ? this.renderRemoveLiquidityControls() : ''}
+            ${this.removeLiquidityZapOutEnabled ? this.renderRemoveLiquidityControls() : ''}
 
             <div class="modal-actions">
                 <button class="btn btn-secondary" onclick="safeModalClose()">Cancel</button>
                 <button class="btn btn-primary remove-liquidity-action-btn" onclick="safeModalExecuteRemoveLiquidity()" ${!this.removeLiquidityAmount || parseFloat(this.removeLiquidityAmount) === 0 ? 'disabled' : ''}>
                     <span class="material-icons">swap_horiz</span>
-                    ${this.convertLibToUsdtEnabled ? 'Remove LP + Convert LIB' : 'Remove LP Liquidity'}
+                    ${this.removeLiquidityZapOutEnabled ? 'Zap Out LP' : 'Remove LP Liquidity'}
                 </button>
             </div>
         `;
@@ -2979,6 +3097,7 @@ class StakingModalNew {
         const slippageOptions = [10, 50, 100];
         return `
             <div class="remove-liquidity-section">
+                ${this.renderRemoveLiquidityOutputTokenPicker()}
                 <div class="remove-liquidity-settings">
                     <div class="form-group">
                         <label class="form-label">Slippage</label>
@@ -3039,6 +3158,79 @@ class StakingModalNew {
         `;
     }
 
+    renderRemoveLiquidityOutputTokenPicker() {
+        const isCustomTokenMode = this.removeLiquidityOutputTokenAddress === 'custom';
+        const selectedToken = isCustomTokenMode ? null : (this.removeLiquiditySelectedOutputToken || this.removeLiquidityOutputTokens[0]);
+        const selectedPickerToken = isCustomTokenMode
+            ? { symbol: 'Custom', address: 'custom' }
+            : selectedToken;
+        const selectedPickerLabelParts = isCustomTokenMode
+            ? { symbol: 'Custom token', shortAddress: '', fullLabel: 'Custom token' }
+            : this.getZapTokenLabelParts(selectedToken);
+        const selectedPickerBalance = isCustomTokenMode ? 'Add by address' : (selectedToken?.name || selectedToken?.symbol || '--');
+        const tokenOptions = this.removeLiquidityOutputTokens.map(token => this.renderZapTokenPickerRow(
+            token,
+            selectedPickerToken?.address,
+            {
+                rowClass: 'zap-token-option remove-liquidity-output-token-option',
+                balanceLabel: token.name || token.symbol || '--'
+            }
+        )).join('') + this.renderZapTokenPickerRow(
+            { symbol: 'Custom', address: 'custom' },
+            selectedPickerToken?.address,
+            {
+                rowClass: 'zap-token-option remove-liquidity-output-token-option',
+                label: 'Custom token',
+                balanceLabel: 'Add by address',
+                iconText: '+',
+                iconClass: 'zap-token-icon-custom'
+            }
+        );
+
+        return `
+            <div class="form-group">
+                <label class="form-label">Output Token</label>
+                <details class="zap-token-picker remove-liquidity-output-token-picker">
+                    <summary class="zap-token-trigger">
+                        ${this.renderZapTokenIcon(selectedPickerToken, isCustomTokenMode ? {
+                            iconText: '+',
+                            iconClass: 'zap-token-icon-custom',
+                            iconUrl: ''
+                        } : {})}
+                        <span class="zap-token-option-text">
+                            <span class="zap-token-option-label">
+                                <span>${this.escapeHtml(selectedPickerLabelParts.symbol || 'Select token')}</span>${selectedPickerLabelParts.shortAddress ? ` <span class="zap-token-option-address">${this.escapeHtml(selectedPickerLabelParts.shortAddress)}</span>` : ''}
+                            </span>
+                            <span class="zap-token-option-balance">${this.escapeHtml(selectedPickerBalance || '--')}</span>
+                        </span>
+                        <span class="material-icons zap-token-expand" aria-hidden="true">expand_more</span>
+                    </summary>
+                    <div class="zap-token-menu" role="listbox" aria-label="Zap-out output token">
+                        ${tokenOptions}
+                    </div>
+                </details>
+            </div>
+
+            ${isCustomTokenMode ? `
+                <div class="zap-custom-token-row">
+                    <input
+                        type="text"
+                        id="remove-liquidity-custom-output-token-input"
+                        class="form-input"
+                        placeholder="0x..."
+                        value="${this.escapeHtml(this.removeLiquidityCustomOutputTokenAddress)}"
+                        spellcheck="false"
+                    >
+                    <button class="btn btn-secondary zap-token-add-btn" onclick="safeModalAddRemoveLiquidityCustomOutputToken()">
+                        <span class="material-icons">add</span>
+                        Add
+                    </button>
+                </div>
+                ${this.removeLiquidityCustomOutputTokenError ? `<div class="zap-field-error">${this.escapeHtml(this.removeLiquidityCustomOutputTokenError)}</div>` : ''}
+            ` : ''}
+        `;
+    }
+
     renderRemoveLiquidityPreviewPanel() {
         const isLoading = this.removeLiquidityPreviewStatus === 'loading';
         const isError = this.removeLiquidityPreviewStatus === 'error';
@@ -3051,6 +3243,91 @@ class StakingModalNew {
             isError ? 'zap-quote-error' : '',
             !hasPreview && !isLoading && !isError ? 'zap-quote-placeholder' : ''
         ].filter(Boolean).join(' ');
+        const slippageDisplay = `${(Number(this.removeLiquiditySlippageBps) / 100).toFixed(2)}%`;
+        const deadlineDisplay = `${Number(this.removeLiquidityDeadlineMinutes) || 20} min`;
+
+        if (this.removeLiquidityZapOutEnabled) {
+            const outputToken = this.removeLiquiditySelectedOutputToken;
+            const outputSymbol = outputToken?.symbol || 'token';
+            let summary = this.removeLiquidityAmount
+                ? `Checking Kyber zap-out to ${outputSymbol}...`
+                : `Enter an amount to preview ${outputSymbol} output.`;
+            let routerDisplay = pendingValue;
+            let estimatedOutput = pendingValue;
+            let outputValue = pendingValue;
+            let priceImpactDisplay = pendingValue;
+
+            if (isLoading) {
+                summary = 'Loading Kyber zap-out route...';
+            } else if (isError) {
+                summary = this.removeLiquidityPreviewError || 'Unable to fetch a Kyber zap-out preview.';
+                routerDisplay = 'Unsupported';
+            } else if (hasPreview) {
+                const routeData = this.getRemoveLiquidityRouteData();
+                const outputEntry = this.getRemoveLiquidityQuoteSummaryEntry([
+                    'zapDetails.finalAmount',
+                    'zapDetails.outputAmount',
+                    'outputAmount',
+                    'amountOut',
+                    'routeSummary.amountOut'
+                ], pendingValue);
+                const outputUsdEntry = this.getRemoveLiquidityQuoteSummaryEntry([
+                    'zapDetails.finalAmountUsd',
+                    'amountOutUsd',
+                    'receivedUsd',
+                    'routeSummary.amountOutUsd'
+                ], pendingValue);
+                const priceImpactEntry = this.getRemoveLiquidityQuoteSummaryEntry([
+                    'zapDetails.priceImpact',
+                    'zapDetails.priceImpactPcm',
+                    'priceImpact',
+                    'priceImpactPcm'
+                ], pendingValue);
+                routerDisplay = this.formatAddress(this.getRemoveLiquidityRouterAddress(routeData) || '');
+                estimatedOutput = outputEntry.value === pendingValue
+                    ? pendingValue
+                    : this.formatZapDisplayAmount(outputEntry.value, outputToken?.decimals ?? 18, outputSymbol);
+                outputValue = outputUsdEntry.value === pendingValue ? pendingValue : this.formatUsdDisplay(outputUsdEntry.value);
+                priceImpactDisplay = priceImpactEntry.value === pendingValue ? pendingValue : this.formatZapPercent(priceImpactEntry);
+                summary = `Kyber zap-out to ${outputSymbol}`;
+            }
+
+            const rows = [
+                this.renderZapQuoteRow('Route', 'Kyber ZaaS'),
+                this.renderZapQuoteRow('Kyber Router', routerDisplay || pendingValue),
+                this.renderZapQuoteRow('LP amount', this.removeLiquidityAmount ? `${this.removeLiquidityAmount} LP` : pendingValue),
+                this.renderZapQuoteRow('Output token', outputSymbol),
+                this.renderZapQuoteRow(`Estimated ${outputSymbol}`, estimatedOutput),
+                this.renderZapQuoteRow('Estimated value', outputValue),
+                this.renderZapQuoteRow('Price impact', priceImpactDisplay),
+                this.renderZapQuoteRow('Slippage', slippageDisplay),
+                this.renderZapQuoteRow('Deadline', deadlineDisplay)
+            ];
+
+            return `
+                <div class="${cardClass}">
+                    <div class="zap-quote-header">
+                        <div class="zap-route-summary">${this.escapeHtml(summary)}</div>
+                        <div class="zap-refresh-controls">
+                            <button
+                                type="button"
+                                class="zap-refresh-btn"
+                                onclick="safeModalFetchRemoveLiquidityPreview()"
+                                title="Refresh Kyber zap-out preview"
+                                aria-label="Refresh Kyber zap-out preview"
+                                ${!this.canFetchRemoveLiquidityPreview() || isLoading ? 'disabled' : ''}
+                            >
+                                <span class="material-icons">sync</span>
+                            </button>
+                        </div>
+                    </div>
+                    <dl class="zap-quote-list remove-liquidity-preview-list">
+                        ${rows.join('')}
+                    </dl>
+                </div>
+            `;
+        }
+
         let summary = this.removeLiquidityAmount
             ? 'Checking remove liquidity support...'
             : 'Enter an amount to preview pair token outputs.';
@@ -3059,9 +3336,6 @@ class StakingModalNew {
         let token1Display = pendingValue;
         let token0MinDisplay = pendingValue;
         let token1MinDisplay = pendingValue;
-        const slippageDisplay = `${(Number(this.removeLiquiditySlippageBps) / 100).toFixed(2)}%`;
-        const deadlineDisplay = `${Number(this.removeLiquidityDeadlineMinutes) || 20} min`;
-
         if (isLoading) {
             summary = 'Loading LP reserves...';
         } else if (isError) {
@@ -3088,59 +3362,6 @@ class StakingModalNew {
             this.renderZapQuoteRow('Slippage', slippageDisplay),
             this.renderZapQuoteRow('Deadline', deadlineDisplay)
         ];
-
-        if (this.convertLibToUsdtEnabled) {
-            const conversion = this.removeLiquidityPreview?.conversion;
-            const conversionFromSymbol = conversion?.fromToken?.symbol || 'LIB';
-            const conversionToSymbol = conversion?.toToken?.symbol || 'USDT';
-            rows = [
-                this.renderZapQuoteRow('DEX', dexDisplay),
-                this.renderZapQuoteRow('LP removal output', hasPreview ? `${token0Display} + ${token1Display}` : pendingValue),
-                this.renderZapQuoteRow(`${conversionFromSymbol} to convert`, pendingValue),
-                this.renderZapQuoteRow(`Estimated ${conversionToSymbol} from conversion`, pendingValue),
-                this.renderZapQuoteRow(`Estimated total ${conversionToSymbol}`, pendingValue),
-                this.renderZapQuoteRow(`Minimum total ${conversionToSymbol}`, pendingValue),
-                this.renderZapQuoteRow('Slippage', slippageDisplay),
-                this.renderZapQuoteRow('Deadline', deadlineDisplay)
-            ];
-
-            if (conversion?.supported) {
-                summary = `${conversion.fromToken.symbol} converts to ${conversion.toToken.symbol} after LP removal`;
-                rows = [
-                    this.renderZapQuoteRow('DEX', dexDisplay),
-                    this.renderZapQuoteRow('LP removal output', `${token0Display} + ${token1Display}`),
-                    this.renderZapQuoteRow(
-                        `${conversion.fromToken.symbol} to convert`,
-                        this.formatRemoveLiquidityTokenAmount(conversion.amountIn, conversion.fromToken)
-                    ),
-                    this.renderZapQuoteRow(
-                        `Estimated ${conversion.toToken.symbol} from conversion`,
-                        this.formatRemoveLiquidityTokenAmount(conversion.amountOut, conversion.toToken)
-                    ),
-                    this.renderZapQuoteRow(
-                        `Estimated total ${conversion.toToken.symbol}`,
-                        this.formatRemoveLiquidityTokenAmount(conversion.finalAmount, conversion.toToken)
-                    ),
-                    this.renderZapQuoteRow(
-                        `Minimum total ${conversion.toToken.symbol}`,
-                        this.formatRemoveLiquidityTokenAmount(conversion.finalMinAmount, conversion.toToken)
-                    ),
-                    this.renderZapQuoteRow('Slippage', slippageDisplay),
-                    this.renderZapQuoteRow('Deadline', deadlineDisplay)
-                ];
-            } else if (conversion?.reason) {
-                rows = [
-                    this.renderZapQuoteRow('DEX', dexDisplay),
-                    this.renderZapQuoteRow('Conversion', conversion.reason),
-                    this.renderZapQuoteRow('Slippage', slippageDisplay),
-                    this.renderZapQuoteRow('Deadline', deadlineDisplay)
-                ];
-            } else if (!hasPreview && !isError) {
-                summary = this.removeLiquidityAmount
-                    ? 'Checking LIB to USDT conversion...'
-                    : 'Enter an amount to preview final USDT output.';
-            }
-        }
 
         return `
             <div class="${cardClass}">
@@ -3876,64 +4097,98 @@ class StakingModalNew {
         }
     }
 
-    async executeRemoveLiquidityConversion({ service, preview, conversion, amountIn, userAddress, provider, signer }) {
-        const spender = preview.adapter.routerAddress;
-        const allowance = await service.getTokenAllowance({
-            tokenAddress: conversion.fromToken.address,
-            owner: userAddress,
-            spender,
-            provider
-        });
-
-        if (allowance.lt(amountIn)) {
-            this.pendingOperations.approveRemoveLiquidityConversion = true;
-            this.setActionPhase('approveRemoveLiquidityConversion', 'userApproval');
-            window.notificationManager?.info(`Approving ${conversion.fromToken.symbol} for conversion...`);
-
-            await window.contractManager.executeTransactionOnce(async () => {
-                const tx = await service.approveTokenIfNeeded({
-                    tokenAddress: conversion.fromToken.address,
-                    spender,
-                    amountRaw: amountIn,
-                    signer
-                });
-                if (!tx) {
-                    throw new Error(`${conversion.fromToken.symbol} allowance is already sufficient.`);
-                }
-                console.log(`✅ ${conversion.fromToken.symbol} conversion approval sent: ${tx.hash}`);
-                return tx;
-            }, 'approveRemoveLiquidityConversion');
-
-            this.pendingOperations.approveRemoveLiquidityConversion = false;
-            this.setActionPhase('approveRemoveLiquidityConversion', 'idle');
+    async approveRemoveLiquidityZapOutIfNeeded(lpTokenAddress, routerAddress, liquidityRaw) {
+        const provider = window.contractManager?.provider || window.walletManager?.provider;
+        const signer = window.contractManager?.signer;
+        if (!provider || !signer) {
+            throw new Error('Wallet signer is required for zap-out approval.');
         }
 
-        const quote = await service.getSwapQuote({
-            routerAddress: preview.adapter.routerAddress,
-            amountIn,
-            path: conversion.path,
-            provider
-        });
-        const amountOutMin = service.calculateMinAmount(quote.amountOut, this.removeLiquiditySlippageBps);
+        const userAddress = await signer.getAddress();
+        const erc20Abi = [
+            'function allowance(address owner,address spender) view returns (uint256)',
+            'function approve(address spender,uint256 amount) returns (bool)'
+        ];
+        const lpReadContract = new window.ethers.Contract(lpTokenAddress, erc20Abi, provider);
+        const allowance = await lpReadContract.allowance(userAddress, routerAddress);
+
+        if (allowance.gte(liquidityRaw)) {
+            return null;
+        }
+
+        this.pendingOperations.approveRemoveLiquidityZapOut = true;
+        this.setActionPhase('approveRemoveLiquidityZapOut', 'userApproval');
+        window.notificationManager?.info('Approving Kyber to spend LP tokens...');
+
+        const lpWithSigner = new window.ethers.Contract(lpTokenAddress, erc20Abi, signer);
+        const result = await window.contractManager.executeTransactionOnce(async () => {
+            const tx = await lpWithSigner.approve(routerAddress, liquidityRaw);
+            console.log(`✅ Kyber zap-out approval sent: ${tx.hash}`);
+            return tx;
+        }, 'approveRemoveLiquidityZapOut');
+
+        this.pendingOperations.approveRemoveLiquidityZapOut = false;
+        this.setActionPhase('approveRemoveLiquidityZapOut', 'idle');
+        return result;
+    }
+
+    async buildRemoveLiquidityZapOutRoute() {
+        const networkConfig = this.getKyberZapNetworkConfig();
+        const route = this.getRemoveLiquidityRouteEncoded();
         const deadlineSeconds = Math.floor(Date.now() / 1000) + (Number(this.removeLiquidityDeadlineMinutes) || 20) * 60;
 
-        this.pendingOperations.convertRemoveLiquidityToken = true;
-        this.setActionPhase('convertRemoveLiquidityToken', 'userApproval');
-        window.notificationManager?.info(`Converting ${conversion.fromToken.symbol} to ${conversion.toToken.symbol}...`);
+        return this.getKyberZapService().buildOutRoute({
+            networkConfig,
+            route,
+            sender: window.walletManager.address,
+            recipient: window.walletManager.address,
+            deadline: deadlineSeconds
+        });
+    }
+
+    getRemoveLiquidityZapOutTransactionRequest(buildData) {
+        const txData = buildData?.txData || buildData?.calldata || buildData?.callData || buildData?.transaction?.data || buildData?.data;
+        const to = this.getRemoveLiquidityRouterAddress(buildData);
+        const rawValue = buildData?.value || buildData?.txValue || buildData?.transaction?.value || '0';
+
+        if (!to || !txData) {
+            throw new Error('Kyber did not return zap-out transaction calldata.');
+        }
+
+        this.validateZapRouterAddress(to);
+
+        return {
+            to,
+            data: txData,
+            value: window.ethers.BigNumber.from(rawValue || '0')
+        };
+    }
+
+    async executeRemoveLiquidityZapOutTransaction(lpTokenAddress, liquidityRaw) {
+        await window.contractManager.ensureSigner();
+
+        if (!this.removeLiquidityPreview?.supported || !this.removeLiquidityPreview?.zapOut) {
+            await this.fetchRemoveLiquidityPreview({ force: true });
+        }
+
+        if (!this.removeLiquidityPreview?.supported || !this.removeLiquidityPreview?.zapOut) {
+            throw new Error(this.removeLiquidityPreviewError || 'Kyber zap-out is not supported for this pool.');
+        }
+
+        window.notificationManager?.info('Building Kyber zap-out transaction...');
+        const buildData = await this.buildRemoveLiquidityZapOutRoute();
+        const transactionRequest = this.getRemoveLiquidityZapOutTransactionRequest(buildData);
+        await this.approveRemoveLiquidityZapOutIfNeeded(lpTokenAddress, transactionRequest.to, liquidityRaw);
+
+        this.pendingOperations.zapOutLP = true;
+        this.setActionPhase('zapOutLP', 'userApproval');
+        window.notificationManager?.info('Zapping out LP tokens...');
 
         return await window.contractManager.executeTransactionOnce(async () => {
-            const tx = await service.swapExactTokensForTokens({
-                routerAddress: preview.adapter.routerAddress,
-                amountIn,
-                amountOutMin,
-                path: conversion.path,
-                recipient: userAddress,
-                deadline: deadlineSeconds,
-                signer
-            });
-            console.log(`✅ ${conversion.fromToken.symbol} conversion sent: ${tx.hash}`);
+            const tx = await window.contractManager.signer.sendTransaction(transactionRequest);
+            console.log(`✅ Kyber zap-out transaction sent: ${tx.hash}`);
             return tx;
-        }, 'convertRemoveLiquidityToken');
+        }, 'zapOutLP');
     }
 
     async executeRemoveLiquidityTransaction(lpTokenAddress, liquidityRaw) {
@@ -3952,10 +4207,6 @@ class StakingModalNew {
         if (!preview?.supported) {
             throw new Error(this.removeLiquidityPreviewError || 'Remove liquidity is not supported for this pool.');
         }
-        const conversion = this.convertLibToUsdtEnabled ? preview.conversion : null;
-        if (this.convertLibToUsdtEnabled && !conversion?.supported) {
-            throw new Error(preview.conversion?.reason || 'LIB to USDT conversion is not supported for this pool.');
-        }
 
         await service.validateRouterFactory({
             routerAddress: preview.adapter.routerAddress,
@@ -3971,14 +4222,6 @@ class StakingModalNew {
         if (lpBalance.lt(liquidityRaw)) {
             throw new Error('Insufficient LP token balance.');
         }
-
-        const preConversionBalance = conversion
-            ? await service.getTokenBalance({
-                tokenAddress: conversion.fromToken.address,
-                owner: userAddress,
-                provider
-            })
-            : null;
 
         const allowance = await service.getAllowance({
             lpTokenAddress,
@@ -4031,38 +4274,6 @@ class StakingModalNew {
             return tx;
         }, 'removeLiquidity');
 
-        if (!conversion) {
-            return removeResult;
-        }
-
-        this.pendingOperations.removeLiquidity = false;
-        this.setActionPhase('removeLiquidity', 'idle');
-
-        try {
-            const postConversionBalance = await service.getTokenBalance({
-                tokenAddress: conversion.fromToken.address,
-                owner: userAddress,
-                provider
-            });
-            const actualAmountIn = postConversionBalance.sub(preConversionBalance);
-            if (actualAmountIn.lte(0)) {
-                throw new Error(`No ${conversion.fromToken.symbol} was received to convert.`);
-            }
-
-            await this.executeRemoveLiquidityConversion({
-                service,
-                preview,
-                conversion,
-                amountIn: actualAmountIn,
-                userAddress,
-                provider,
-                signer
-            });
-        } catch (error) {
-            error.removeLiquidityCompleted = true;
-            throw error;
-        }
-
         return removeResult;
     }
 
@@ -4103,10 +4314,14 @@ class StakingModalNew {
             window.notificationManager?.info('Removing LP liquidity...');
             const lpTokenAddress = this.currentPair.lpToken || this.currentPair.address;
             const liquidityRaw = this.getRemoveLiquidityAmountRaw();
-            await this.executeRemoveLiquidityTransaction(lpTokenAddress, liquidityRaw);
+            if (this.removeLiquidityZapOutEnabled) {
+                await this.executeRemoveLiquidityZapOutTransaction(lpTokenAddress, liquidityRaw);
+            } else {
+                await this.executeRemoveLiquidityTransaction(lpTokenAddress, liquidityRaw);
+            }
             window.notificationManager?.success(
-                this.convertLibToUsdtEnabled
-                    ? 'Liquidity removed and LIB converted to USDT successfully!'
+                this.removeLiquidityZapOutEnabled
+                    ? 'LP tokens zapped out successfully!'
                     : 'Liquidity removed successfully!'
             );
 
@@ -4125,26 +4340,20 @@ class StakingModalNew {
             console.log('✅ Home page data refreshed after remove liquidity');
         } catch (error) {
             console.error('❌ Remove liquidity failed:', error);
-            const detailMessage = error?.userMessage?.message || error?.message || '';
-            const partialSuccessMessage = 'Liquidity was removed, but LIB conversion failed. Your returned tokens remain in your wallet.';
-            const fallbackMessage = 'Remove liquidity failed. Your LP tokens remain in your wallet.';
-            const errorMessage = error?.removeLiquidityCompleted
-                ? (detailMessage ? `${partialSuccessMessage} Details: ${detailMessage}` : partialSuccessMessage)
-                : (detailMessage || fallbackMessage);
-            const errorTitle = error?.userMessage?.title || (error?.removeLiquidityCompleted ? 'Conversion failed' : undefined);
-            window.notificationManager?.error(errorMessage, {title: errorTitle});
+            const errorMessage = error?.userMessage?.message || error?.message || 'Remove liquidity failed. Your LP tokens remain in your wallet.';
+            window.notificationManager?.error(errorMessage, {title: error?.userMessage?.title});
             await this.loadUserBalances().catch(loadError => {
                 console.warn('Unable to refresh balances after remove-liquidity failure:', loadError.message);
             });
         } finally {
             this.pendingOperations.approveRemoveLiquidity = false;
             this.pendingOperations.removeLiquidity = false;
-            this.pendingOperations.approveRemoveLiquidityConversion = false;
-            this.pendingOperations.convertRemoveLiquidityToken = false;
+            this.pendingOperations.approveRemoveLiquidityZapOut = false;
+            this.pendingOperations.zapOutLP = false;
             this.setActionPhase('approveRemoveLiquidity', 'idle');
             this.setActionPhase('removeLiquidity', 'idle');
-            this.setActionPhase('approveRemoveLiquidityConversion', 'idle');
-            this.setActionPhase('convertRemoveLiquidityToken', 'idle');
+            this.setActionPhase('approveRemoveLiquidityZapOut', 'idle');
+            this.setActionPhase('zapOutLP', 'idle');
             this.isExecutingRemoveLiquidity = false;
             this.updateRemoveLiquidityButton();
         }
@@ -4465,6 +4674,19 @@ window.safeModalAddZapCustomToken = function() {
         }
     } catch (error) {
         console.error('❌ Error adding custom zap token:', error);
+    }
+};
+
+window.safeModalAddRemoveLiquidityCustomOutputToken = function() {
+    try {
+        const modal = window.stakingModal || window.stakingModalNew || window.getStakingModal();
+        if (modal && typeof modal.addRemoveLiquidityCustomOutputToken === 'function') {
+            modal.addRemoveLiquidityCustomOutputToken();
+        } else {
+            console.warn('⚠️ Modal addRemoveLiquidityCustomOutputToken method not available');
+        }
+    } catch (error) {
+        console.error('❌ Error adding custom remove-liquidity output token:', error);
     }
 };
 

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -375,6 +375,7 @@ class StakingModalNew {
                 this.removeLiquidityAmount = sanitizedValue;
                 this.updateSlider('remove-liquidity');
                 this.updateRemoveLiquidityUsdEstimate();
+                this.updateRemoveLiquidityBalanceError();
                 this.resetRemoveLiquidityPreview();
                 this.debounceRemoveLiquidityPreview();
             }
@@ -818,8 +819,8 @@ class StakingModalNew {
 
     getRemoveLiquidityPreviewErrorMessage(error) {
         const message = error?.message || String(error || '');
-        if (/remove liquidity\s*=\s*\d+\s*>\s*position liquidity\s*=\s*0/i.test(message)) {
-            return 'Refresh your balance or try a smaller amount.';
+        if (/remove liquidity\s*=\s*\d+\s*>\s*position liquidity\s*=\s*\d+/i.test(message)) {
+            return 'Amount exceeds your available LP balance.';
         }
 
         return message || 'Unable to preview remove liquidity.';
@@ -831,6 +832,37 @@ class StakingModalNew {
         }
 
         return window.ethers.utils.parseUnits(this.removeLiquidityAmount.toString(), this.userBalanceDecimals);
+    }
+
+    getRemoveLiquidityBalanceError() {
+        if (!this.removeLiquidityAmount || parseFloat(this.removeLiquidityAmount) <= 0) {
+            return '';
+        }
+
+        try {
+            const liquidityRaw = this.getRemoveLiquidityAmountRaw();
+            const balanceRaw = this.userBalanceRaw || window.ethers?.BigNumber?.from?.(0);
+            if (liquidityRaw && balanceRaw?.gte && !balanceRaw.gte(liquidityRaw)) {
+                return `Amount exceeds available LP balance (${this.userBalance || '0'} LP).`;
+            }
+        } catch (error) {
+            const amount = parseFloat(this.removeLiquidityAmount);
+            const balance = parseFloat(this.userBalance);
+            if (Number.isFinite(amount) && Number.isFinite(balance) && amount > balance) {
+                return `Amount exceeds available LP balance (${this.userBalance || '0'} LP).`;
+            }
+        }
+
+        return '';
+    }
+
+    updateRemoveLiquidityBalanceError() {
+        const errorElement = document.getElementById('remove-liquidity-balance-error');
+        if (!errorElement) return;
+
+        const balanceError = this.getRemoveLiquidityBalanceError();
+        errorElement.textContent = balanceError;
+        errorElement.hidden = !balanceError;
     }
 
     getRemoveLiquidityCustomSlippageError(value = this.removeLiquidityCustomSlippage) {
@@ -920,13 +952,13 @@ class StakingModalNew {
         return !!this.currentPair
             && !!this.removeLiquidityAmount
             && parseFloat(this.removeLiquidityAmount) > 0
+            && !this.getRemoveLiquidityBalanceError()
             && !this.hasInvalidRemoveLiquidityCustomSlippage();
     }
 
     canFetchRemoveLiquidityPreview() {
-        return this.removeLiquidityZapOutEnabled
-            && this.canPrepareRemoveLiquidityPreview()
-            && !!this.removeLiquiditySelectedOutputToken;
+        return this.canPrepareRemoveLiquidityPreview()
+            && (!this.removeLiquidityZapOutEnabled || !!this.removeLiquiditySelectedOutputToken);
     }
 
     getRemoveLiquidityOutputTokenAddressForKyber(token = this.removeLiquiditySelectedOutputToken) {
@@ -2575,7 +2607,7 @@ class StakingModalNew {
         const hasSufficientBalance = balanceRaw.gte(removeUnits);
         const hasValidPreview = this.removeLiquidityPreviewStatus === 'ready'
             && this.removeLiquidityPreview?.supported;
-        const shouldWaitForOpenPreview = this.removeLiquidityZapOutEnabled && !hasValidPreview;
+        const shouldWaitForPreview = hasAmount && !hasValidPreview;
         const approvePhase = this.actionPhases?.approveRemoveLiquidity || 'idle';
         const removePhase = this.actionPhases?.removeLiquidity || 'idle';
         const approveZapOutPhase = this.actionPhases?.approveRemoveLiquidityZapOut || 'idle';
@@ -2608,12 +2640,16 @@ class StakingModalNew {
         const shouldDisable = this.isExecutingRemoveLiquidity
             || !hasAmount
             || !hasSufficientBalance
-            || shouldWaitForOpenPreview;
+            || shouldWaitForPreview;
         removeButton.disabled = shouldDisable;
         if (!hasSufficientBalance && hasAmount) {
             removeButton.title = 'Insufficient LP token balance';
-        } else if (shouldWaitForOpenPreview) {
-            removeButton.title = this.removeLiquidityPreviewError || 'Wait for a supported Kyber zap-out preview.';
+        } else if (shouldWaitForPreview) {
+            removeButton.title = this.removeLiquidityPreviewError || (
+                this.removeLiquidityZapOutEnabled
+                    ? 'Wait for a supported Kyber zap-out preview.'
+                    : 'Wait for a supported remove-liquidity preview.'
+            );
         } else {
             removeButton.title = this.removeLiquidityZapOutEnabled
                 ? 'Zap out LP liquidity to one token'
@@ -3139,6 +3175,7 @@ class StakingModalNew {
     }
 
     renderRemoveLiquidityTab() {
+        const balanceError = this.getRemoveLiquidityBalanceError();
         return `
             <div class="balance-info">
                 <span class="balance-label">Available LP Tokens:</span>
@@ -3157,6 +3194,7 @@ class StakingModalNew {
                     inputmode="decimal"
                 >
                 ${this.renderLpUsdEstimateElement('remove-liquidity-usd-estimate', this.removeLiquidityAmount)}
+                <div id="remove-liquidity-balance-error" class="zap-field-error zap-balance-error" aria-live="polite" ${balanceError ? '' : 'hidden'}>${this.escapeHtml(balanceError)}</div>
                 <div class="slider-container">
                     <input
                         type="range"
@@ -3188,7 +3226,7 @@ class StakingModalNew {
                 </label>
             </div>
 
-            ${this.removeLiquidityZapOutEnabled ? this.renderRemoveLiquidityControls() : ''}
+            ${this.renderRemoveLiquidityControls()}
 
             <div class="modal-actions">
                 <button class="btn btn-secondary" onclick="safeModalClose()">Cancel</button>
@@ -3216,7 +3254,7 @@ class StakingModalNew {
         const slippageOptions = [10, 50, 100];
         return `
             <div class="remove-liquidity-section">
-                ${this.renderRemoveLiquidityOutputTokenPicker()}
+                ${this.removeLiquidityZapOutEnabled ? this.renderRemoveLiquidityOutputTokenPicker() : ''}
                 <div class="remove-liquidity-settings">
                     <div class="form-group">
                         <label class="form-label">Slippage</label>
@@ -3351,8 +3389,9 @@ class StakingModalNew {
     }
 
     renderRemoveLiquidityPreviewPanel() {
+        const balanceError = this.getRemoveLiquidityBalanceError();
         const isLoading = this.removeLiquidityPreviewStatus === 'loading';
-        const isError = this.removeLiquidityPreviewStatus === 'error';
+        const isError = this.removeLiquidityPreviewStatus === 'error' || !!balanceError;
         const hasPreview = this.removeLiquidityPreviewStatus === 'ready' && this.removeLiquidityPreview?.supported;
         const pendingValue = isLoading ? '...' : '-';
         const cardClass = [
@@ -3379,7 +3418,7 @@ class StakingModalNew {
             if (isLoading) {
                 summary = 'Loading Kyber zap-out route...';
             } else if (isError) {
-                summary = this.removeLiquidityPreviewError || 'Unable to fetch a Kyber zap-out preview.';
+                summary = balanceError || this.removeLiquidityPreviewError || 'Unable to fetch a Kyber zap-out preview.';
                 routerDisplay = 'Unsupported';
             } else if (hasPreview) {
                 const routeData = this.getRemoveLiquidityRouteData();
@@ -3452,7 +3491,7 @@ class StakingModalNew {
         if (isLoading) {
             summary = 'Loading LP reserves...';
         } else if (isError) {
-            summary = this.removeLiquidityPreviewError || 'Remove liquidity is not supported for this pool.';
+            summary = balanceError || this.removeLiquidityPreviewError || 'Remove liquidity is not supported for this pool.';
             dexDisplay = this.removeLiquidityPreview?.factoryAddress
                 ? `Unsupported factory ${this.formatAddress(this.removeLiquidityPreview.factoryAddress)}`
                 : 'Unsupported';
@@ -3468,10 +3507,10 @@ class StakingModalNew {
 
         let rows = [
             this.renderZapQuoteRow('DEX', dexDisplay),
-            this.renderZapQuoteRow('Estimated token0', token0Display),
-            this.renderZapQuoteRow('Estimated token1', token1Display),
-            this.renderZapQuoteRow('Minimum token0', token0MinDisplay),
-            this.renderZapQuoteRow('Minimum token1', token1MinDisplay),
+            this.renderZapQuoteRow(`Estimated ${this.removeLiquidityPreview?.token0?.symbol || 'token0'}`, token0Display),
+            this.renderZapQuoteRow(`Estimated ${this.removeLiquidityPreview?.token1?.symbol || 'token1'}`, token1Display),
+            this.renderZapQuoteRow(`Minimum ${this.removeLiquidityPreview?.token0?.symbol || 'token0'}`, token0MinDisplay),
+            this.renderZapQuoteRow(`Minimum ${this.removeLiquidityPreview?.token1?.symbol || 'token1'}`, token1MinDisplay),
             this.renderZapQuoteRow('Slippage', slippageDisplay),
             this.renderZapQuoteRow('Deadline', deadlineDisplay)
         ];

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -299,8 +299,9 @@ class StakingModalNew {
             }
 
             // Percentage buttons
-            if (e.target.closest('.percentage-btn, .remove-liquidity-percentage-btn')) {
-                const percentage = parseInt(e.target.closest('.percentage-btn, .remove-liquidity-percentage-btn').dataset.percentage);
+            const percentageButton = e.target.closest('.percentage-btn, .remove-liquidity-percentage-btn');
+            if (percentageButton) {
+                const percentage = parseInt(percentageButton.dataset.percentage);
                 this.setPercentage(percentage);
             }
 
@@ -323,7 +324,7 @@ class StakingModalNew {
                 this.setRemoveLiquidityOutputToken(button.dataset.tokenAddress);
             }
 
-            if (e.target.closest('.zap-percentage-btn')) {
+            if (e.target.closest('.zap-percentage-btn') && !e.target.closest('.remove-liquidity-percentage-btn')) {
                 const button = e.target.closest('.zap-percentage-btn');
                 this.setZapAmountPercentage(parseInt(button.dataset.percentage, 10));
             }
@@ -702,12 +703,10 @@ class StakingModalNew {
         return estimate ? ` <span class="lp-usd-estimate">(${this.escapeHtml(estimate)})</span>` : '';
     }
 
-    renderLpUsdEstimateElement(id, amount, { preserveSpace = false } = {}) {
+    renderLpUsdEstimateElement(id, amount) {
         const estimate = this.formatLpUsdEstimate(amount);
-        const hiddenAttribute = estimate || preserveSpace ? '' : ' hidden';
-        const emptyClass = !estimate && preserveSpace ? ' lp-usd-estimate-empty' : '';
-        const ariaHiddenAttribute = !estimate && preserveSpace ? ' aria-hidden="true"' : '';
-        return `<div id="${id}" class="lp-usd-estimate${emptyClass}" aria-live="polite"${ariaHiddenAttribute}${hiddenAttribute}>${this.escapeHtml(estimate)}</div>`;
+        const hiddenAttribute = estimate ? '' : ' hidden';
+        return `<div id="${id}" class="lp-usd-estimate" aria-live="polite"${hiddenAttribute}>${this.escapeHtml(estimate)}</div>`;
     }
 
     getZapLpAmountForUsdEstimate(amount) {
@@ -865,13 +864,6 @@ class StakingModalNew {
         errorElement.textContent = balanceError;
         errorElement.hidden = false;
         errorElement.classList.toggle('zap-balance-error-empty', !balanceError);
-        if (errorElement.setAttribute && errorElement.removeAttribute) {
-            if (balanceError) {
-                errorElement.removeAttribute('aria-hidden');
-            } else {
-                errorElement.setAttribute('aria-hidden', 'true');
-            }
-        }
     }
 
     getRemoveLiquidityCustomSlippageError(value = this.removeLiquidityCustomSlippage) {
@@ -3259,7 +3251,6 @@ class StakingModalNew {
             Math.abs(removeLiquidityPercentage - percentage) < 0.001
         );
         const balanceErrorClass = balanceError ? '' : ' zap-balance-error-empty';
-        const balanceErrorAriaHidden = balanceError ? '' : ' aria-hidden="true"';
 
         return `
             <div class="balance-info">
@@ -3287,7 +3278,7 @@ class StakingModalNew {
                     inputmode="decimal"
                 >
                 <div class="remove-liquidity-meta-row">
-                    ${this.renderLpUsdEstimateElement('remove-liquidity-usd-estimate', this.removeLiquidityAmount, { preserveSpace: true })}
+                    ${this.renderLpUsdEstimateElement('remove-liquidity-usd-estimate', this.removeLiquidityAmount)}
                     <label class="checkbox-label remove-liquidity-checkbox-label">
                         <input
                             type="checkbox"
@@ -3297,7 +3288,7 @@ class StakingModalNew {
                         <span class="checkmark"></span>
                         Convert to one preferred token
                     </label>
-                    <div id="remove-liquidity-balance-error" class="zap-field-error zap-balance-error${balanceErrorClass}" aria-live="polite"${balanceErrorAriaHidden}>${this.escapeHtml(balanceError)}</div>
+                    <div id="remove-liquidity-balance-error" class="zap-field-error zap-balance-error${balanceErrorClass}" aria-live="polite">${this.escapeHtml(balanceError)}</div>
                 </div>
             </div>
 
@@ -3314,7 +3305,7 @@ class StakingModalNew {
     }
 
     updateRemoveLiquidityUsdEstimate() {
-        this.updateLpUsdEstimate('remove-liquidity-usd-estimate', this.removeLiquidityAmount, { preserveSpace: true });
+        this.updateLpUsdEstimate('remove-liquidity-usd-estimate', this.removeLiquidityAmount);
     }
 
     formatRemoveLiquidityTokenAmount(amount, token) {
@@ -3726,20 +3717,12 @@ class StakingModalNew {
         }
     }
 
-    updateLpUsdEstimate(elementId, amount, { preserveSpace = false } = {}) {
+    updateLpUsdEstimate(elementId, amount) {
         const estimateElement = document.getElementById(elementId);
         if (estimateElement) {
             const estimate = this.formatLpUsdEstimate(amount);
             estimateElement.textContent = estimate;
-            estimateElement.hidden = !estimate && !preserveSpace;
-            estimateElement.classList.toggle('lp-usd-estimate-empty', !estimate && preserveSpace);
-            if (estimateElement.setAttribute && estimateElement.removeAttribute) {
-                if (!estimate && preserveSpace) {
-                    estimateElement.setAttribute('aria-hidden', 'true');
-                } else {
-                    estimateElement.removeAttribute('aria-hidden');
-                }
-            }
+            estimateElement.hidden = !estimate;
         }
     }
 

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -46,7 +46,7 @@ class StakingModalNew {
 
         // V2 remove-liquidity state
         this.removeLiquidityService = window.V2RemoveLiquidityService ? new window.V2RemoveLiquidityService() : null;
-        this.removeLiquidityEnabled = false;
+        this.convertLibToUsdtEnabled = false;
         this.removeLiquidityAmount = '';
         this.removeLiquidityPreview = null;
         this.removeLiquidityPreviewStatus = 'idle';
@@ -72,7 +72,9 @@ class StakingModalNew {
             approveZap: 'idle',
             zap: 'idle',
             approveRemoveLiquidity: 'idle',
-            removeLiquidity: 'idle'
+            removeLiquidity: 'idle',
+            approveRemoveLiquidityConversion: 'idle',
+            convertRemoveLiquidityToken: 'idle'
         };
         this.pendingOperations = {
             approve: false,
@@ -82,7 +84,9 @@ class StakingModalNew {
             approveZap: false,
             zap: false,
             approveRemoveLiquidity: false,
-            removeLiquidity: false
+            removeLiquidity: false,
+            approveRemoveLiquidityConversion: false,
+            convertRemoveLiquidityToken: false
         };
 
         // Execution guards
@@ -125,6 +129,10 @@ class StakingModalNew {
                 return 'approveRemoveLiquidity';
             case 'removeLiquidity':
                 return 'removeLiquidity';
+            case 'approveRemoveLiquidityConversion':
+                return 'approveRemoveLiquidityConversion';
+            case 'convertRemoveLiquidityToken':
+                return 'convertRemoveLiquidityToken';
             default:
                 return null;
         }
@@ -159,7 +167,10 @@ class StakingModalNew {
             this.updateUnstakeButton();
         }
 
-        if (action === 'approveRemoveLiquidity' || action === 'removeLiquidity') {
+        if (action === 'approveRemoveLiquidity'
+            || action === 'removeLiquidity'
+            || action === 'approveRemoveLiquidityConversion'
+            || action === 'convertRemoveLiquidityToken') {
             this.updateRemoveLiquidityButton();
         }
 
@@ -405,7 +416,7 @@ class StakingModalNew {
             }
 
             if (e.target.id === 'remove-liquidity-checkbox') {
-                this.removeLiquidityEnabled = e.target.checked;
+                this.convertLibToUsdtEnabled = e.target.checked;
                 this.resetRemoveLiquidityPreview();
                 this.renderTabContent();
                 this.debounceRemoveLiquidityPreview(0);
@@ -506,7 +517,7 @@ class StakingModalNew {
         this.zapCustomSlippageError = '';
         this.zapQuoteRequestId += 1;
         this.stopZapQuoteAutoRefresh();
-        this.removeLiquidityEnabled = false;
+        this.convertLibToUsdtEnabled = false;
         this.removeLiquidityAmount = '';
         this.removeLiquidityPreview = null;
         this.removeLiquidityPreviewStatus = 'idle';
@@ -863,7 +874,91 @@ class StakingModalNew {
     }
 
     canFetchRemoveLiquidityPreview() {
-        return this.removeLiquidityEnabled && this.canPrepareRemoveLiquidityPreview();
+        return this.convertLibToUsdtEnabled && this.canPrepareRemoveLiquidityPreview();
+    }
+
+    getRemoveLiquidityConversionTokens(preview = this.removeLiquidityPreview) {
+        if (!preview?.supported) {
+            return null;
+        }
+
+        const tokens = [preview.token0, preview.token1];
+        const fromToken = tokens.find(token => String(token.symbol || '').toUpperCase() === 'LIB');
+        const toToken = tokens.find(token => String(token.symbol || '').toUpperCase() === 'USDT');
+
+        if (!fromToken || !toToken || this.normalizeAddress(fromToken.address) === this.normalizeAddress(toToken.address)) {
+            return null;
+        }
+
+        return {
+            fromToken,
+            toToken,
+            path: [fromToken.address, toToken.address]
+        };
+    }
+
+    normalizeAddress(address) {
+        return String(address || '').toLowerCase();
+    }
+
+    async addRemoveLiquidityConversionPreview(preview, provider) {
+        if (!this.convertLibToUsdtEnabled || !preview?.supported) {
+            return preview;
+        }
+
+        const conversion = this.getRemoveLiquidityConversionTokens(preview);
+        if (!conversion) {
+            return {
+                ...preview,
+                conversion: {
+                    supported: false,
+                    reason: 'LIB to USDT conversion is only available for LIB/USDT pools.'
+                }
+            };
+        }
+
+        const service = this.getRemoveLiquidityService();
+        const quote = await service.getSwapQuote({
+            routerAddress: preview.adapter.routerAddress,
+            amountIn: conversion.fromToken.amount.raw,
+            path: conversion.path,
+            provider
+        });
+        const amountOutMin = service.calculateMinAmount(quote.amountOut, this.removeLiquiditySlippageBps);
+        const returnedTargetAmount = window.ethers.BigNumber.from(conversion.toToken.amount.raw);
+        const returnedTargetMinAmount = window.ethers.BigNumber.from(conversion.toToken.minAmount.raw);
+        const finalAmount = returnedTargetAmount.add(quote.amountOut);
+        const finalMinAmount = returnedTargetMinAmount.add(amountOutMin);
+
+        return {
+            ...preview,
+            conversion: {
+                supported: true,
+                fromToken: conversion.fromToken,
+                toToken: conversion.toToken,
+                path: conversion.path,
+                amountIn: {
+                    raw: quote.amountIn.toString(),
+                    formatted: service.formatUnits(quote.amountIn, conversion.fromToken.decimals)
+                },
+                amountOut: {
+                    raw: quote.amountOut.toString(),
+                    formatted: service.formatUnits(quote.amountOut, conversion.toToken.decimals)
+                },
+                minAmountOut: {
+                    raw: amountOutMin.toString(),
+                    formatted: service.formatUnits(amountOutMin, conversion.toToken.decimals)
+                },
+                finalAmount: {
+                    raw: finalAmount.toString(),
+                    formatted: service.formatUnits(finalAmount, conversion.toToken.decimals)
+                },
+                finalMinAmount: {
+                    raw: finalMinAmount.toString(),
+                    formatted: service.formatUnits(finalMinAmount, conversion.toToken.decimals)
+                }
+            }
+        };
     }
 
     debounceRemoveLiquidityPreview(delay = 400) {
@@ -914,25 +1009,28 @@ class StakingModalNew {
             this.updateRemoveLiquidityPreviewPanel();
             this.updateRemoveLiquidityButton();
 
-            const preview = await this.getRemoveLiquidityService().getPreview({
+            const basePreview = await this.getRemoveLiquidityService().getPreview({
                 chainId,
                 lpTokenAddress,
                 liquidityRaw,
                 slippageBps: this.removeLiquiditySlippageBps,
                 provider
             });
+            const preview = await this.addRemoveLiquidityConversionPreview(basePreview, provider);
 
             if (requestId !== this.removeLiquidityPreviewRequestId) {
                 return;
             }
 
             this.removeLiquidityPreview = preview;
-            if (preview.supported) {
+            if (preview.supported && (!this.convertLibToUsdtEnabled || preview.conversion?.supported)) {
                 this.removeLiquidityPreviewStatus = 'ready';
                 this.removeLiquidityPreviewError = '';
             } else {
                 this.removeLiquidityPreviewStatus = 'error';
-                this.removeLiquidityPreviewError = preview.reason || 'Remove liquidity is not supported for this pool.';
+                this.removeLiquidityPreviewError = preview.conversion?.reason
+                    || preview.reason
+                    || 'Remove liquidity is not supported for this pool.';
             }
         } catch (error) {
             if (requestId !== this.removeLiquidityPreviewRequestId) {
@@ -2226,18 +2324,35 @@ class StakingModalNew {
         const hasSufficientBalance = balanceRaw.gte(removeUnits);
         const hasValidPreview = this.removeLiquidityPreviewStatus === 'ready'
             && this.removeLiquidityPreview?.supported;
-        const shouldWaitForOpenPreview = this.removeLiquidityEnabled && !hasValidPreview;
+        const hasSupportedConversion = !this.convertLibToUsdtEnabled
+            || this.removeLiquidityPreview?.conversion?.supported;
+        const shouldWaitForOpenPreview = this.convertLibToUsdtEnabled
+            && (!hasValidPreview || !hasSupportedConversion);
         const approvePhase = this.actionPhases?.approveRemoveLiquidity || 'idle';
         const removePhase = this.actionPhases?.removeLiquidity || 'idle';
-        const activePhase = approvePhase !== 'idle' ? approvePhase : removePhase;
+        const approveConversionPhase = this.actionPhases?.approveRemoveLiquidityConversion || 'idle';
+        const convertPhase = this.actionPhases?.convertRemoveLiquidityToken || 'idle';
+        const activePhase = approvePhase !== 'idle'
+            ? approvePhase
+            : removePhase !== 'idle'
+                ? removePhase
+                : approveConversionPhase !== 'idle'
+                    ? approveConversionPhase
+                    : convertPhase;
 
         if (activePhase !== 'idle') {
             removeButton.disabled = true;
             if (buttonIcon) buttonIcon.textContent = 'hourglass_empty';
             if (buttonText) {
-                buttonText.textContent = approvePhase !== 'idle'
-                    ? (approvePhase === 'userApproval' ? ' Approve Router...' : ' Confirming Approval...')
-                    : (removePhase === 'userApproval' ? ' Remove Liquidity...' : ' Removing Liquidity...');
+                if (approvePhase !== 'idle') {
+                    buttonText.textContent = approvePhase === 'userApproval' ? ' Approve LP...' : ' Confirming LP Approval...';
+                } else if (removePhase !== 'idle') {
+                    buttonText.textContent = removePhase === 'userApproval' ? ' Remove Liquidity...' : ' Removing Liquidity...';
+                } else if (approveConversionPhase !== 'idle') {
+                    buttonText.textContent = approveConversionPhase === 'userApproval' ? ' Approve LIB...' : ' Confirming LIB Approval...';
+                } else {
+                    buttonText.textContent = convertPhase === 'userApproval' ? ' Convert LIB...' : ' Converting LIB...';
+                }
             }
             return;
         }
@@ -2250,13 +2365,19 @@ class StakingModalNew {
         if (!hasSufficientBalance && hasAmount) {
             removeButton.title = 'Insufficient LP token balance';
         } else if (shouldWaitForOpenPreview) {
-            removeButton.title = this.removeLiquidityPreviewError || 'Wait for a supported remove-liquidity preview.';
+            removeButton.title = this.removeLiquidityPreviewError || 'Wait for a supported LIB to USDT conversion preview.';
         } else {
-            removeButton.title = 'Remove LP liquidity';
+            removeButton.title = this.convertLibToUsdtEnabled
+                ? 'Remove LP liquidity and convert LIB to USDT'
+                : 'Remove LP liquidity';
         }
 
         if (buttonIcon) buttonIcon.textContent = 'swap_horiz';
-        if (buttonText) buttonText.textContent = ' Remove LP Liquidity';
+        if (buttonText) {
+            buttonText.textContent = this.convertLibToUsdtEnabled
+                ? ' Remove LP + Convert LIB'
+                : ' Remove LP Liquidity';
+        }
     }
 
     /**
@@ -2466,7 +2587,7 @@ class StakingModalNew {
         this.zapQuoteRequestId += 1;
         this.stopZapQuoteAutoRefresh();
         this.clearZapQuoteRateLimitTimer();
-        this.removeLiquidityEnabled = false;
+        this.convertLibToUsdtEnabled = false;
         this.removeLiquidityAmount = '';
         this.removeLiquidityPreview = null;
         this.removeLiquidityPreviewStatus = 'idle';
@@ -2821,20 +2942,20 @@ class StakingModalNew {
                     <input
                         type="checkbox"
                         id="remove-liquidity-checkbox"
-                        ${this.removeLiquidityEnabled ? 'checked' : ''}
+                        ${this.convertLibToUsdtEnabled ? 'checked' : ''}
                     >
                     <span class="checkmark"></span>
-                    Show pair-token return preview and settings
+                    Convert returned LIB to USDT after removing LP
                 </label>
             </div>
 
-            ${this.removeLiquidityEnabled ? this.renderRemoveLiquidityControls() : ''}
+            ${this.convertLibToUsdtEnabled ? this.renderRemoveLiquidityControls() : ''}
 
             <div class="modal-actions">
                 <button class="btn btn-secondary" onclick="safeModalClose()">Cancel</button>
                 <button class="btn btn-primary remove-liquidity-action-btn" onclick="safeModalExecuteRemoveLiquidity()" ${!this.removeLiquidityAmount || parseFloat(this.removeLiquidityAmount) === 0 ? 'disabled' : ''}>
                     <span class="material-icons">swap_horiz</span>
-                    Remove LP Liquidity
+                    ${this.convertLibToUsdtEnabled ? 'Remove LP + Convert LIB' : 'Remove LP Liquidity'}
                 </button>
             </div>
         `;
@@ -2964,7 +3085,28 @@ class StakingModalNew {
             this.renderZapQuoteRow('Minimum token1', token1MinDisplay),
             this.renderZapQuoteRow('Slippage', slippageDisplay),
             this.renderZapQuoteRow('Deadline', deadlineDisplay)
-        ].join('');
+        ];
+
+        if (this.convertLibToUsdtEnabled) {
+            const conversion = this.removeLiquidityPreview?.conversion;
+            if (conversion?.supported) {
+                rows.splice(
+                    5,
+                    0,
+                    this.renderZapQuoteRow('Convert after remove', `${conversion.fromToken.symbol} to ${conversion.toToken.symbol}`),
+                    this.renderZapQuoteRow(
+                        `Estimated final ${conversion.toToken.symbol}`,
+                        this.formatRemoveLiquidityTokenAmount(conversion.finalAmount, conversion.toToken)
+                    ),
+                    this.renderZapQuoteRow(
+                        `Minimum final ${conversion.toToken.symbol}`,
+                        this.formatRemoveLiquidityTokenAmount(conversion.finalMinAmount, conversion.toToken)
+                    )
+                );
+            } else if (conversion?.reason) {
+                rows.splice(5, 0, this.renderZapQuoteRow('Convert after remove', conversion.reason));
+            }
+        }
 
         return `
             <div class="${cardClass}">
@@ -2984,7 +3126,7 @@ class StakingModalNew {
                     </div>
                 </div>
                 <dl class="zap-quote-list remove-liquidity-preview-list">
-                    ${rows}
+                    ${rows.join('')}
                 </dl>
             </div>
         `;
@@ -3700,6 +3842,66 @@ class StakingModalNew {
         }
     }
 
+    async executeRemoveLiquidityConversion({ service, preview, conversion, amountIn, userAddress, provider, signer }) {
+        const spender = preview.adapter.routerAddress;
+        const allowance = await service.getTokenAllowance({
+            tokenAddress: conversion.fromToken.address,
+            owner: userAddress,
+            spender,
+            provider
+        });
+
+        if (allowance.lt(amountIn)) {
+            this.pendingOperations.approveRemoveLiquidityConversion = true;
+            this.setActionPhase('approveRemoveLiquidityConversion', 'userApproval');
+            window.notificationManager?.info(`Approving ${conversion.fromToken.symbol} for conversion...`);
+
+            await window.contractManager.executeTransactionOnce(async () => {
+                const tx = await service.approveTokenIfNeeded({
+                    tokenAddress: conversion.fromToken.address,
+                    spender,
+                    amountRaw: amountIn,
+                    signer
+                });
+                if (!tx) {
+                    throw new Error(`${conversion.fromToken.symbol} allowance is already sufficient.`);
+                }
+                console.log(`✅ ${conversion.fromToken.symbol} conversion approval sent: ${tx.hash}`);
+                return tx;
+            }, 'approveRemoveLiquidityConversion');
+
+            this.pendingOperations.approveRemoveLiquidityConversion = false;
+            this.setActionPhase('approveRemoveLiquidityConversion', 'idle');
+        }
+
+        const quote = await service.getSwapQuote({
+            routerAddress: preview.adapter.routerAddress,
+            amountIn,
+            path: conversion.path,
+            provider
+        });
+        const amountOutMin = service.calculateMinAmount(quote.amountOut, this.removeLiquiditySlippageBps);
+        const deadlineSeconds = Math.floor(Date.now() / 1000) + (Number(this.removeLiquidityDeadlineMinutes) || 20) * 60;
+
+        this.pendingOperations.convertRemoveLiquidityToken = true;
+        this.setActionPhase('convertRemoveLiquidityToken', 'userApproval');
+        window.notificationManager?.info(`Converting ${conversion.fromToken.symbol} to ${conversion.toToken.symbol}...`);
+
+        return await window.contractManager.executeTransactionOnce(async () => {
+            const tx = await service.swapExactTokensForTokens({
+                routerAddress: preview.adapter.routerAddress,
+                amountIn,
+                amountOutMin,
+                path: conversion.path,
+                recipient: userAddress,
+                deadline: deadlineSeconds,
+                signer
+            });
+            console.log(`✅ ${conversion.fromToken.symbol} conversion sent: ${tx.hash}`);
+            return tx;
+        }, 'convertRemoveLiquidityToken');
+    }
+
     async executeRemoveLiquidityTransaction(lpTokenAddress, liquidityRaw) {
         const service = this.getRemoveLiquidityService();
         const provider = window.contractManager?.provider || window.walletManager?.provider;
@@ -3716,6 +3918,10 @@ class StakingModalNew {
         if (!preview?.supported) {
             throw new Error(this.removeLiquidityPreviewError || 'Remove liquidity is not supported for this pool.');
         }
+        const conversion = this.convertLibToUsdtEnabled ? preview.conversion : null;
+        if (this.convertLibToUsdtEnabled && !conversion?.supported) {
+            throw new Error(preview.conversion?.reason || 'LIB to USDT conversion is not supported for this pool.');
+        }
 
         await service.validateRouterFactory({
             routerAddress: preview.adapter.routerAddress,
@@ -3731,6 +3937,14 @@ class StakingModalNew {
         if (lpBalance.lt(liquidityRaw)) {
             throw new Error('Insufficient LP token balance.');
         }
+
+        const preConversionBalance = conversion
+            ? await service.getTokenBalance({
+                tokenAddress: conversion.fromToken.address,
+                owner: userAddress,
+                provider
+            })
+            : null;
 
         const allowance = await service.getAllowance({
             lpTokenAddress,
@@ -3767,7 +3981,7 @@ class StakingModalNew {
         this.setActionPhase('removeLiquidity', 'userApproval');
         window.notificationManager?.info('Removing liquidity...');
 
-        return await window.contractManager.executeTransactionOnce(async () => {
+        const removeResult = await window.contractManager.executeTransactionOnce(async () => {
             const tx = await service.removeLiquidity({
                 routerAddress: preview.adapter.routerAddress,
                 token0: preview.token0.address,
@@ -3782,6 +3996,42 @@ class StakingModalNew {
             console.log(`✅ Remove liquidity transaction sent: ${tx.hash}`);
             return tx;
         }, 'removeLiquidity');
+
+        if (!conversion) {
+            return removeResult;
+        }
+
+        this.pendingOperations.removeLiquidity = false;
+        this.setActionPhase('removeLiquidity', 'idle');
+
+        const postConversionBalance = await service.getTokenBalance({
+            tokenAddress: conversion.fromToken.address,
+            owner: userAddress,
+            provider
+        });
+        const actualAmountIn = postConversionBalance.sub(preConversionBalance);
+        if (actualAmountIn.lte(0)) {
+            const error = new Error(`No ${conversion.fromToken.symbol} was received to convert.`);
+            error.removeLiquidityCompleted = true;
+            throw error;
+        }
+
+        try {
+            await this.executeRemoveLiquidityConversion({
+                service,
+                preview,
+                conversion,
+                amountIn: actualAmountIn,
+                userAddress,
+                provider,
+                signer
+            });
+        } catch (error) {
+            error.removeLiquidityCompleted = true;
+            throw error;
+        }
+
+        return removeResult;
     }
 
     async executeRemoveLiquidity() {
@@ -3822,7 +4072,11 @@ class StakingModalNew {
             const lpTokenAddress = this.currentPair.lpToken || this.currentPair.address;
             const liquidityRaw = this.getRemoveLiquidityAmountRaw();
             await this.executeRemoveLiquidityTransaction(lpTokenAddress, liquidityRaw);
-            window.notificationManager?.success('Liquidity removed successfully!');
+            window.notificationManager?.success(
+                this.convertLibToUsdtEnabled
+                    ? 'Liquidity removed and LIB converted to USDT successfully!'
+                    : 'Liquidity removed successfully!'
+            );
 
             this.clearInputs();
             this.close();
@@ -3839,7 +4093,10 @@ class StakingModalNew {
             console.log('✅ Home page data refreshed after remove liquidity');
         } catch (error) {
             console.error('❌ Remove liquidity failed:', error);
-            const errorMessage = error?.userMessage?.message || error?.message || 'Remove liquidity failed. Your LP tokens remain in your wallet.';
+            const fallbackMessage = error?.removeLiquidityCompleted
+                ? 'Liquidity was removed, but LIB conversion failed. Your returned tokens remain in your wallet.'
+                : 'Remove liquidity failed. Your LP tokens remain in your wallet.';
+            const errorMessage = error?.userMessage?.message || error?.message || fallbackMessage;
             window.notificationManager?.error(errorMessage, {title: error?.userMessage?.title});
             await this.loadUserBalances().catch(loadError => {
                 console.warn('Unable to refresh balances after remove-liquidity failure:', loadError.message);
@@ -3847,8 +4104,12 @@ class StakingModalNew {
         } finally {
             this.pendingOperations.approveRemoveLiquidity = false;
             this.pendingOperations.removeLiquidity = false;
+            this.pendingOperations.approveRemoveLiquidityConversion = false;
+            this.pendingOperations.convertRemoveLiquidityToken = false;
             this.setActionPhase('approveRemoveLiquidity', 'idle');
             this.setActionPhase('removeLiquidity', 'idle');
+            this.setActionPhase('approveRemoveLiquidityConversion', 'idle');
+            this.setActionPhase('convertRemoveLiquidityToken', 'idle');
             this.isExecutingRemoveLiquidity = false;
             this.updateRemoveLiquidityButton();
         }

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -879,6 +879,35 @@ class StakingModalNew {
         return '';
     }
 
+    updateCustomSlippageFieldError(inputId, errorId, errorMessage) {
+        const input = document.getElementById(inputId);
+        if (!input) return;
+
+        input.setAttribute?.('aria-invalid', errorMessage ? 'true' : 'false');
+        if (errorMessage) {
+            input.setAttribute?.('aria-describedby', errorId);
+        } else {
+            input.removeAttribute?.('aria-describedby');
+        }
+
+        let errorElement = document.getElementById(errorId);
+        if (!errorMessage) {
+            errorElement?.remove?.();
+            return;
+        }
+
+        if (!errorElement && typeof document.createElement === 'function') {
+            errorElement = document.createElement('div');
+            errorElement.id = errorId;
+            errorElement.className = 'zap-field-error';
+            input.closest?.('.form-group')?.appendChild?.(errorElement);
+        }
+
+        if (errorElement) {
+            errorElement.textContent = errorMessage;
+        }
+    }
+
     hasInvalidRemoveLiquidityCustomSlippage() {
         return !!this.getRemoveLiquidityCustomSlippageError();
     }
@@ -936,6 +965,11 @@ class StakingModalNew {
         this.removeLiquidityCustomSlippageSelected = true;
         this.removeLiquidityCustomSlippageError = this.getRemoveLiquidityCustomSlippageError(sanitizedValue);
         this.updateRemoveLiquiditySlippageButtonState();
+        this.updateCustomSlippageFieldError(
+            'remove-liquidity-custom-slippage-input',
+            'remove-liquidity-custom-slippage-error',
+            this.removeLiquidityCustomSlippageError
+        );
 
         if (this.removeLiquidityCustomSlippageError) {
             this.resetRemoveLiquidityPreview();
@@ -1489,6 +1523,11 @@ class StakingModalNew {
         const sanitizedValue = this.applyDecimalLimit(String(value ?? ''), 2);
         this.zapCustomSlippage = sanitizedValue;
         this.zapCustomSlippageError = this.getZapCustomSlippageError(sanitizedValue);
+        this.updateCustomSlippageFieldError(
+            'zap-custom-slippage-input',
+            'zap-custom-slippage-error',
+            this.zapCustomSlippageError
+        );
 
         if (this.zapCustomSlippageError) {
             this.resetZapQuoteState();
@@ -3369,9 +3408,10 @@ class StakingModalNew {
                                 max="100"
                                 step="0.01"
                                 aria-invalid="${this.removeLiquidityCustomSlippageError ? 'true' : 'false'}"
+                                ${this.removeLiquidityCustomSlippageError ? 'aria-describedby="remove-liquidity-custom-slippage-error"' : ''}
                             >
                         </div>
-                        ${this.removeLiquidityCustomSlippageError ? `<div class="zap-field-error">${this.escapeHtml(this.removeLiquidityCustomSlippageError)}</div>` : ''}
+                        ${this.removeLiquidityCustomSlippageError ? `<div id="remove-liquidity-custom-slippage-error" class="zap-field-error">${this.escapeHtml(this.removeLiquidityCustomSlippageError)}</div>` : ''}
                     </div>
 
                     <div class="form-group">
@@ -3502,6 +3542,7 @@ class StakingModalNew {
 
     renderRemoveLiquidityPreviewPanel() {
         const balanceError = this.getRemoveLiquidityBalanceError();
+        const invalidCustomSlippage = this.hasInvalidRemoveLiquidityCustomSlippage();
         const isLoading = this.removeLiquidityPreviewStatus === 'loading';
         const hasPreview = this.removeLiquidityPreviewStatus === 'ready' && this.removeLiquidityPreview?.supported;
         const isError = this.removeLiquidityPreviewStatus === 'error' || !!balanceError;
@@ -3531,6 +3572,8 @@ class StakingModalNew {
 
             if (isLoading) {
                 summary = 'Loading Kyber zap-out route...';
+            } else if (invalidCustomSlippage) {
+                summary = `Enter a valid custom slippage to preview ${outputSymbol} output.`;
             } else if (isPositionBalanceError) {
                 summary = 'Kyber cannot quote more LP than your available balance.';
             } else if (isError) {
@@ -3558,11 +3601,11 @@ class StakingModalNew {
                 const suggestedSlippage = data?.suggestedSlippage || data?.slippage || this.removeLiquiditySlippageBps;
                 slippageDisplay = `${(Number(suggestedSlippage) / 100).toFixed(2)}%`;
                 slippageRiskClass = this.isHighZapSlippage(suggestedSlippage) ? 'zap-risk-high' : '';
-                if (slippageRiskClass) {
-                    warningMessages.push('High slippage tolerance. This transaction may execute at a much worse rate.');
-                }
                 feeDisplay = this.formatZapFeeDetailsDisplay(this.getRemoveLiquidityProtocolFeeDetails(data));
                 summary = `Kyber zap-out to ${outputSymbol}`;
+            }
+            if (slippageRiskClass) {
+                warningMessages.push('High slippage tolerance. This transaction may execute at a much worse rate.');
             }
 
             const rows = [];
@@ -3623,6 +3666,8 @@ class StakingModalNew {
         const warningMessages = [];
         if (isLoading) {
             summary = 'Loading LP reserves...';
+        } else if (invalidCustomSlippage) {
+            summary = 'Enter a valid custom slippage to preview remove liquidity.';
         } else if (isError) {
             summary = balanceError || this.removeLiquidityPreviewError || 'Remove liquidity is not supported for this pool.';
             dexDisplay = this.removeLiquidityPreview?.factoryAddress
@@ -3636,9 +3681,9 @@ class StakingModalNew {
             token0MinDisplay = this.formatRemoveLiquidityTokenAmount(preview.token0.minAmount, preview.token0);
             token1MinDisplay = this.formatRemoveLiquidityTokenAmount(preview.token1.minAmount, preview.token1);
             summary = `${preview.token0.symbol} + ${preview.token1.symbol} via ${dexDisplay}`;
-            if (slippageRiskClass) {
-                warningMessages.push('High slippage tolerance. This transaction may execute at a much worse rate.');
-            }
+        }
+        if (slippageRiskClass) {
+            warningMessages.push('High slippage tolerance. This transaction may execute at a much worse rate.');
         }
 
         const estimatedPairDisplay = hasPreview
@@ -3912,6 +3957,7 @@ class StakingModalNew {
     }
 
     renderZapQuotePanel() {
+        const invalidCustomSlippage = this.hasInvalidZapCustomSlippage();
         const isLoading = this.zapQuoteStatus === 'loading';
         const isError = this.zapQuoteStatus === 'error';
         const hasQuote = this.zapQuoteStatus === 'ready' && !!this.zapQuote;
@@ -3946,6 +3992,8 @@ class StakingModalNew {
 
         if (isLoading) {
             routeSummary = 'Fetching quote...';
+        } else if (invalidCustomSlippage) {
+            routeSummary = 'Enter a valid custom slippage to preview the LP route.';
         } else if (isError) {
             routeSummary = this.zapQuoteError || 'Unable to fetch a zap quote.';
         } else if (hasQuote) {
@@ -3977,10 +4025,10 @@ class StakingModalNew {
             const suggestedSlippage = data?.suggestedSlippage || data?.slippage || this.zapSlippageBps;
             slippageDisplay = `${(Number(suggestedSlippage) / 100).toFixed(2)}%`;
             slippageRiskClass = this.isHighZapSlippage(suggestedSlippage) ? 'zap-risk-high' : '';
-            if (slippageRiskClass) {
-                warningMessages.push('High slippage tolerance. This transaction may execute at a much worse rate.');
-            }
             routeSummary = this.getZapRouteSummary();
+        }
+        if (slippageRiskClass) {
+            warningMessages.push('High slippage tolerance. This transaction may execute at a much worse rate.');
         }
 
         const quoteRows = [

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -54,6 +54,7 @@ class StakingModalNew {
         this.removeLiquiditySlippageBps = window.CONFIG?.KYBER_ZAP?.DEFAULT_SLIPPAGE_BPS || 50;
         this.removeLiquidityCustomSlippage = '';
         this.removeLiquidityCustomSlippageError = '';
+        this.removeLiquidityCustomSlippageSelected = false;
         this.removeLiquidityDeadlineMinutes = window.CONFIG?.KYBER_ZAP?.DEFAULT_DEADLINE_MINUTES || 20;
         this.removeLiquiditySettingsOpen = false;
         this.removeLiquidityPreviewDebounceTimer = null;
@@ -303,7 +304,7 @@ class StakingModalNew {
                 this.setPercentage(percentage);
             }
 
-            if (e.target.closest('.zap-slippage-btn')) {
+            if (e.target.closest('.zap-slippage-btn') && !e.target.closest('.remove-liquidity-slippage-btn')) {
                 const button = e.target.closest('.zap-slippage-btn');
                 this.setZapSlippage(button.dataset.slippage);
             }
@@ -342,6 +343,12 @@ class StakingModalNew {
                 document.querySelectorAll('.remove-liquidity-output-token-picker[open]').forEach(menu => {
                     menu.open = false;
                 });
+            }
+        });
+
+        document.addEventListener('focusin', (e) => {
+            if (e.target.id === 'remove-liquidity-custom-slippage-input') {
+                this.selectRemoveLiquidityCustomSlippage();
             }
         });
 
@@ -791,6 +798,7 @@ class StakingModalNew {
         this.removeLiquidityPreviewError = '';
         this.removeLiquidityCustomSlippage = '';
         this.removeLiquidityCustomSlippageError = '';
+        this.removeLiquidityCustomSlippageSelected = false;
         this.removeLiquiditySettingsOpen = false;
         this.removeLiquidityCustomOutputTokenAddress = '';
         this.removeLiquidityCustomOutputTokenError = '';
@@ -874,7 +882,24 @@ class StakingModalNew {
     }
 
     isRemoveLiquidityCustomSlippageActive() {
-        return !!this.removeLiquidityCustomSlippage && !this.hasInvalidRemoveLiquidityCustomSlippage();
+        return (this.removeLiquidityCustomSlippageSelected || !!this.removeLiquidityCustomSlippage)
+            && !this.hasInvalidRemoveLiquidityCustomSlippage();
+    }
+
+    updateRemoveLiquiditySlippageButtonState() {
+        document.querySelectorAll('.remove-liquidity-slippage-btn').forEach(button => {
+            const isCustom = button.dataset?.slippage === 'custom';
+            const isPreset = Number(button.dataset?.slippage) === this.removeLiquiditySlippageBps;
+            const isActive = isCustom
+                ? this.isRemoveLiquidityCustomSlippageActive()
+                : isPreset && !this.removeLiquidityCustomSlippageSelected && !this.removeLiquidityCustomSlippage;
+            button.classList.toggle('active', isActive);
+        });
+    }
+
+    selectRemoveLiquidityCustomSlippage() {
+        this.removeLiquidityCustomSlippageSelected = true;
+        this.updateRemoveLiquiditySlippageButtonState();
     }
 
     toggleRemoveLiquiditySettings() {
@@ -884,6 +909,8 @@ class StakingModalNew {
 
     setRemoveLiquiditySlippage(value) {
         if (value === 'custom') {
+            this.removeLiquidityCustomSlippageSelected = true;
+            this.renderTabContent();
             const customInput = document.getElementById('remove-liquidity-custom-slippage-input');
             if (customInput) customInput.focus();
             return;
@@ -894,6 +921,7 @@ class StakingModalNew {
             this.removeLiquiditySlippageBps = parsed;
             this.removeLiquidityCustomSlippage = '';
             this.removeLiquidityCustomSlippageError = '';
+            this.removeLiquidityCustomSlippageSelected = false;
             this.resetRemoveLiquidityPreview();
             this.renderTabContent();
             this.debounceRemoveLiquidityPreview(0);
@@ -903,7 +931,9 @@ class StakingModalNew {
     setRemoveLiquidityCustomSlippageInput(value) {
         const sanitizedValue = this.applyDecimalLimit(String(value ?? ''), 2);
         this.removeLiquidityCustomSlippage = sanitizedValue;
+        this.removeLiquidityCustomSlippageSelected = true;
         this.removeLiquidityCustomSlippageError = this.getRemoveLiquidityCustomSlippageError(sanitizedValue);
+        this.updateRemoveLiquiditySlippageButtonState();
 
         if (this.removeLiquidityCustomSlippageError) {
             this.resetRemoveLiquidityPreview({
@@ -3329,7 +3359,7 @@ class StakingModalNew {
                             ${slippageOptions.map(option => `
                                 <button
                                     type="button"
-                                    class="zap-slippage-btn remove-liquidity-slippage-btn ${this.removeLiquiditySlippageBps === option && !this.removeLiquidityCustomSlippage ? 'active' : ''}"
+                                    class="zap-slippage-btn remove-liquidity-slippage-btn ${this.removeLiquiditySlippageBps === option && !this.removeLiquidityCustomSlippageSelected && !this.removeLiquidityCustomSlippage ? 'active' : ''}"
                                     data-slippage="${option}"
                                 >
                                     ${(option / 100).toFixed(option < 10 ? 2 : 1)}%

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -3517,8 +3517,7 @@ class StakingModalNew {
         const balanceError = this.getRemoveLiquidityBalanceError();
         const isLoading = this.removeLiquidityPreviewStatus === 'loading';
         const hasPreview = this.removeLiquidityPreviewStatus === 'ready' && this.removeLiquidityPreview?.supported;
-        const showBalanceAsWarning = this.removeLiquidityZapOutEnabled && !!balanceError;
-        const isError = this.removeLiquidityPreviewStatus === 'error' || (!!balanceError && !showBalanceAsWarning);
+        const isError = this.removeLiquidityPreviewStatus === 'error' || !!balanceError;
         const pendingValue = isLoading ? '...' : '-';
         const cardClass = [
             'zap-quote-card',

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -502,7 +502,6 @@ class StakingModalNew {
         // Reset form inputs
         this.stakeAmount = '';
         this.unstakeAmount = '';
-        this.removeLiquidityAmount = '';
         this.zapInputAmount = '';
         this.zapQuote = null;
         this.zapQuoteStatus = 'idle';
@@ -517,15 +516,7 @@ class StakingModalNew {
         this.zapCustomSlippageError = '';
         this.zapQuoteRequestId += 1;
         this.stopZapQuoteAutoRefresh();
-        this.convertLibToUsdtEnabled = false;
-        this.removeLiquidityAmount = '';
-        this.removeLiquidityPreview = null;
-        this.removeLiquidityPreviewStatus = 'idle';
-        this.removeLiquidityPreviewError = '';
-        this.removeLiquidityCustomSlippage = '';
-        this.removeLiquidityCustomSlippageError = '';
-        this.removeLiquidityPreviewRequestId += 1;
-        this.clearRemoveLiquidityPreviewDebounce();
+        this.resetRemoveLiquidityFormState();
 
         // Reset transaction progress state
         this.resetActionStates(false);
@@ -765,6 +756,18 @@ class StakingModalNew {
         }
     }
 
+    resetRemoveLiquidityFormState() {
+        this.convertLibToUsdtEnabled = false;
+        this.removeLiquidityAmount = '';
+        this.removeLiquidityPreview = null;
+        this.removeLiquidityPreviewStatus = 'idle';
+        this.removeLiquidityPreviewError = '';
+        this.removeLiquidityCustomSlippage = '';
+        this.removeLiquidityCustomSlippageError = '';
+        this.removeLiquidityPreviewRequestId += 1;
+        this.clearRemoveLiquidityPreviewDebounce();
+    }
+
     resetRemoveLiquidityPreview({ status = 'idle', error = '' } = {}) {
         this.removeLiquidityPreview = null;
         this.removeLiquidityPreviewStatus = status;
@@ -882,10 +885,7 @@ class StakingModalNew {
             return null;
         }
 
-        const chainId = this.getRemoveLiquidityChainId();
-        const chainConfig = window.CONFIG?.DEX_REMOVE_LIQUIDITY?.[String(chainId)]
-            || window.CONFIG?.DEX_REMOVE_LIQUIDITY?.[Number(chainId)]
-            || null;
+        const chainConfig = window.CONFIG?.DEX_REMOVE_LIQUIDITY?.[String(this.getRemoveLiquidityChainId())] || null;
         const conversionConfig = chainConfig?.libToUsdtConversion || null;
         const fromAddress = this.normalizeAddress(conversionConfig?.fromToken);
         const toAddress = this.normalizeAddress(conversionConfig?.toToken);
@@ -2585,7 +2585,6 @@ class StakingModalNew {
         // Clear state
         this.stakeAmount = '';
         this.unstakeAmount = '';
-        this.removeLiquidityAmount = '';
         this.zapInputAmount = '';
         this.zapQuote = null;
         this.zapQuoteStatus = 'idle';
@@ -2598,15 +2597,7 @@ class StakingModalNew {
         this.zapQuoteRequestId += 1;
         this.stopZapQuoteAutoRefresh();
         this.clearZapQuoteRateLimitTimer();
-        this.convertLibToUsdtEnabled = false;
-        this.removeLiquidityAmount = '';
-        this.removeLiquidityPreview = null;
-        this.removeLiquidityPreviewStatus = 'idle';
-        this.removeLiquidityPreviewError = '';
-        this.removeLiquidityCustomSlippage = '';
-        this.removeLiquidityCustomSlippageError = '';
-        this.removeLiquidityPreviewRequestId += 1;
-        this.clearRemoveLiquidityPreviewDebounce();
+        this.resetRemoveLiquidityFormState();
         this.isApproved = false;
         this.needsApproval = false;
         this.resetActionStates(false);

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -3210,6 +3210,15 @@ class StakingModalNew {
 
     renderRemoveLiquidityTab() {
         const balanceError = this.getRemoveLiquidityBalanceError();
+        const removeLiquidityAmount = parseFloat(this.removeLiquidityAmount) || 0;
+        const removeLiquidityMax = parseFloat(this.userBalance) || 0;
+        const removeLiquidityPercentage = removeLiquidityMax > 0
+            ? Math.min(100, Math.max(0, (removeLiquidityAmount / removeLiquidityMax) * 100))
+            : 0;
+        const activeRemoveLiquidityPercentage = [25, 50, 75, 100].find(percentage =>
+            Math.abs(removeLiquidityPercentage - percentage) < 0.001
+        );
+
         return `
             <div class="balance-info">
                 <span class="balance-label">Available LP Tokens:</span>
@@ -3236,15 +3245,15 @@ class StakingModalNew {
                         id="remove-liquidity-slider"
                         min="0"
                         max="100"
-                        value="0"
+                        value="${removeLiquidityPercentage}"
                         data-type="remove-liquidity"
                     >
                 </div>
                 <div class="percentage-buttons">
-                    <button class="percentage-btn" data-percentage="25">25%</button>
-                    <button class="percentage-btn" data-percentage="50">50%</button>
-                    <button class="percentage-btn" data-percentage="75">75%</button>
-                    <button class="percentage-btn" data-percentage="100">MAX</button>
+                    <button class="percentage-btn${activeRemoveLiquidityPercentage === 25 ? ' active' : ''}" data-percentage="25">25%</button>
+                    <button class="percentage-btn${activeRemoveLiquidityPercentage === 50 ? ' active' : ''}" data-percentage="50">50%</button>
+                    <button class="percentage-btn${activeRemoveLiquidityPercentage === 75 ? ' active' : ''}" data-percentage="75">75%</button>
+                    <button class="percentage-btn${activeRemoveLiquidityPercentage === 100 ? ' active' : ''}" data-percentage="100">MAX</button>
                 </div>
             </div>
 

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -1721,6 +1721,106 @@ class StakingModalNew {
         return { value: fallback, path: null };
     }
 
+    isRemoveLiquidityOutputTokenAddress(address, outputToken = this.removeLiquiditySelectedOutputToken) {
+        if (!address || !outputToken) {
+            return false;
+        }
+
+        const service = this.getKyberZapService();
+        const normalizedAddress = service.normalizeAddress(address);
+        const normalizedOutputAddress = service.normalizeAddress(this.getRemoveLiquidityOutputTokenAddressForKyber(outputToken));
+        if (normalizedAddress === normalizedOutputAddress) {
+            return true;
+        }
+
+        const wrappedNativeAddress = service.normalizeAddress(this.getKyberZapNetworkConfig()?.WRAPPED_NATIVE_TOKEN_ADDRESS);
+        return this.isNativeZapToken(outputToken.address)
+            && (this.isNativeZapToken(address) || (!!wrappedNativeAddress && normalizedAddress === wrappedNativeAddress));
+    }
+
+    getZapActionTokenAmount(token, outputToken) {
+        if (!token || !this.isRemoveLiquidityOutputTokenAddress(token.address, outputToken)) {
+            return null;
+        }
+
+        const amount = token.amount ?? token.amountRaw ?? token.value ?? null;
+        return amount === undefined || amount === null || amount === '' ? null : String(amount);
+    }
+
+    collectRemoveLiquidityOutputAmounts(outputToken = this.removeLiquiditySelectedOutputToken) {
+        const data = this.getRemoveLiquidityRouteData();
+        const actions = data?.zapDetails?.actions;
+        if (!Array.isArray(actions)) {
+            return [];
+        }
+
+        const amounts = [];
+        const addTokenAmount = token => {
+            const amount = this.getZapActionTokenAmount(token, outputToken);
+            if (amount) {
+                amounts.push(amount);
+            }
+        };
+        const addTokens = tokens => {
+            if (Array.isArray(tokens)) {
+                tokens.forEach(addTokenAmount);
+            }
+        };
+        const addSwapOutputs = swapAction => {
+            if (Array.isArray(swapAction?.swaps)) {
+                swapAction.swaps.forEach(swap => addTokenAmount(swap?.tokenOut || swap?.token_out));
+            }
+        };
+
+        actions.forEach(action => {
+            const removeLiquidity = action?.removeLiquidity || action?.remove_liquidity;
+            addTokens(removeLiquidity?.tokens);
+            addTokenAmount(removeLiquidity?.token0);
+            addTokenAmount(removeLiquidity?.token1);
+
+            addSwapOutputs(action?.aggregatorSwap || action?.aggregator_swap);
+            addSwapOutputs(action?.poolSwap || action?.pool_swap);
+            addTokens((action?.refund || action?.refundAction || action?.refund_action)?.tokens);
+        });
+
+        return amounts;
+    }
+
+    sumZapRawAmounts(amounts) {
+        if (!amounts.length) {
+            return null;
+        }
+
+        if (amounts.every(amount => /^\d+$/.test(String(amount)))) {
+            return amounts.reduce((total, amount) => total + BigInt(amount), 0n).toString();
+        }
+
+        const numericAmounts = amounts.map(Number);
+        if (numericAmounts.every(Number.isFinite)) {
+            return numericAmounts.reduce((total, amount) => total + amount, 0).toString();
+        }
+
+        return amounts[0];
+    }
+
+    getRemoveLiquidityEstimatedOutputEntry(outputToken, fallback = 'N/A') {
+        const directEntry = this.getRemoveLiquidityQuoteSummaryEntry([
+            'zapDetails.finalAmount',
+            'zapDetails.outputAmount',
+            'outputAmount',
+            'amountOut',
+            'routeSummary.amountOut'
+        ], null);
+        if (directEntry.value !== null) {
+            return directEntry;
+        }
+
+        const actionAmount = this.sumZapRawAmounts(this.collectRemoveLiquidityOutputAmounts(outputToken));
+        return actionAmount
+            ? { value: actionAmount, path: 'zapDetails.actions' }
+            : { value: fallback, path: null };
+    }
+
     getZapHighSlippageBps() {
         return window.CONFIG?.KYBER_ZAP?.HIGH_SLIPPAGE_BPS || 300;
     }
@@ -3065,7 +3165,7 @@ class StakingModalNew {
                         ${this.removeLiquidityZapOutEnabled ? 'checked' : ''}
                     >
                     <span class="checkmark"></span>
-                    Zap out to one token with Kyber
+                    Convert to one preferred token
                 </label>
             </div>
 
@@ -3264,13 +3364,7 @@ class StakingModalNew {
                 routerDisplay = 'Unsupported';
             } else if (hasPreview) {
                 const routeData = this.getRemoveLiquidityRouteData();
-                const outputEntry = this.getRemoveLiquidityQuoteSummaryEntry([
-                    'zapDetails.finalAmount',
-                    'zapDetails.outputAmount',
-                    'outputAmount',
-                    'amountOut',
-                    'routeSummary.amountOut'
-                ], pendingValue);
+                const outputEntry = this.getRemoveLiquidityEstimatedOutputEntry(outputToken, pendingValue);
                 const outputUsdEntry = this.getRemoveLiquidityQuoteSummaryEntry([
                     'zapDetails.finalAmountUsd',
                     'amountOutUsd',

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -3613,12 +3613,6 @@ class StakingModalNew {
                 minimumPairDisplay,
                 '',
                 'Transaction reverts if either token output is below this value after max slippage.'
-            ),
-            this.renderZapQuoteRow(
-                'DEX',
-                dexDisplay,
-                '',
-                'Router/factory selected for this LP position.'
             )
         ];
 

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -3486,8 +3486,9 @@ class StakingModalNew {
     renderRemoveLiquidityPreviewPanel() {
         const balanceError = this.getRemoveLiquidityBalanceError();
         const isLoading = this.removeLiquidityPreviewStatus === 'loading';
-        const isError = this.removeLiquidityPreviewStatus === 'error' || !!balanceError;
         const hasPreview = this.removeLiquidityPreviewStatus === 'ready' && this.removeLiquidityPreview?.supported;
+        const showBalanceAsWarning = this.removeLiquidityZapOutEnabled && !!balanceError;
+        const isError = this.removeLiquidityPreviewStatus === 'error' || (!!balanceError && !showBalanceAsWarning);
         const pendingValue = isLoading ? '...' : '-';
         const cardClass = [
             'zap-quote-card',
@@ -3499,6 +3500,7 @@ class StakingModalNew {
         if (this.removeLiquidityZapOutEnabled) {
             const outputToken = this.removeLiquiditySelectedOutputToken;
             const outputSymbol = outputToken?.symbol || 'token';
+            const isPositionBalanceError = !!balanceError;
             let summary = this.removeLiquidityAmount
                 ? `Checking Kyber zap-out to ${outputSymbol}...`
                 : `Enter an amount to preview ${outputSymbol} output.`;
@@ -3509,8 +3511,10 @@ class StakingModalNew {
 
             if (isLoading) {
                 summary = 'Loading Kyber zap-out route...';
+            } else if (isPositionBalanceError) {
+                summary = 'Kyber cannot quote more LP than your available balance.';
             } else if (isError) {
-                summary = balanceError || this.removeLiquidityPreviewError || 'Unable to fetch a Kyber zap-out preview.';
+                summary = this.removeLiquidityPreviewError || 'Unable to fetch a Kyber zap-out preview.';
             } else if (hasPreview) {
                 const data = this.getRemoveLiquidityRouteData();
                 const outputEntry = this.getRemoveLiquidityEstimatedOutputEntry(outputToken, pendingValue);
@@ -3532,12 +3536,12 @@ class StakingModalNew {
             }
 
             const rows = [];
-            if (isError) {
+            if (isError || isPositionBalanceError) {
                 rows.push(this.renderZapQuoteRow(
-                    'Route',
-                    'Unsupported',
+                    'Kyber quote',
+                    isPositionBalanceError ? 'Unavailable above LP balance' : 'Unsupported',
                     '',
-                    'Routing status for this LP position.'
+                    'Kyber zap-out requires the selected wallet position to hold the requested LP amount.'
                 ));
             }
             rows.push(
@@ -4563,6 +4567,13 @@ class StakingModalNew {
                 this.updateRemoveLiquidityPreviewPanel();
                 this.updateRemoveLiquidityButton();
                 window.notificationManager?.error(slippageError);
+                return;
+            }
+            const balanceError = this.getRemoveLiquidityBalanceError();
+            if (balanceError) {
+                this.updateRemoveLiquidityPreviewPanel();
+                this.updateRemoveLiquidityButton();
+                window.notificationManager?.error(balanceError);
                 return;
             }
 

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -3077,7 +3077,7 @@ class StakingModalNew {
             summary = `${preview.token0.symbol} + ${preview.token1.symbol} via ${dexDisplay}`;
         }
 
-        const rows = [
+        let rows = [
             this.renderZapQuoteRow('DEX', dexDisplay),
             this.renderZapQuoteRow('Estimated token0', token0Display),
             this.renderZapQuoteRow('Estimated token1', token1Display),
@@ -3089,22 +3089,54 @@ class StakingModalNew {
 
         if (this.convertLibToUsdtEnabled) {
             const conversion = this.removeLiquidityPreview?.conversion;
+            const conversionFromSymbol = conversion?.fromToken?.symbol || 'LIB';
+            const conversionToSymbol = conversion?.toToken?.symbol || 'USDT';
+            rows = [
+                this.renderZapQuoteRow('DEX', dexDisplay),
+                this.renderZapQuoteRow('LP removal output', hasPreview ? `${token0Display} + ${token1Display}` : pendingValue),
+                this.renderZapQuoteRow(`${conversionFromSymbol} to convert`, pendingValue),
+                this.renderZapQuoteRow(`Estimated ${conversionToSymbol} from conversion`, pendingValue),
+                this.renderZapQuoteRow(`Estimated total ${conversionToSymbol}`, pendingValue),
+                this.renderZapQuoteRow(`Minimum total ${conversionToSymbol}`, pendingValue),
+                this.renderZapQuoteRow('Slippage', slippageDisplay),
+                this.renderZapQuoteRow('Deadline', deadlineDisplay)
+            ];
+
             if (conversion?.supported) {
-                rows.splice(
-                    5,
-                    0,
-                    this.renderZapQuoteRow('Convert after remove', `${conversion.fromToken.symbol} to ${conversion.toToken.symbol}`),
+                summary = `${conversion.fromToken.symbol} converts to ${conversion.toToken.symbol} after LP removal`;
+                rows = [
+                    this.renderZapQuoteRow('DEX', dexDisplay),
+                    this.renderZapQuoteRow('LP removal output', `${token0Display} + ${token1Display}`),
                     this.renderZapQuoteRow(
-                        `Estimated final ${conversion.toToken.symbol}`,
+                        `${conversion.fromToken.symbol} to convert`,
+                        this.formatRemoveLiquidityTokenAmount(conversion.amountIn, conversion.fromToken)
+                    ),
+                    this.renderZapQuoteRow(
+                        `Estimated ${conversion.toToken.symbol} from conversion`,
+                        this.formatRemoveLiquidityTokenAmount(conversion.amountOut, conversion.toToken)
+                    ),
+                    this.renderZapQuoteRow(
+                        `Estimated total ${conversion.toToken.symbol}`,
                         this.formatRemoveLiquidityTokenAmount(conversion.finalAmount, conversion.toToken)
                     ),
                     this.renderZapQuoteRow(
-                        `Minimum final ${conversion.toToken.symbol}`,
+                        `Minimum total ${conversion.toToken.symbol}`,
                         this.formatRemoveLiquidityTokenAmount(conversion.finalMinAmount, conversion.toToken)
-                    )
-                );
+                    ),
+                    this.renderZapQuoteRow('Slippage', slippageDisplay),
+                    this.renderZapQuoteRow('Deadline', deadlineDisplay)
+                ];
             } else if (conversion?.reason) {
-                rows.splice(5, 0, this.renderZapQuoteRow('Convert after remove', conversion.reason));
+                rows = [
+                    this.renderZapQuoteRow('DEX', dexDisplay),
+                    this.renderZapQuoteRow('Conversion', conversion.reason),
+                    this.renderZapQuoteRow('Slippage', slippageDisplay),
+                    this.renderZapQuoteRow('Deadline', deadlineDisplay)
+                ];
+            } else if (!hasPreview && !isError) {
+                summary = this.removeLiquidityAmount
+                    ? 'Checking LIB to USDT conversion...'
+                    : 'Enter an amount to preview final USDT output.';
             }
         }
 

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -55,6 +55,7 @@ class StakingModalNew {
         this.removeLiquidityCustomSlippage = '';
         this.removeLiquidityCustomSlippageError = '';
         this.removeLiquidityDeadlineMinutes = window.CONFIG?.KYBER_ZAP?.DEFAULT_DEADLINE_MINUTES || 20;
+        this.removeLiquiditySettingsOpen = false;
         this.removeLiquidityPreviewDebounceTimer = null;
         this.removeLiquidityPreviewRequestId = 0;
         this.removeLiquidityOutputTokenAddress = '';
@@ -305,6 +306,10 @@ class StakingModalNew {
             if (e.target.closest('.zap-slippage-btn')) {
                 const button = e.target.closest('.zap-slippage-btn');
                 this.setZapSlippage(button.dataset.slippage);
+            }
+
+            if (e.target.closest('.remove-liquidity-settings-toggle')) {
+                this.toggleRemoveLiquiditySettings();
             }
 
             if (e.target.closest('.remove-liquidity-slippage-btn')) {
@@ -801,6 +806,7 @@ class StakingModalNew {
         this.removeLiquidityPreviewError = '';
         this.removeLiquidityCustomSlippage = '';
         this.removeLiquidityCustomSlippageError = '';
+        this.removeLiquiditySettingsOpen = false;
         this.removeLiquidityCustomOutputTokenAddress = '';
         this.removeLiquidityCustomOutputTokenError = '';
         this.removeLiquidityPreviewRequestId += 1;
@@ -884,6 +890,11 @@ class StakingModalNew {
 
     isRemoveLiquidityCustomSlippageActive() {
         return !!this.removeLiquidityCustomSlippage && !this.hasInvalidRemoveLiquidityCustomSlippage();
+    }
+
+    toggleRemoveLiquiditySettings() {
+        this.removeLiquiditySettingsOpen = !this.removeLiquiditySettingsOpen;
+        this.renderTabContent();
     }
 
     setRemoveLiquiditySlippage(value) {
@@ -3250,14 +3261,31 @@ class StakingModalNew {
         return this.formatZapDisplayAmount(amount.raw ?? amount.formatted, token.decimals ?? 18, token.symbol || '');
     }
 
+    formatRemoveLiquidityMinOutputAmount(value, token, fallback = '-') {
+        const valueText = String(value ?? '');
+        if (!/^\d+$/.test(valueText) || !token) {
+            return fallback;
+        }
+
+        try {
+            const slippageBps = BigInt(Math.trunc(Number(this.removeLiquiditySlippageBps) || 0));
+            const minAmount = (BigInt(valueText) * (10000n - slippageBps)) / 10000n;
+            return this.formatZapDisplayAmount(minAmount.toString(), token.decimals ?? 18, token.symbol || '');
+        } catch (error) {
+            return fallback;
+        }
+    }
+
     renderRemoveLiquidityControls() {
-        const slippageOptions = [10, 50, 100];
-        return `
-            <div class="remove-liquidity-section">
-                ${this.removeLiquidityZapOutEnabled ? this.renderRemoveLiquidityOutputTokenPicker() : ''}
-                <div class="remove-liquidity-settings">
+        const slippageOptions = [5, 10, 50, 100];
+        const slippageDisplay = `${(Number(this.removeLiquiditySlippageBps) / 100).toFixed(2)}%`;
+        const settingsPanel = this.removeLiquiditySettingsOpen ? `
+                <div class="remove-liquidity-settings-panel">
                     <div class="form-group">
-                        <label class="form-label">Slippage</label>
+                        <label
+                            class="form-label"
+                            title="Maximum output movement allowed before the transaction reverts."
+                        >Max Slippage</label>
                         <div class="remove-liquidity-slippage-row">
                             ${slippageOptions.map(option => `
                                 <button
@@ -3265,7 +3293,7 @@ class StakingModalNew {
                                     class="remove-liquidity-slippage-btn ${this.removeLiquiditySlippageBps === option && !this.removeLiquidityCustomSlippage ? 'active' : ''}"
                                     data-slippage="${option}"
                                 >
-                                    ${(option / 100).toFixed(1)}%
+                                    ${(option / 100).toFixed(option < 10 ? 2 : 1)}%
                                 </button>
                             `).join('')}
                             <button
@@ -3279,7 +3307,7 @@ class StakingModalNew {
                                 type="number"
                                 id="remove-liquidity-custom-slippage-input"
                                 class="form-input remove-liquidity-custom-slippage"
-                                placeholder="${(this.removeLiquiditySlippageBps / 100).toFixed(2)}%"
+                                placeholder="${slippageDisplay}"
                                 value="${this.escapeHtml(this.removeLiquidityCustomSlippage)}"
                                 min="0.01"
                                 max="100"
@@ -3291,7 +3319,11 @@ class StakingModalNew {
                     </div>
 
                     <div class="form-group">
-                        <label class="form-label" for="remove-liquidity-deadline-input">Deadline</label>
+                        <label
+                            class="form-label"
+                            for="remove-liquidity-deadline-input"
+                            title="Latest time this transaction can execute before it reverts."
+                        >Transaction time limit</label>
                         <div class="remove-liquidity-deadline-row">
                             <input
                                 type="number"
@@ -3307,6 +3339,27 @@ class StakingModalNew {
                         </div>
                     </div>
                 </div>
+        ` : '';
+
+        return `
+            <div class="remove-liquidity-section">
+                ${this.removeLiquidityZapOutEnabled ? this.renderRemoveLiquidityOutputTokenPicker() : ''}
+                <div class="remove-liquidity-settings-summary">
+                    <button
+                        type="button"
+                        class="remove-liquidity-settings-toggle"
+                        aria-expanded="${this.removeLiquiditySettingsOpen ? 'true' : 'false'}"
+                        title="Adjust max slippage and transaction time limit"
+                    >
+                        <span
+                            class="remove-liquidity-settings-label"
+                            title="Maximum output movement allowed before the transaction reverts."
+                        >Max slippage:</span>
+                        <strong>${slippageDisplay}</strong>
+                        <span class="material-icons" aria-hidden="true">${this.removeLiquiditySettingsOpen ? 'expand_less' : 'expand_more'}</span>
+                    </button>
+                </div>
+                ${settingsPanel}
 
                 <div id="remove-liquidity-preview-panel">
                     ${this.renderRemoveLiquidityPreviewPanel()}
@@ -3401,60 +3454,67 @@ class StakingModalNew {
             isError ? 'zap-quote-error' : '',
             !hasPreview && !isLoading && !isError ? 'zap-quote-placeholder' : ''
         ].filter(Boolean).join(' ');
-        const slippageDisplay = `${(Number(this.removeLiquiditySlippageBps) / 100).toFixed(2)}%`;
-        const deadlineDisplay = `${Number(this.removeLiquidityDeadlineMinutes) || 20} min`;
-
         if (this.removeLiquidityZapOutEnabled) {
             const outputToken = this.removeLiquiditySelectedOutputToken;
             const outputSymbol = outputToken?.symbol || 'token';
             let summary = this.removeLiquidityAmount
                 ? `Checking Kyber zap-out to ${outputSymbol}...`
                 : `Enter an amount to preview ${outputSymbol} output.`;
-            let routerDisplay = pendingValue;
             let estimatedOutput = pendingValue;
-            let outputValue = pendingValue;
+            let minimumReceivedDisplay = pendingValue;
             let priceImpactDisplay = pendingValue;
 
             if (isLoading) {
                 summary = 'Loading Kyber zap-out route...';
             } else if (isError) {
                 summary = balanceError || this.removeLiquidityPreviewError || 'Unable to fetch a Kyber zap-out preview.';
-                routerDisplay = 'Unsupported';
             } else if (hasPreview) {
-                const routeData = this.getRemoveLiquidityRouteData();
                 const outputEntry = this.getRemoveLiquidityEstimatedOutputEntry(outputToken, pendingValue);
-                const outputUsdEntry = this.getRemoveLiquidityQuoteSummaryEntry([
-                    'zapDetails.finalAmountUsd',
-                    'amountOutUsd',
-                    'receivedUsd',
-                    'routeSummary.amountOutUsd'
-                ], pendingValue);
                 const priceImpactEntry = this.getRemoveLiquidityQuoteSummaryEntry([
                     'zapDetails.priceImpact',
                     'zapDetails.priceImpactPcm',
                     'priceImpact',
                     'priceImpactPcm'
                 ], pendingValue);
-                routerDisplay = this.formatAddress(this.getRemoveLiquidityRouterAddress(routeData) || '');
                 estimatedOutput = outputEntry.value === pendingValue
                     ? pendingValue
                     : this.formatZapDisplayAmount(outputEntry.value, outputToken?.decimals ?? 18, outputSymbol);
-                outputValue = outputUsdEntry.value === pendingValue ? pendingValue : this.formatUsdDisplay(outputUsdEntry.value);
+                minimumReceivedDisplay = outputEntry.value === pendingValue
+                    ? pendingValue
+                    : this.formatRemoveLiquidityMinOutputAmount(outputEntry.value, outputToken, pendingValue);
                 priceImpactDisplay = priceImpactEntry.value === pendingValue ? pendingValue : this.formatZapPercent(priceImpactEntry);
                 summary = `Kyber zap-out to ${outputSymbol}`;
             }
 
-            const rows = [
-                this.renderZapQuoteRow('Route', 'Kyber ZaaS'),
-                this.renderZapQuoteRow('Kyber Router', routerDisplay || pendingValue),
-                this.renderZapQuoteRow('LP amount', this.removeLiquidityAmount ? `${this.removeLiquidityAmount} LP` : pendingValue),
-                this.renderZapQuoteRow('Output token', outputSymbol),
-                this.renderZapQuoteRow(`Estimated ${outputSymbol}`, estimatedOutput),
-                this.renderZapQuoteRow('Estimated value', outputValue),
-                this.renderZapQuoteRow('Price impact', priceImpactDisplay),
-                this.renderZapQuoteRow('Slippage', slippageDisplay),
-                this.renderZapQuoteRow('Deadline', deadlineDisplay)
-            ];
+            const rows = [];
+            if (isError) {
+                rows.push(this.renderZapQuoteRow(
+                    'Route',
+                    'Unsupported',
+                    '',
+                    'Routing status for this LP position.'
+                ));
+            }
+            rows.push(
+                this.renderZapQuoteRow(
+                    `Estimated ${outputSymbol}`,
+                    estimatedOutput,
+                    '',
+                    'Expected output token amount from the latest Kyber route.'
+                ),
+                this.renderZapQuoteRow(
+                    'Minimum received',
+                    minimumReceivedDisplay,
+                    '',
+                    'Transaction reverts if the final output is below this value after max slippage.'
+                ),
+                this.renderZapQuoteRow(
+                    'Price impact',
+                    priceImpactDisplay,
+                    '',
+                    'Estimated effect of the route on execution price.'
+                )
+            );
 
             return `
                 <div class="${cardClass}">
@@ -3505,14 +3565,31 @@ class StakingModalNew {
             summary = `${preview.token0.symbol} + ${preview.token1.symbol} via ${dexDisplay}`;
         }
 
+        const estimatedPairDisplay = hasPreview
+            ? `${token0Display} + ${token1Display}`
+            : pendingValue;
+        const minimumPairDisplay = hasPreview
+            ? `${token0MinDisplay} + ${token1MinDisplay}`
+            : pendingValue;
         let rows = [
-            this.renderZapQuoteRow('DEX', dexDisplay),
-            this.renderZapQuoteRow(`Estimated ${this.removeLiquidityPreview?.token0?.symbol || 'token0'}`, token0Display),
-            this.renderZapQuoteRow(`Estimated ${this.removeLiquidityPreview?.token1?.symbol || 'token1'}`, token1Display),
-            this.renderZapQuoteRow(`Minimum ${this.removeLiquidityPreview?.token0?.symbol || 'token0'}`, token0MinDisplay),
-            this.renderZapQuoteRow(`Minimum ${this.removeLiquidityPreview?.token1?.symbol || 'token1'}`, token1MinDisplay),
-            this.renderZapQuoteRow('Slippage', slippageDisplay),
-            this.renderZapQuoteRow('Deadline', deadlineDisplay)
+            this.renderZapQuoteRow(
+                'You receive',
+                estimatedPairDisplay,
+                '',
+                'Estimated pair token amounts returned by burning the selected LP amount.'
+            ),
+            this.renderZapQuoteRow(
+                'Minimum received',
+                minimumPairDisplay,
+                '',
+                'Transaction reverts if either token output is below this value after max slippage.'
+            ),
+            this.renderZapQuoteRow(
+                'DEX',
+                dexDisplay,
+                '',
+                'Router/factory selected for this LP position.'
+            )
         ];
 
         return `
@@ -3733,10 +3810,11 @@ class StakingModalNew {
         `;
     }
 
-    renderZapQuoteRow(label, value, riskClass = '') {
+    renderZapQuoteRow(label, value, riskClass = '', title = '') {
+        const titleAttribute = title ? ` title="${this.escapeHtml(title)}"` : '';
         return `
                     <div class="zap-quote-row${riskClass ? ` ${riskClass}` : ''}">
-                        <dt>${this.escapeHtml(label)}</dt>
+                        <dt${titleAttribute}>${this.escapeHtml(label)}</dt>
                         <dd>${this.escapeHtml(value)}</dd>
                     </div>
         `;

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -198,7 +198,7 @@ window.CONFIG = {
         }
     },
 
-    // Explicit V2 DEX allowlist for unstake -> remove liquidity flows.
+    // Explicit V2 DEX allowlist for guided remove-liquidity flows.
     // Routers are intentionally configured here because they cannot be safely discovered from LP pairs.
     DEX_REMOVE_LIQUIDITY: {
         56: {

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -198,6 +198,26 @@ window.CONFIG = {
         }
     },
 
+    // Explicit V2 DEX allowlist for unstake -> remove liquidity flows.
+    // Routers are intentionally configured here because they cannot be safely discovered from LP pairs.
+    DEX_REMOVE_LIQUIDITY: {
+        56: {
+            wrappedNative: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
+            factories: {
+                '0x8909dc15e40173ff4699343b6eb8132c65e18ec6': {
+                    name: 'Uniswap V2',
+                    type: 'uniswapV2',
+                    router: '0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24'
+                },
+                '0xca143ce32fe78f1f7019d7d551a6402fc5350c73': {
+                    name: 'PancakeSwap V2',
+                    type: 'uniswapV2',
+                    router: '0x10ed43c718714eb63d5aa57b78b54704e256024e'
+                }
+            }
+        }
+    },
+
     // Platform Configuration
     PLATFORMS: {
         // Available platforms for dropdown (matches contract values)

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -203,6 +203,10 @@ window.CONFIG = {
     DEX_REMOVE_LIQUIDITY: {
         56: {
             wrappedNative: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
+            libToUsdtConversion: {
+                fromToken: '0x05A4cfAF5a8f939d61E4Ec6D6287c9a065d6574c',
+                toToken: '0x55d398326f99059fF775485246999027B3197955'
+            },
             factories: {
                 '0x8909dc15e40173ff4699343b6eb8132c65e18ec6': {
                     name: 'Uniswap V2',

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -203,10 +203,6 @@ window.CONFIG = {
     DEX_REMOVE_LIQUIDITY: {
         56: {
             wrappedNative: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
-            libToUsdtConversion: {
-                fromToken: '0x05A4cfAF5a8f939d61E4Ec6D6287c9a065d6574c',
-                toToken: '0x55d398326f99059fF775485246999027B3197955'
-            },
             factories: {
                 '0x8909dc15e40173ff4699343b6eb8132c65e18ec6': {
                     name: 'Uniswap V2',

--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -170,6 +170,7 @@ class MasterInitializer {
             'js/components/home-page.js',
             'js/services/kyber-zap-rate-limiter.js',
             'js/services/kyber-zap-service.js',
+            'js/services/v2-remove-liquidity-service.js',
             'js/components/staking-modal-new.js'
         ];
         console.log('Loading homepage UI components');

--- a/js/services/kyber-zap-service.js
+++ b/js/services/kyber-zap-service.js
@@ -83,8 +83,9 @@
             }
         }
 
-        getQuoteRequestKey({ networkKey, walletAddress, lpTokenAddress, tokenAddress, amountRaw, slippageBps }) {
+        getQuoteRequestKey({ networkKey, walletAddress, lpTokenAddress, tokenAddress, amountRaw, slippageBps, type = 'in' }) {
             return [
+                type,
                 networkKey || this.getCurrentNetworkKey(),
                 walletAddress || '',
                 String(lpTokenAddress || '').toLowerCase(),
@@ -306,6 +307,65 @@
             return payload;
         }
 
+        async fetchOutQuote({ networkConfig, lpTokenAddress, walletAddress, tokenOutAddress, liquidityRaw, slippageBps, platform }) {
+            const initialRateLimitWaitMs = this.getQuoteRateLimitWaitMs();
+            if (initialRateLimitWaitMs > 0) {
+                throw this.createRateLimitError(initialRateLimitWaitMs);
+            }
+
+            if (!networkConfig) {
+                throw new Error('Zap out is not available on this network.');
+            }
+
+            const baseUrl = this.getConfig()?.BASE_URL || 'https://zap-api.kyberswap.com';
+            const dexCandidates = await this.getDexCandidates({ networkConfig, poolAddress: lpTokenAddress, platform });
+            let payload = null;
+            let lastError = null;
+
+            for (const dexId of dexCandidates) {
+                const rateLimit = this.quoteRateLimiter.reserve();
+                if (!rateLimit.allowed) {
+                    throw this.createRateLimitError(rateLimit.waitMs);
+                }
+
+                const params = new URLSearchParams({
+                    dexFrom: dexId,
+                    'poolFrom.id': lpTokenAddress,
+                    'positionFrom.id': walletAddress,
+                    liquidityOut: liquidityRaw.toString(),
+                    tokenOut: tokenOutAddress,
+                    slippage: slippageBps.toString()
+                });
+
+                const url = `${baseUrl}/${networkConfig.CHAIN}/api/v1/out/route?${params.toString()}`;
+                const response = await this.fetchImpl(url, {
+                    headers: {
+                        accept: 'application/json',
+                        'x-client-id': this.getConfig()?.CLIENT_ID || 'liberdus-lp-staking'
+                    }
+                });
+                const candidatePayload = await response.json().catch(() => ({}));
+                const failed = !response.ok || (candidatePayload.code && candidatePayload.code !== 0 && candidatePayload.code !== 200);
+
+                if (!failed) {
+                    payload = candidatePayload;
+                    break;
+                }
+
+                lastError = new Error(candidatePayload.message || `Kyber zap-out quote failed with status ${response.status}`);
+                const canTryNextDex = /invalid pool|does not belong to given dex id/i.test(lastError.message);
+                if (!canTryNextDex) {
+                    break;
+                }
+            }
+
+            if (!payload) {
+                throw lastError || new Error('Unable to fetch a Kyber zap-out quote.');
+            }
+
+            return payload;
+        }
+
         async buildRoute({ networkConfig, route, sender, recipient = sender, deadline }) {
             if (!networkConfig) {
                 throw new Error('Zap is not available on this network.');
@@ -335,6 +395,40 @@
 
             if (!response.ok || (payload.code && payload.code !== 0 && payload.code !== 200)) {
                 throw new Error(payload.message || `Kyber build failed with status ${response.status}`);
+            }
+
+            return payload?.data || payload;
+        }
+
+        async buildOutRoute({ networkConfig, route, sender, recipient = sender, deadline }) {
+            if (!networkConfig) {
+                throw new Error('Zap out is not available on this network.');
+            }
+
+            if (!route) {
+                throw new Error('Kyber zap-out route is missing. Refresh the quote and try again.');
+            }
+
+            const baseUrl = this.getConfig()?.BASE_URL || 'https://zap-api.kyberswap.com';
+            const response = await this.fetchImpl(`${baseUrl}/${networkConfig.CHAIN}/api/v1/out/route/build`, {
+                method: 'POST',
+                headers: {
+                    accept: 'application/json',
+                    'content-type': 'application/json',
+                    'x-client-id': this.getConfig()?.CLIENT_ID || 'liberdus-lp-staking'
+                },
+                body: JSON.stringify({
+                    sender,
+                    recipient,
+                    route,
+                    deadline,
+                    source: this.getConfig()?.SOURCE || 'liberdus-lp-staking'
+                })
+            });
+            const payload = await response.json().catch(() => ({}));
+
+            if (!response.ok || (payload.code && payload.code !== 0 && payload.code !== 200)) {
+                throw new Error(payload.message || `Kyber zap-out build failed with status ${response.status}`);
             }
 
             return payload?.data || payload;

--- a/js/services/kyber-zap-service.js
+++ b/js/services/kyber-zap-service.js
@@ -83,9 +83,8 @@
             }
         }
 
-        getQuoteRequestKey({ networkKey, walletAddress, lpTokenAddress, tokenAddress, amountRaw, slippageBps, type = 'in' }) {
+        getQuoteRequestKey({ networkKey, walletAddress, lpTokenAddress, tokenAddress, amountRaw, slippageBps }) {
             return [
-                type,
                 networkKey || this.getCurrentNetworkKey(),
                 walletAddress || '',
                 String(lpTokenAddress || '').toLowerCase(),

--- a/js/services/v2-remove-liquidity-service.js
+++ b/js/services/v2-remove-liquidity-service.js
@@ -88,7 +88,9 @@
         getRouterAbi() {
             return [
                 'function factory() view returns (address)',
-                'function removeLiquidity(address tokenA,address tokenB,uint256 liquidity,uint256 amountAMin,uint256 amountBMin,address to,uint256 deadline) returns (uint256 amountA,uint256 amountB)'
+                'function removeLiquidity(address tokenA,address tokenB,uint256 liquidity,uint256 amountAMin,uint256 amountBMin,address to,uint256 deadline) returns (uint256 amountA,uint256 amountB)',
+                'function getAmountsOut(uint256 amountIn,address[] calldata path) view returns (uint256[] memory amounts)',
+                'function swapExactTokensForTokens(uint256 amountIn,uint256 amountOutMin,address[] calldata path,address to,uint256 deadline) returns (uint256[] memory amounts)'
             ];
         }
 
@@ -322,8 +324,7 @@
                 throw new Error('LP token, owner, spender, and provider are required for allowance checks.');
             }
 
-            const lpContract = this.createContract(lpTokenAddress, this.getErc20Abi(), provider);
-            return lpContract.allowance(owner, spender);
+            return this.getTokenAllowance({ tokenAddress: lpTokenAddress, owner, spender, provider });
         }
 
         async getBalance({ lpTokenAddress, owner, provider = this.getProvider() }) {
@@ -331,8 +332,25 @@
                 throw new Error('LP token, owner, and provider are required for balance checks.');
             }
 
-            const lpContract = this.createContract(lpTokenAddress, this.getErc20Abi(), provider);
-            return lpContract.balanceOf(owner);
+            return this.getTokenBalance({ tokenAddress: lpTokenAddress, owner, provider });
+        }
+
+        async getTokenAllowance({ tokenAddress, owner, spender, provider = this.getProvider() }) {
+            if (!tokenAddress || !owner || !spender || !provider) {
+                throw new Error('Token, owner, spender, and provider are required for allowance checks.');
+            }
+
+            const tokenContract = this.createContract(tokenAddress, this.getErc20Abi(), provider);
+            return tokenContract.allowance(owner, spender);
+        }
+
+        async getTokenBalance({ tokenAddress, owner, provider = this.getProvider() }) {
+            if (!tokenAddress || !owner || !provider) {
+                throw new Error('Token, owner, and provider are required for balance checks.');
+            }
+
+            const tokenContract = this.createContract(tokenAddress, this.getErc20Abi(), provider);
+            return tokenContract.balanceOf(owner);
         }
 
         async approveIfNeeded({ lpTokenAddress, spender, liquidityRaw, signer }) {
@@ -340,21 +358,51 @@
                 throw new Error('LP token, spender, liquidity amount, and signer are required for approval.');
             }
 
+            return this.approveTokenIfNeeded({
+                tokenAddress: lpTokenAddress,
+                spender,
+                amountRaw: liquidityRaw,
+                signer
+            });
+        }
+
+        async approveTokenIfNeeded({ tokenAddress, spender, amountRaw, signer }) {
+            if (!tokenAddress || !spender || !amountRaw || !signer) {
+                throw new Error('Token, spender, amount, and signer are required for approval.');
+            }
+
             const owner = await signer.getAddress();
-            const allowance = await this.getAllowance({
-                lpTokenAddress,
+            const allowance = await this.getTokenAllowance({
+                tokenAddress,
                 owner,
                 spender,
                 provider: signer.provider || this.getProvider()
             });
-            const liquidity = this.toBigNumber(liquidityRaw);
+            const amount = this.toBigNumber(amountRaw);
 
-            if (allowance.gte(liquidity)) {
+            if (allowance.gte(amount)) {
                 return null;
             }
 
-            const lpContract = this.createContract(lpTokenAddress, this.getErc20Abi(), signer);
-            return lpContract.approve(spender, liquidity);
+            const tokenContract = this.createContract(tokenAddress, this.getErc20Abi(), signer);
+            return tokenContract.approve(spender, amount);
+        }
+
+        async getSwapQuote({ routerAddress, amountIn, path, provider = this.getProvider() }) {
+            if (!routerAddress || !amountIn || !Array.isArray(path) || path.length < 2 || !provider) {
+                throw new Error('Router, amount, path, and provider are required for swap quotes.');
+            }
+
+            const routerContract = this.createContract(routerAddress, this.getRouterAbi(), provider);
+            const amounts = await routerContract.getAmountsOut(this.toBigNumber(amountIn), path);
+            const amountOut = amounts[amounts.length - 1];
+
+            return {
+                path,
+                amounts,
+                amountIn: this.toBigNumber(amountIn),
+                amountOut: this.toBigNumber(amountOut)
+            };
         }
 
         async removeLiquidity({ routerAddress, token0, token1, liquidityRaw, amount0Min, amount1Min, recipient, deadline, signer }) {
@@ -369,6 +417,21 @@
                 this.toBigNumber(liquidityRaw),
                 this.toBigNumber(amount0Min),
                 this.toBigNumber(amount1Min),
+                recipient,
+                deadline
+            );
+        }
+
+        async swapExactTokensForTokens({ routerAddress, amountIn, amountOutMin, path, recipient, deadline, signer }) {
+            if (!routerAddress || !amountIn || !amountOutMin || !Array.isArray(path) || path.length < 2 || !recipient || !deadline || !signer) {
+                throw new Error('Router, amounts, path, recipient, deadline, and signer are required for token swaps.');
+            }
+
+            const routerContract = this.createContract(routerAddress, this.getRouterAbi(), signer);
+            return routerContract.swapExactTokensForTokens(
+                this.toBigNumber(amountIn),
+                this.toBigNumber(amountOutMin),
+                path,
                 recipient,
                 deadline
             );

--- a/js/services/v2-remove-liquidity-service.js
+++ b/js/services/v2-remove-liquidity-service.js
@@ -58,6 +58,12 @@
             return typeof address === 'string' ? address.toLowerCase() : '';
         }
 
+        getPairMetaCacheKey(lpTokenAddress, chainId = this.getCurrentChainId()) {
+            const parsedChainId = typeof chainId === 'string' ? Number(chainId) : chainId;
+            const chainKey = Number.isFinite(parsedChainId) ? String(parsedChainId) : 'unknown';
+            return `${chainKey}:${this.normalizeAddress(lpTokenAddress)}`;
+        }
+
         toBigNumber(value) {
             const ethers = this.getEthers();
             return ethers.BigNumber?.from ? ethers.BigNumber.from(value) : BigInt(value);
@@ -108,12 +114,12 @@
             return new ethers.Contract(address, abi, runner);
         }
 
-        async readPairMeta(lpTokenAddress, provider = this.getProvider()) {
+        async readPairMeta(lpTokenAddress, provider = this.getProvider(), chainId = this.getCurrentChainId()) {
             if (!lpTokenAddress || !provider) {
                 throw new Error('LP token address and provider are required.');
             }
 
-            const cacheKey = this.normalizeAddress(lpTokenAddress);
+            const cacheKey = this.getPairMetaCacheKey(lpTokenAddress, chainId);
             if (this.pairMetaCache.has(cacheKey)) {
                 return this.pairMetaCache.get(cacheKey);
             }
@@ -170,7 +176,7 @@
                 };
             }
 
-            const pairMeta = await this.readPairMeta(lpTokenAddress, provider);
+            const pairMeta = await this.readPairMeta(lpTokenAddress, provider, resolvedChainId);
             const factoryKey = this.normalizeAddress(pairMeta.factoryAddress);
             const factoryConfig = chainConfig.factories?.[factoryKey] || null;
 

--- a/js/services/v2-remove-liquidity-service.js
+++ b/js/services/v2-remove-liquidity-service.js
@@ -1,0 +1,383 @@
+/**
+ * V2RemoveLiquidityService - Uniswap V2-compatible remove-liquidity helpers.
+ *
+ * The router allowlist is explicit by chain/factory because LP pairs do not expose
+ * a trusted router address.
+ */
+(function(global) {
+    'use strict';
+
+    if (global.V2RemoveLiquidityService) {
+        console.warn('V2RemoveLiquidityService already exists, skipping redeclaration');
+        return;
+    }
+
+    class V2RemoveLiquidityService {
+        constructor(options = {}) {
+            this.global = options.global || global;
+            this.pairMetaCache = new Map();
+            this.tokenMetaCache = new Map();
+        }
+
+        getConfig() {
+            return this.global.CONFIG?.DEX_REMOVE_LIQUIDITY || {};
+        }
+
+        getEthers() {
+            const ethers = this.global.ethers;
+            if (!ethers) {
+                throw new Error('Ethers.js is not available.');
+            }
+            return ethers;
+        }
+
+        getProvider(provider) {
+            return provider
+                || this.global.contractManager?.provider
+                || this.global.walletManager?.provider
+                || null;
+        }
+
+        getCurrentChainId() {
+            const chainId = this.global.networkSelector?.getCurrentChainId?.()
+                ?? this.global.contractManager?.getCurrentChainIdSafe?.()
+                ?? this.global.walletManager?.networkManager?.getCurrentChainId?.();
+            const parsed = typeof chainId === 'string' ? Number(chainId) : chainId;
+            return Number.isFinite(parsed) ? parsed : null;
+        }
+
+        getChainConfig(chainId = this.getCurrentChainId()) {
+            if (chainId === null || chainId === undefined) {
+                return null;
+            }
+
+            return this.getConfig()?.[String(chainId)] || this.getConfig()?.[Number(chainId)] || null;
+        }
+
+        normalizeAddress(address) {
+            return typeof address === 'string' ? address.toLowerCase() : '';
+        }
+
+        toBigNumber(value) {
+            const ethers = this.getEthers();
+            return ethers.BigNumber?.from ? ethers.BigNumber.from(value) : BigInt(value);
+        }
+
+        formatUnits(value, decimals = 18) {
+            const ethers = this.getEthers();
+            if (ethers.utils?.formatUnits) {
+                return ethers.utils.formatUnits(value, decimals);
+            }
+            if (ethers.formatUnits) {
+                return ethers.formatUnits(value, decimals);
+            }
+            return String(value);
+        }
+
+        getPairAbi() {
+            return [
+                'function factory() view returns (address)',
+                'function token0() view returns (address)',
+                'function token1() view returns (address)',
+                'function getReserves() view returns (uint112,uint112,uint32)',
+                'function totalSupply() view returns (uint256)',
+                'function decimals() view returns (uint8)'
+            ];
+        }
+
+        getRouterAbi() {
+            return [
+                'function factory() view returns (address)',
+                'function removeLiquidity(address tokenA,address tokenB,uint256 liquidity,uint256 amountAMin,uint256 amountBMin,address to,uint256 deadline) returns (uint256 amountA,uint256 amountB)'
+            ];
+        }
+
+        getErc20Abi() {
+            return [
+                'function allowance(address owner,address spender) view returns (uint256)',
+                'function approve(address spender,uint256 amount) returns (bool)',
+                'function balanceOf(address owner) view returns (uint256)',
+                'function decimals() view returns (uint8)',
+                'function symbol() view returns (string)',
+                'function name() view returns (string)'
+            ];
+        }
+
+        createContract(address, abi, runner) {
+            const ethers = this.getEthers();
+            return new ethers.Contract(address, abi, runner);
+        }
+
+        async readPairMeta(lpTokenAddress, provider = this.getProvider()) {
+            if (!lpTokenAddress || !provider) {
+                throw new Error('LP token address and provider are required.');
+            }
+
+            const cacheKey = this.normalizeAddress(lpTokenAddress);
+            if (this.pairMetaCache.has(cacheKey)) {
+                return this.pairMetaCache.get(cacheKey);
+            }
+
+            const pairContract = this.createContract(lpTokenAddress, this.getPairAbi(), provider);
+            const [factoryAddress, token0Address, token1Address, lpDecimals] = await Promise.all([
+                pairContract.factory(),
+                pairContract.token0(),
+                pairContract.token1(),
+                pairContract.decimals().catch(() => 18)
+            ]);
+
+            const pairMeta = {
+                lpTokenAddress,
+                factoryAddress,
+                token0Address,
+                token1Address,
+                lpDecimals: Number(lpDecimals) || 18
+            };
+
+            this.pairMetaCache.set(cacheKey, pairMeta);
+            return pairMeta;
+        }
+
+        async validateRouterFactory({ routerAddress, factoryAddress, provider = this.getProvider() }) {
+            if (!routerAddress || !factoryAddress || !provider) {
+                throw new Error('Router, factory, and provider are required for router validation.');
+            }
+
+            const routerContract = this.createContract(routerAddress, this.getRouterAbi(), provider);
+            const routerFactory = await routerContract.factory();
+            if (this.normalizeAddress(routerFactory) !== this.normalizeAddress(factoryAddress)) {
+                throw new Error('Configured remove-liquidity router does not match the LP factory.');
+            }
+
+            return true;
+        }
+
+        async getMatchedAdapter({ chainId = this.getCurrentChainId(), lpTokenAddress, provider = this.getProvider() }) {
+            const resolvedChainId = Number(chainId);
+            if (!Number.isFinite(resolvedChainId)) {
+                return {
+                    supported: false,
+                    reason: 'Unable to determine the selected chain.'
+                };
+            }
+
+            const chainConfig = this.getChainConfig(resolvedChainId);
+            if (!chainConfig) {
+                return {
+                    supported: false,
+                    chainId: resolvedChainId,
+                    reason: 'Remove liquidity is not configured for this network.'
+                };
+            }
+
+            const pairMeta = await this.readPairMeta(lpTokenAddress, provider);
+            const factoryKey = this.normalizeAddress(pairMeta.factoryAddress);
+            const factoryConfig = chainConfig.factories?.[factoryKey] || null;
+
+            if (!factoryConfig?.router) {
+                return {
+                    supported: false,
+                    chainId: resolvedChainId,
+                    factoryAddress: pairMeta.factoryAddress,
+                    reason: 'This LP factory is not supported for guided remove liquidity.'
+                };
+            }
+
+            await this.validateRouterFactory({
+                routerAddress: factoryConfig.router,
+                factoryAddress: pairMeta.factoryAddress,
+                provider
+            });
+
+            return {
+                supported: true,
+                chainId: resolvedChainId,
+                wrappedNative: chainConfig.wrappedNative,
+                factoryAddress: pairMeta.factoryAddress,
+                routerAddress: factoryConfig.router,
+                name: factoryConfig.name,
+                type: factoryConfig.type,
+                pairMeta
+            };
+        }
+
+        async getTokenMetadata(address, provider = this.getProvider()) {
+            const normalized = this.normalizeAddress(address);
+            if (this.tokenMetaCache.has(normalized)) {
+                return this.tokenMetaCache.get(normalized);
+            }
+
+            const tokenContract = this.createContract(address, this.getErc20Abi(), provider);
+            const [symbol, name, decimals] = await Promise.all([
+                tokenContract.symbol().catch(() => 'TOKEN'),
+                tokenContract.name().catch(() => 'Token'),
+                tokenContract.decimals().catch(() => 18)
+            ]);
+
+            const metadata = {
+                address,
+                symbol: typeof symbol === 'string' && symbol.trim() ? symbol.trim() : 'TOKEN',
+                name: typeof name === 'string' && name.trim() ? name.trim() : 'Token',
+                decimals: Number(decimals) || 18
+            };
+
+            this.tokenMetaCache.set(normalized, metadata);
+            return metadata;
+        }
+
+        calculateMinAmount(amount, slippageBps) {
+            const bps = Number(slippageBps);
+            if (!Number.isFinite(bps) || bps < 0 || bps > 10000) {
+                throw new Error('Slippage must be between 0 and 10000 bps.');
+            }
+
+            return amount.mul(10000 - Math.trunc(bps)).div(10000);
+        }
+
+        async getPreview({ chainId = this.getCurrentChainId(), lpTokenAddress, liquidityRaw, slippageBps = 50, provider = this.getProvider() }) {
+            if (!liquidityRaw) {
+                throw new Error('Liquidity amount is required.');
+            }
+
+            const adapter = await this.getMatchedAdapter({ chainId, lpTokenAddress, provider });
+            if (!adapter.supported) {
+                return adapter;
+            }
+
+            const pairContract = this.createContract(lpTokenAddress, this.getPairAbi(), provider);
+            const [reserves, totalSupplyRaw] = await Promise.all([
+                pairContract.getReserves(),
+                pairContract.totalSupply()
+            ]);
+
+            const reserve0 = this.toBigNumber(reserves[0]);
+            const reserve1 = this.toBigNumber(reserves[1]);
+            const totalSupply = this.toBigNumber(totalSupplyRaw);
+            const liquidity = this.toBigNumber(liquidityRaw);
+
+            if (totalSupply.isZero?.() || totalSupply.eq?.(0)) {
+                throw new Error('LP total supply is zero.');
+            }
+
+            const amount0 = liquidity.mul(reserve0).div(totalSupply);
+            const amount1 = liquidity.mul(reserve1).div(totalSupply);
+            const amount0Min = this.calculateMinAmount(amount0, slippageBps);
+            const amount1Min = this.calculateMinAmount(amount1, slippageBps);
+            const [token0Meta, token1Meta] = await Promise.all([
+                this.getTokenMetadata(adapter.pairMeta.token0Address, provider),
+                this.getTokenMetadata(adapter.pairMeta.token1Address, provider)
+            ]);
+
+            return {
+                supported: true,
+                adapter,
+                lpToken: {
+                    address: lpTokenAddress,
+                    decimals: adapter.pairMeta.lpDecimals,
+                    liquidity: {
+                        raw: liquidity.toString(),
+                        formatted: this.formatUnits(liquidity, adapter.pairMeta.lpDecimals)
+                    },
+                    totalSupply: {
+                        raw: totalSupply.toString(),
+                        formatted: this.formatUnits(totalSupply, adapter.pairMeta.lpDecimals)
+                    }
+                },
+                token0: {
+                    ...token0Meta,
+                    reserve: {
+                        raw: reserve0.toString(),
+                        formatted: this.formatUnits(reserve0, token0Meta.decimals)
+                    },
+                    amount: {
+                        raw: amount0.toString(),
+                        formatted: this.formatUnits(amount0, token0Meta.decimals)
+                    },
+                    minAmount: {
+                        raw: amount0Min.toString(),
+                        formatted: this.formatUnits(amount0Min, token0Meta.decimals)
+                    }
+                },
+                token1: {
+                    ...token1Meta,
+                    reserve: {
+                        raw: reserve1.toString(),
+                        formatted: this.formatUnits(reserve1, token1Meta.decimals)
+                    },
+                    amount: {
+                        raw: amount1.toString(),
+                        formatted: this.formatUnits(amount1, token1Meta.decimals)
+                    },
+                    minAmount: {
+                        raw: amount1Min.toString(),
+                        formatted: this.formatUnits(amount1Min, token1Meta.decimals)
+                    }
+                },
+                slippageBps: Number(slippageBps)
+            };
+        }
+
+        async getAllowance({ lpTokenAddress, owner, spender, provider = this.getProvider() }) {
+            if (!lpTokenAddress || !owner || !spender || !provider) {
+                throw new Error('LP token, owner, spender, and provider are required for allowance checks.');
+            }
+
+            const lpContract = this.createContract(lpTokenAddress, this.getErc20Abi(), provider);
+            return lpContract.allowance(owner, spender);
+        }
+
+        async getBalance({ lpTokenAddress, owner, provider = this.getProvider() }) {
+            if (!lpTokenAddress || !owner || !provider) {
+                throw new Error('LP token, owner, and provider are required for balance checks.');
+            }
+
+            const lpContract = this.createContract(lpTokenAddress, this.getErc20Abi(), provider);
+            return lpContract.balanceOf(owner);
+        }
+
+        async approveIfNeeded({ lpTokenAddress, spender, liquidityRaw, signer }) {
+            if (!lpTokenAddress || !spender || !liquidityRaw || !signer) {
+                throw new Error('LP token, spender, liquidity amount, and signer are required for approval.');
+            }
+
+            const owner = await signer.getAddress();
+            const allowance = await this.getAllowance({
+                lpTokenAddress,
+                owner,
+                spender,
+                provider: signer.provider || this.getProvider()
+            });
+            const liquidity = this.toBigNumber(liquidityRaw);
+
+            if (allowance.gte(liquidity)) {
+                return null;
+            }
+
+            const lpContract = this.createContract(lpTokenAddress, this.getErc20Abi(), signer);
+            return lpContract.approve(spender, liquidity);
+        }
+
+        async removeLiquidity({ routerAddress, token0, token1, liquidityRaw, amount0Min, amount1Min, recipient, deadline, signer }) {
+            if (!routerAddress || !token0 || !token1 || !liquidityRaw || !recipient || !deadline || !signer) {
+                throw new Error('Router, tokens, liquidity amount, recipient, deadline, and signer are required.');
+            }
+
+            const routerContract = this.createContract(routerAddress, this.getRouterAbi(), signer);
+            return routerContract.removeLiquidity(
+                token0,
+                token1,
+                this.toBigNumber(liquidityRaw),
+                this.toBigNumber(amount0Min),
+                this.toBigNumber(amount1Min),
+                recipient,
+                deadline
+            );
+        }
+    }
+
+    global.V2RemoveLiquidityService = V2RemoveLiquidityService;
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = { V2RemoveLiquidityService };
+    }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/services/v2-remove-liquidity-service.js
+++ b/js/services/v2-remove-liquidity-service.js
@@ -88,9 +88,7 @@
         getRouterAbi() {
             return [
                 'function factory() view returns (address)',
-                'function removeLiquidity(address tokenA,address tokenB,uint256 liquidity,uint256 amountAMin,uint256 amountBMin,address to,uint256 deadline) returns (uint256 amountA,uint256 amountB)',
-                'function getAmountsOut(uint256 amountIn,address[] calldata path) view returns (uint256[] memory amounts)',
-                'function swapExactTokensForTokens(uint256 amountIn,uint256 amountOutMin,address[] calldata path,address to,uint256 deadline) returns (uint256[] memory amounts)'
+                'function removeLiquidity(address tokenA,address tokenB,uint256 liquidity,uint256 amountAMin,uint256 amountBMin,address to,uint256 deadline) returns (uint256 amountA,uint256 amountB)'
             ];
         }
 
@@ -388,23 +386,6 @@
             return tokenContract.approve(spender, amount);
         }
 
-        async getSwapQuote({ routerAddress, amountIn, path, provider = this.getProvider() }) {
-            if (!routerAddress || !amountIn || !Array.isArray(path) || path.length < 2 || !provider) {
-                throw new Error('Router, amount, path, and provider are required for swap quotes.');
-            }
-
-            const routerContract = this.createContract(routerAddress, this.getRouterAbi(), provider);
-            const amounts = await routerContract.getAmountsOut(this.toBigNumber(amountIn), path);
-            const amountOut = amounts[amounts.length - 1];
-
-            return {
-                path,
-                amounts,
-                amountIn: this.toBigNumber(amountIn),
-                amountOut: this.toBigNumber(amountOut)
-            };
-        }
-
         async removeLiquidity({ routerAddress, token0, token1, liquidityRaw, amount0Min, amount1Min, recipient, deadline, signer }) {
             if (!routerAddress || !token0 || !token1 || !liquidityRaw || !recipient || !deadline || !signer) {
                 throw new Error('Router, tokens, liquidity amount, recipient, deadline, and signer are required.');
@@ -417,21 +398,6 @@
                 this.toBigNumber(liquidityRaw),
                 this.toBigNumber(amount0Min),
                 this.toBigNumber(amount1Min),
-                recipient,
-                deadline
-            );
-        }
-
-        async swapExactTokensForTokens({ routerAddress, amountIn, amountOutMin, path, recipient, deadline, signer }) {
-            if (!routerAddress || !amountIn || !amountOutMin || !Array.isArray(path) || path.length < 2 || !recipient || !deadline || !signer) {
-                throw new Error('Router, amounts, path, recipient, deadline, and signer are required for token swaps.');
-            }
-
-            const routerContract = this.createContract(routerAddress, this.getRouterAbi(), signer);
-            return routerContract.swapExactTokensForTokens(
-                this.toBigNumber(amountIn),
-                this.toBigNumber(amountOutMin),
-                path,
                 recipient,
                 deadline
             );

--- a/js/services/v2-remove-liquidity-service.js
+++ b/js/services/v2-remove-liquidity-service.js
@@ -64,6 +64,12 @@
             return `${chainKey}:${this.normalizeAddress(lpTokenAddress)}`;
         }
 
+        getTokenMetaCacheKey(address, chainId = this.getCurrentChainId()) {
+            const parsedChainId = typeof chainId === 'string' ? Number(chainId) : chainId;
+            const chainKey = Number.isFinite(parsedChainId) ? String(parsedChainId) : 'unknown';
+            return `${chainKey}:${this.normalizeAddress(address)}`;
+        }
+
         toBigNumber(value) {
             const ethers = this.getEthers();
             return ethers.BigNumber?.from ? ethers.BigNumber.from(value) : BigInt(value);
@@ -207,10 +213,10 @@
             };
         }
 
-        async getTokenMetadata(address, provider = this.getProvider()) {
-            const normalized = this.normalizeAddress(address);
-            if (this.tokenMetaCache.has(normalized)) {
-                return this.tokenMetaCache.get(normalized);
+        async getTokenMetadata(address, provider = this.getProvider(), chainId = this.getCurrentChainId()) {
+            const cacheKey = this.getTokenMetaCacheKey(address, chainId);
+            if (this.tokenMetaCache.has(cacheKey)) {
+                return this.tokenMetaCache.get(cacheKey);
             }
 
             const tokenContract = this.createContract(address, this.getErc20Abi(), provider);
@@ -227,7 +233,7 @@
                 decimals: Number(decimals) || 18
             };
 
-            this.tokenMetaCache.set(normalized, metadata);
+            this.tokenMetaCache.set(cacheKey, metadata);
             return metadata;
         }
 
@@ -270,8 +276,8 @@
             const amount0Min = this.calculateMinAmount(amount0, slippageBps);
             const amount1Min = this.calculateMinAmount(amount1, slippageBps);
             const [token0Meta, token1Meta] = await Promise.all([
-                this.getTokenMetadata(adapter.pairMeta.token0Address, provider),
-                this.getTokenMetadata(adapter.pairMeta.token1Address, provider)
+                this.getTokenMetadata(adapter.pairMeta.token0Address, provider, adapter.chainId),
+                this.getTokenMetadata(adapter.pairMeta.token1Address, provider, adapter.chainId)
             ]);
 
             return {

--- a/js/utils/version-check.js
+++ b/js/utils/version-check.js
@@ -175,6 +175,11 @@
             
             // JavaScript - Root
             `${basePath}js/master-initializer.js`,
+
+            // JavaScript - Services
+            `${basePath}js/services/kyber-zap-rate-limiter.js`,
+            `${basePath}js/services/kyber-zap-service.js`,
+            `${basePath}js/services/v2-remove-liquidity-service.js`,
             
             // JavaScript - Utils (only existing files)
             `${basePath}js/utils/admin-test.js`,
@@ -202,6 +207,7 @@
             `${basePath}css/base.css`,
             `${basePath}css/components.css`,
             `${basePath}css/network-indicator-selector.css`,
+            `${basePath}css/staking-modal.css`,
             `${basePath}css/theme-toggle.css`,
             `${basePath}css/wallet-popup.css`
         ];

--- a/tests/kyber-zap-service.test.js
+++ b/tests/kyber-zap-service.test.js
@@ -142,6 +142,99 @@ describe('KyberZapService', () => {
         );
     });
 
+    it('builds Kyber zap-out quote URLs with pool, position, liquidity, token out, and slippage', async () => {
+        const KyberZapService = await loadKyberZapService();
+        globalThis.fetch = vi.fn().mockResolvedValue(createJsonResponse({
+            payload: { data: { route: '0xout' } }
+        }));
+        const service = new KyberZapService();
+
+        const quote = await service.fetchOutQuote({
+            networkConfig: { CHAIN: 'bsc', DEX: 'DEX_UNISWAPV2' },
+            lpTokenAddress: '0xlp',
+            walletAddress: '0xwallet',
+            tokenOutAddress: '0xouttoken',
+            liquidityRaw: { toString: () => '500' },
+            slippageBps: 75,
+            platform: null
+        });
+
+        expect(quote.data.route).toBe('0xout');
+        expect(globalThis.fetch).toHaveBeenCalledWith(
+            'https://zap-api.kyberswap.com/bsc/api/v1/out/route?dexFrom=DEX_UNISWAPV2&poolFrom.id=0xlp&positionFrom.id=0xwallet&liquidityOut=500&tokenOut=0xouttoken&slippage=75',
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    accept: 'application/json',
+                    'x-client-id': 'liberdus-lp-staking'
+                })
+            })
+        );
+    });
+
+    it('tries fallback DEX candidates for Kyber zap-out quotes', async () => {
+        const KyberZapService = await loadKyberZapService();
+        globalThis.fetch = vi.fn()
+            .mockResolvedValueOnce(createJsonResponse({
+                ok: false,
+                status: 400,
+                payload: { message: 'Pool does not belong to given dex id' }
+            }))
+            .mockResolvedValueOnce(createJsonResponse({
+                payload: { data: { route: '0xout' } }
+            }));
+        const service = new KyberZapService();
+
+        const quote = await service.fetchOutQuote({
+            networkConfig: {
+                CHAIN: 'bsc',
+                DEX: 'DEX_UNISWAPV2',
+                DEX_CANDIDATES: ['DEX_PANCAKESWAPV2']
+            },
+            lpTokenAddress: '0xlp',
+            walletAddress: '0xwallet',
+            tokenOutAddress: '0xouttoken',
+            liquidityRaw: { toString: () => '500' },
+            slippageBps: 75,
+            platform: null
+        });
+
+        expect(quote.data.route).toBe('0xout');
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+        expect(globalThis.fetch.mock.calls[0][0]).toContain('dexFrom=DEX_UNISWAPV2');
+        expect(globalThis.fetch.mock.calls[1][0]).toContain('dexFrom=DEX_PANCAKESWAPV2');
+    });
+
+    it('builds Kyber zap-out routes through the out build endpoint', async () => {
+        const KyberZapService = await loadKyberZapService();
+        globalThis.fetch = vi.fn().mockResolvedValue(createJsonResponse({
+            payload: { data: { txData: '0xabcdef' } }
+        }));
+        const service = new KyberZapService();
+
+        const build = await service.buildOutRoute({
+            networkConfig: { CHAIN: 'bsc' },
+            route: '0xout',
+            sender: '0xsender',
+            recipient: '0xrecipient',
+            deadline: 1777306663
+        });
+
+        expect(build.txData).toBe('0xabcdef');
+        expect(globalThis.fetch).toHaveBeenCalledWith(
+            'https://zap-api.kyberswap.com/bsc/api/v1/out/route/build',
+            expect.objectContaining({
+                method: 'POST',
+                body: JSON.stringify({
+                    sender: '0xsender',
+                    recipient: '0xrecipient',
+                    route: '0xout',
+                    deadline: 1777306663,
+                    source: 'liberdus-lp-staking'
+                })
+            })
+        );
+    });
+
     it('fetches and caches GeckoTerminal token market metadata', async () => {
         const KyberZapService = await loadKyberZapService();
         globalThis.fetch = vi.fn().mockResolvedValue(createJsonResponse({

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1040,6 +1040,51 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).not.toContain('<dt>Minimum token0</dt>');
     });
 
+    it('derives checked remove-liquidity output amount from Kyber zap-out actions', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
+        const bnbToken = { address: 'native', symbol: 'BNB', name: 'BNB', decimals: 18 };
+        modal.removeLiquidityOutputTokens = [bnbToken];
+        modal.removeLiquidityOutputTokenAddress = 'native';
+        modal.removeLiquiditySelectedOutputToken = bnbToken;
+        modal.removeLiquidityPreview = {
+            supported: true,
+            zapOut: true,
+            outputToken: bnbToken,
+            data: {
+                route: '0xout-route',
+                routerAddress: '0x0e97C887b61cCd952a53578B04763E7134429e05',
+                zapDetails: {
+                    finalAmountUsd: '0.40',
+                    priceImpact: 1.26,
+                    actions: [
+                        {
+                            type: 'ACTION_TYPE_AGGREGATOR_SWAP',
+                            aggregatorSwap: {
+                                swaps: [
+                                    {
+                                        tokenOut: {
+                                            address: globalThis.CONFIG.KYBER_ZAP.NATIVE_TOKEN_ADDRESS,
+                                            amount: '1230000000000000',
+                                            amountUsd: '0.40'
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        };
+
+        const html = modal.renderRemoveLiquidityPreviewPanel();
+
+        expect(html).toContain('<dt>Estimated BNB</dt>');
+        expect(html).toContain('0.00123 BNB');
+        expect(html).toContain('<dt>Estimated value</dt>');
+        expect(html).toContain('$0.4');
+    });
+
     it('configured output token selection refreshes the zap-out quote', async () => {
         vi.useFakeTimers();
         const modal = await createLoadedModal();

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -964,7 +964,7 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('id="remove-liquidity-usd-estimate"');
         expect(html).toContain('id="remove-liquidity-checkbox"');
         expect(html).toContain('remove-liquidity-action-btn');
-        expect(html).toContain('Remove liquidity and return pair tokens');
+        expect(html).toContain('Show pair-token return preview and settings');
         expect(html).toContain('LIB + USDT via Uniswap V2');
         expect(html).toContain('<dt>Minimum token0</dt>');
         expect(html).toContain('99.5 LIB');
@@ -979,7 +979,7 @@ describe('StakingModalNew zap cleanup', () => {
         const html = modal.renderUnstakeTab();
 
         expect(html).not.toContain('id="remove-liquidity-checkbox"');
-        expect(html).not.toContain('Remove liquidity and return pair tokens');
+        expect(html).not.toContain('Show pair-token return preview and settings');
         expect(html).not.toContain('remove-liquidity-preview-panel');
     });
 
@@ -1028,6 +1028,63 @@ describe('StakingModalNew zap cleanup', () => {
 
         expect(removeButton.disabled).toBe(false);
         expect(removeButton.title).toBe('Remove LP liquidity');
+    });
+
+    it('enables the remove-liquidity action with a valid amount when details are closed', async () => {
+        const modal = await createLoadedModal();
+        modal.currentPair = { name: 'LIB/USDT', lpToken: '0xlp' };
+        modal.removeLiquidityAmount = '1';
+        modal.removeLiquidityEnabled = false;
+        modal.userBalanceRaw = { gte: vi.fn(() => true) };
+        const removeButton = createElement({ classes: ['btn', 'btn-primary', 'remove-liquidity-action-btn'] });
+        removeButton.disabled = true;
+        removeButton.title = 'Confirm the remove-liquidity details first';
+        removeButton.childNodes = [{ textContent: 'swap_horiz' }, { textContent: ' Remove LP Liquidity' }];
+        removeButton.querySelector = vi.fn(() => removeButton.childNodes[0]);
+        globalThis.document.querySelector = vi.fn(selector => (
+            selector.includes('safeModalExecuteRemoveLiquidity') ? removeButton : null
+        ));
+
+        modal.updateRemoveLiquidityButton();
+
+        expect(removeButton.disabled).toBe(false);
+        expect(removeButton.title).toBe('Remove LP liquidity');
+    });
+
+    it('fetches a remove-liquidity preview on execute when details are closed', async () => {
+        vi.useFakeTimers();
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        const readyPreview = modal.removeLiquidityPreview;
+        modal.removeLiquidityEnabled = false;
+        modal.removeLiquidityPreview = null;
+        modal.removeLiquidityPreviewStatus = 'idle';
+        modal.getRemoveLiquidityAmountRaw = vi.fn(() => createAmount(1));
+        modal.fetchRemoveLiquidityPreview = vi.fn(async () => {
+            modal.removeLiquidityPreview = readyPreview;
+            modal.removeLiquidityPreviewStatus = 'ready';
+        });
+        modal.executeRemoveLiquidityTransaction = vi.fn().mockResolvedValue({ success: true, hash: '0xremove' });
+        modal.loadUserBalances = vi.fn().mockResolvedValue(undefined);
+        modal.clearInputs = vi.fn();
+        modal.close = vi.fn();
+        globalThis.contractManager = {
+            isReady: vi.fn(() => true)
+        };
+        globalThis.notificationManager = {
+            info: vi.fn(),
+            success: vi.fn(),
+            error: vi.fn()
+        };
+        globalThis.homePage = { refreshData: vi.fn().mockResolvedValue(undefined) };
+
+        const executePromise = modal.executeRemoveLiquidity();
+        await vi.runAllTimersAsync();
+        await executePromise;
+
+        expect(modal.fetchRemoveLiquidityPreview).toHaveBeenCalledWith({ force: true, requireDetailsOpen: false });
+        expect(modal.executeRemoveLiquidityTransaction).toHaveBeenCalledWith('0xlp', expect.objectContaining({ value: 1 }));
+        expect(globalThis.notificationManager.error).not.toHaveBeenCalledWith('Confirm the remove-liquidity details before continuing.');
     });
 
     it('valid custom remove-liquidity slippage applies bps and refreshes the preview', async () => {

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1041,6 +1041,19 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).not.toContain('<dt>Kyber Router</dt>');
     });
 
+    it('renders remove-liquidity slider and preset state from the saved amount', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
+        modal.userBalance = '5';
+        modal.removeLiquidityAmount = '2.5';
+
+        const html = modal.renderRemoveLiquidityTab();
+
+        expect(html).toContain('id="remove-liquidity-slider"');
+        expect(html).toContain('value="50"');
+        expect(html).toContain('<button class="percentage-btn active" data-percentage="50">50%</button>');
+    });
+
     it('renders direct remove-liquidity preview and safeguards when conversion is unchecked', async () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal);

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1218,6 +1218,21 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('0.0025 DAI');
     });
 
+    it('flags high price impact and slippage in checked remove-liquidity zap-out previews', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
+        modal.removeLiquiditySlippageBps = 10000;
+        modal.removeLiquidityPreview.data.zapDetails.priceImpact = 15.42;
+
+        const html = modal.renderRemoveLiquidityPreviewPanel();
+
+        expect(html.match(/zap-quote-row zap-risk-high/g)).toHaveLength(2);
+        expect(html).toContain('15.42%');
+        expect(html).toContain('100.00%');
+        expect(html).toContain('High price impact. You may receive significantly less LP value than expected.');
+        expect(html).toContain('High slippage tolerance. This transaction may execute at a much worse rate.');
+    });
+
     it('renders every Kyber zap-out protocol fee token returned by the route', async () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal, { convert: true });

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1036,6 +1036,46 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).not.toContain('<dt>Minimum token0</dt>');
     });
 
+    it('renders direct remove-liquidity preview and safeguards when conversion is unchecked', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+
+        const html = modal.renderRemoveLiquidityTab();
+
+        expect(html).toContain('Convert to one preferred token');
+        expect(html).not.toContain('remove-liquidity-output-token-picker');
+        expect(html).not.toContain('<label class="form-label">Output Token</label>');
+        expect(html).toContain('LIB + USDT via Uniswap V2');
+        expect(html).toContain('<dt>DEX</dt>');
+        expect(html).toContain('<dt>Estimated LIB</dt>');
+        expect(html).toContain('100 LIB');
+        expect(html).toContain('<dt>Estimated USDT</dt>');
+        expect(html).toContain('50 USDT');
+        expect(html).toContain('<dt>Minimum LIB</dt>');
+        expect(html).toContain('99.5 LIB');
+        expect(html).toContain('<dt>Minimum USDT</dt>');
+        expect(html).toContain('49.75 USDT');
+        expect(html).toContain('<dt>Slippage</dt>');
+        expect(html).toContain('<dt>Deadline</dt>');
+        expect(html).not.toContain('<dt>Kyber Router</dt>');
+    });
+
+    it('shows a readable over-balance warning on unchecked remove liquidity', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.removeLiquidityAmount = '2';
+        modal.userBalance = '1.0';
+        modal.userBalanceRaw = { gte: vi.fn(() => false) };
+
+        const html = modal.renderRemoveLiquidityTab();
+
+        expect(html).toContain('id="remove-liquidity-balance-error"');
+        expect(html).toContain('Amount exceeds available LP balance (1.0 LP).');
+        expect(html).toContain('<dd>Unsupported</dd>');
+        expect(html).not.toContain('remove liquidity = 2000000000000000000');
+        expect(modal.canFetchRemoveLiquidityPreview()).toBe(false);
+    });
+
     it('derives checked remove-liquidity output amount from Kyber zap-out actions', async () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
@@ -1230,18 +1270,18 @@ describe('StakingModalNew zap cleanup', () => {
         expect(removeButton.title).toBe('Remove LP liquidity');
     });
 
-    it('enables the remove-liquidity action with a valid amount when details are closed', async () => {
+    it('keeps the direct remove-liquidity action disabled until a preview loads', async () => {
         const modal = await createLoadedModal();
         modal.currentPair = { name: 'LIB/USDT', lpToken: '0xlp' };
         modal.removeLiquidityAmount = '1';
         modal.removeLiquidityZapOutEnabled = false;
         modal.userBalanceRaw = { gte: vi.fn(() => true) };
-        const removeButton = registerRemoveLiquidityButton('Confirm the remove-liquidity details first');
+        const removeButton = registerRemoveLiquidityButton();
 
         modal.updateRemoveLiquidityButton();
 
-        expect(removeButton.disabled).toBe(false);
-        expect(removeButton.title).toBe('Remove LP liquidity');
+        expect(removeButton.disabled).toBe(true);
+        expect(removeButton.title).toBe('Wait for a supported remove-liquidity preview.');
     });
 
     it('fetches a remove-liquidity preview on execute when details are closed', async () => {
@@ -1510,7 +1550,7 @@ describe('StakingModalNew zap cleanup', () => {
         expect(modal.removeLiquiditySelectedOutputToken).toEqual(expect.objectContaining({ address: USDT_TOKEN_ADDRESS }));
     });
 
-    it('shows a readable zap-out error when Kyber reports zero position liquidity', async () => {
+    it('shows a readable zap-out error when Kyber reports insufficient position liquidity', async () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal);
         modal.removeLiquidityZapOutEnabled = true;
@@ -1526,8 +1566,8 @@ describe('StakingModalNew zap cleanup', () => {
 
         await modal.fetchRemoveLiquidityPreview({ force: true });
 
-        expect(modal.removeLiquidityPreviewError).toBe('Refresh your balance or try a smaller amount.');
-        expect(modal.renderRemoveLiquidityPreviewPanel()).toContain('Refresh your balance or try a smaller amount.');
+        expect(modal.removeLiquidityPreviewError).toBe('Amount exceeds your available LP balance.');
+        expect(modal.renderRemoveLiquidityPreviewPanel()).toContain('Amount exceeds your available LP balance.');
         expect(modal.renderRemoveLiquidityPreviewPanel()).not.toContain('1000000000000000000');
     });
 

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1455,6 +1455,18 @@ describe('StakingModalNew zap cleanup', () => {
         expect(modal.fetchRemoveLiquidityPreview).toHaveBeenCalledTimes(1);
     });
 
+    it('keeps the configured remove-liquidity deadline when the input is cleared', async () => {
+        const modal = await createLoadedModal();
+        modal.removeLiquidityDeadlineMinutes = 45;
+        modal.updateRemoveLiquidityPreviewPanel = vi.fn();
+
+        const sanitizedValue = modal.setRemoveLiquidityDeadlineInput('');
+
+        expect(sanitizedValue).toBe('');
+        expect(modal.removeLiquidityDeadlineMinutes).toBe(20);
+        expect(modal.updateRemoveLiquidityPreviewPanel).toHaveBeenCalledTimes(1);
+    });
+
     it('keeps executeUnstake focused on unstaking only', async () => {
         vi.useFakeTimers();
         const modal = await createLoadedModal();

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -105,10 +105,6 @@ async function loadStakingModalClass() {
     globalThis.CONFIG.DEX_REMOVE_LIQUIDITY = {
         56: {
             wrappedNative: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
-            libToUsdtConversion: {
-                fromToken: LIB_TOKEN_ADDRESS,
-                toToken: USDT_TOKEN_ADDRESS
-            },
             factories: {
                 '0x8909dc15e40173ff4699343b6eb8132c65e18ec6': {
                     name: 'Uniswap V2',

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1069,7 +1069,6 @@ describe('StakingModalNew zap cleanup', () => {
         const html = modal.renderRemoveLiquidityTab();
 
         expect(html).toContain('aria-expanded="true"');
-        expect(html).toContain('0.05%');
         expect(html).toContain('0.1%');
         expect(html).toContain('0.5%');
         expect(html).toContain('1.0%');
@@ -1180,6 +1179,56 @@ describe('StakingModalNew zap cleanup', () => {
 
         expect(html).toContain('Kyber Zap Fee');
         expect(html).toContain('0.0025 DAI');
+    });
+
+    it('renders every Kyber zap-out protocol fee token returned by the route', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
+        const wbnbToken = {
+            address: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
+            symbol: 'WBNB',
+            name: 'Wrapped BNB',
+            decimals: 18
+        };
+        modal.removeLiquidityOutputTokens = [
+            { address: USDT_TOKEN_ADDRESS, symbol: 'USDT', name: 'Tether USD', decimals: 18 },
+            { address: LIB_TOKEN_ADDRESS, symbol: 'LIB', name: 'Liberdus', decimals: 18 },
+            wbnbToken
+        ];
+        modal.removeLiquidityOutputTokenAddress = wbnbToken.address;
+        modal.removeLiquiditySelectedOutputToken = wbnbToken;
+        modal.removeLiquidityPreview = {
+            supported: true,
+            zapOut: true,
+            outputToken: wbnbToken,
+            data: {
+                route: '0xout-route',
+                routerAddress: '0x0e97C887b61cCd952a53578B04763E7134429e05',
+                zapDetails: {
+                    finalAmount: '294841419648257',
+                    actions: [{
+                        type: 'ACTION_TYPE_PROTOCOL_FEE',
+                        protocolFee: {
+                            tokens: [
+                                {
+                                    address: USDT_TOKEN_ADDRESS,
+                                    amount: '248488902181974'
+                                },
+                                {
+                                    address: LIB_TOKEN_ADDRESS,
+                                    amount: '25305065600541886'
+                                }
+                            ]
+                        }
+                    }]
+                }
+            }
+        };
+
+        const html = modal.renderRemoveLiquidityPreviewPanel();
+
+        expect(html).toContain('Kyber Zap Fee');
+        expect(html).toContain('0.000248 USDT + 0.025305 LIB');
     });
 
     it('does not render Kyber Zap Fee for unchecked remove liquidity', async () => {

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1181,9 +1181,11 @@ describe('StakingModalNew zap cleanup', () => {
 
         expect(fetchOutQuote).not.toHaveBeenCalled();
         expect(html).toContain('Amount exceeds available LP balance (1.0 LP).');
+        expect(html).toContain('zap-quote-card remove-liquidity-preview-card zap-quote-error');
         expect(html).toContain('Kyber cannot quote more LP than your available balance.');
         expect(html).toContain('Kyber quote');
         expect(html).toContain('Unavailable above LP balance');
+        expect(html).not.toContain('zap-quote-placeholder');
         expect(html).not.toContain('Route</dt>');
         expect(html).not.toContain('Unsupported</dd>');
     });

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1530,12 +1530,8 @@ describe('StakingModalNew zap cleanup', () => {
 
         await modal.fetchRemoveLiquidityPreview({ force: true });
 
-        expect(modal.removeLiquidityPreviewError).toBe(
-            'Kyber could not find removable liquidity for this wallet and LP position. Refresh your balance or try a smaller amount.'
-        );
-        expect(modal.renderRemoveLiquidityPreviewPanel()).toContain(
-            'Kyber could not find removable liquidity for this wallet and LP position. Refresh your balance or try a smaller amount.'
-        );
+        expect(modal.removeLiquidityPreviewError).toBe('Refresh your balance or try a smaller amount.');
+        expect(modal.renderRemoveLiquidityPreviewPanel()).toContain('Refresh your balance or try a smaller amount.');
         expect(modal.renderRemoveLiquidityPreviewPanel()).not.toContain('1000000000000000000');
     });
 

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1022,7 +1022,7 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('id="remove-liquidity-usd-estimate"');
         expect(html).toContain('id="remove-liquidity-checkbox"');
         expect(html).toContain('remove-liquidity-action-btn');
-        expect(html).toContain('Zap out to one token with Kyber');
+        expect(html).toContain('Convert to one preferred token');
         expect(html).toContain('<label class="form-label">Output Token</label>');
         expect(html).toContain('remove-liquidity-output-token-picker');
         expect(html).toContain('remove-liquidity-output-token-option');
@@ -1157,7 +1157,7 @@ describe('StakingModalNew zap cleanup', () => {
         const html = modal.renderUnstakeTab();
 
         expect(html).not.toContain('id="remove-liquidity-checkbox"');
-        expect(html).not.toContain('Zap out to one token with Kyber');
+        expect(html).not.toContain('Convert to one preferred token');
         expect(html).not.toContain('remove-liquidity-preview-panel');
     });
 

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1514,6 +1514,31 @@ describe('StakingModalNew zap cleanup', () => {
         expect(modal.removeLiquiditySelectedOutputToken).toEqual(expect.objectContaining({ address: USDT_TOKEN_ADDRESS }));
     });
 
+    it('shows a readable zap-out error when Kyber reports zero position liquidity', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.removeLiquidityZapOutEnabled = true;
+        modal.removeLiquidityPreview = null;
+        modal.removeLiquidityPreviewStatus = 'idle';
+        modal.removeLiquidityAmount = '1';
+        modal.userBalanceRaw = { gte: vi.fn(() => true) };
+        globalThis.walletManager = { address: '0xwallet', provider: {} };
+        globalThis.contractManager = { provider: {} };
+        modal.getKyberZapService().fetchOutQuote = vi.fn().mockRejectedValue(
+            new Error('remove liquidity = 1000000000000000000 > position liquidity = 0')
+        );
+
+        await modal.fetchRemoveLiquidityPreview({ force: true });
+
+        expect(modal.removeLiquidityPreviewError).toBe(
+            'Kyber could not find removable liquidity for this wallet and LP position. Refresh your balance or try a smaller amount.'
+        );
+        expect(modal.renderRemoveLiquidityPreviewPanel()).toContain(
+            'Kyber could not find removable liquidity for this wallet and LP position. Refresh your balance or try a smaller amount.'
+        );
+        expect(modal.renderRemoveLiquidityPreviewPanel()).not.toContain('1000000000000000000');
+    });
+
     it('build failures show errors and leave checked zap-out inputs intact', async () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal, { convert: true });

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1150,6 +1150,19 @@ describe('StakingModalNew zap cleanup', () => {
         expect(customButton.classList.contains('active')).toBe(true);
     });
 
+    it('keeps invalid remove-liquidity custom slippage as a field error only', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.removeLiquiditySettingsOpen = true;
+
+        modal.setRemoveLiquidityCustomSlippageInput('101');
+        const html = modal.renderRemoveLiquidityTab();
+
+        expect(modal.removeLiquidityCustomSlippageError).toBe('Enter a custom slippage between 0.01% and 100%.');
+        expect(modal.removeLiquidityPreviewError).toBe('');
+        expect(html.match(/Enter a custom slippage between 0\.01% and 100%\./g)).toHaveLength(1);
+    });
+
     it('shows a readable over-balance warning on unchecked remove liquidity', async () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal);

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -123,6 +123,8 @@ async function loadStakingModalClass() {
             from: vi.fn(value => ({ value, toString: () => String(value) }))
         },
         utils: {
+            isAddress: vi.fn(value => /^0x[a-fA-F0-9]{40}$/.test(String(value))),
+            getAddress: vi.fn(value => String(value)),
             parseUnits: vi.fn(value => ({
                 value,
                 gte: other => Number(value) >= Number(other?.value ?? other),
@@ -231,7 +233,13 @@ function arrangeReadyZapQuote(modal, data = { route: '0xroute' }) {
 function arrangeReadyRemoveLiquidityPreview(modal, { convert = false } = {}) {
     modal.currentPair = { name: 'LIB/USDT', lpToken: '0xlp', address: '0xlp' };
     modal.removeLiquidityAmount = '1';
-    modal.convertLibToUsdtEnabled = convert;
+    modal.removeLiquidityZapOutEnabled = convert;
+    modal.removeLiquidityOutputTokens = [
+        { address: LIB_TOKEN_ADDRESS, symbol: 'LIB', name: 'Liberdus', decimals: 18 },
+        { address: USDT_TOKEN_ADDRESS, symbol: 'USDT', name: 'Tether USD', decimals: 18 }
+    ];
+    modal.removeLiquidityOutputTokenAddress = USDT_TOKEN_ADDRESS;
+    modal.removeLiquiditySelectedOutputToken = modal.removeLiquidityOutputTokens[1];
     modal.removeLiquidityPreviewStatus = 'ready';
     modal.removeLiquidityPreview = {
         supported: true,
@@ -257,16 +265,21 @@ function arrangeReadyRemoveLiquidityPreview(modal, { convert = false } = {}) {
     };
 
     if (convert) {
-        modal.removeLiquidityPreview.conversion = {
+        modal.removeLiquidityPreview = {
             supported: true,
-            fromToken: modal.removeLiquidityPreview.token0,
-            toToken: modal.removeLiquidityPreview.token1,
-            path: [LIB_TOKEN_ADDRESS, USDT_TOKEN_ADDRESS],
-            amountIn: { raw: '100000000000000000000', formatted: '100' },
-            amountOut: { raw: '90000000000000000000', formatted: '90' },
-            minAmountOut: { raw: '89550000000000000000', formatted: '89.55' },
-            finalAmount: { raw: '140000000000000000000', formatted: '140' },
-            finalMinAmount: { raw: '139300000000000000000', formatted: '139.3' }
+            zapOut: true,
+            outputToken: modal.removeLiquiditySelectedOutputToken,
+            liquidityRaw: '1',
+            slippageBps: 50,
+            data: {
+                route: '0xout-route',
+                routerAddress: '0x0e97C887b61cCd952a53578B04763E7134429e05',
+                zapDetails: {
+                    finalAmount: '140000000000000000000',
+                    finalAmountUsd: '140',
+                    priceImpact: 1
+                }
+            }
         };
     }
 }
@@ -335,6 +348,7 @@ describe('StakingModalNew zap cleanup', () => {
         delete globalThis.safeModalFetchZapQuote;
         delete globalThis.safeModalExecuteZap;
         delete globalThis.safeModalAddZapCustomToken;
+        delete globalThis.safeModalAddRemoveLiquidityCustomOutputToken;
         delete globalThis.safeModalFetchRemoveLiquidityPreview;
     });
 
@@ -1008,51 +1022,86 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('id="remove-liquidity-usd-estimate"');
         expect(html).toContain('id="remove-liquidity-checkbox"');
         expect(html).toContain('remove-liquidity-action-btn');
-        expect(html).toContain('Convert returned LIB to USDT after removing LP');
-        expect(html).toContain('LIB converts to USDT after LP removal');
-        expect(html).toContain('<dt>LP removal output</dt>');
-        expect(html).toContain('100 LIB + 50 USDT');
-        expect(html).toContain('<dt>LIB to convert</dt>');
-        expect(html).toContain('<dt>Estimated USDT from conversion</dt>');
-        expect(html).toContain('90 USDT');
-        expect(html).toContain('<dt>Estimated total USDT</dt>');
+        expect(html).toContain('Zap out to one token with Kyber');
+        expect(html).toContain('<label class="form-label">Output Token</label>');
+        expect(html).toContain('remove-liquidity-output-token-picker');
+        expect(html).toContain('remove-liquidity-output-token-option');
+        expect(html).toContain('Custom token');
+        expect(html).toContain('Kyber zap-out to USDT');
+        expect(html).toContain('<dt>Route</dt>');
+        expect(html).toContain('<dt>Kyber Router</dt>');
+        expect(html).toContain('<dt>LP amount</dt>');
+        expect(html).toContain('<dt>Output token</dt>');
+        expect(html).toContain('<dt>Estimated USDT</dt>');
         expect(html).toContain('140 USDT');
-        expect(html).toContain('<dt>Minimum total USDT</dt>');
-        expect(html).toContain('139.3 USDT');
+        expect(html).toContain('<dt>Estimated value</dt>');
+        expect(html).toContain('$140');
         expect(html).not.toContain('<dt>Estimated token0</dt>');
         expect(html).not.toContain('<dt>Minimum token0</dt>');
     });
 
-    it('matches remove-liquidity conversion tokens by configured address', async () => {
+    it('configured output token selection refreshes the zap-out quote', async () => {
+        vi.useFakeTimers();
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal);
+        modal.removeLiquidityZapOutEnabled = true;
+        modal.removeLiquidityPreview = null;
+        modal.removeLiquidityPreviewStatus = 'idle';
+        modal.userBalanceRaw = { gte: vi.fn(() => true) };
+        globalThis.walletManager = { address: '0xwallet', provider: {} };
+        globalThis.contractManager = { provider: {} };
+        const fetchOutQuote = vi.fn().mockResolvedValue({
+            data: {
+                route: '0xroute',
+                routerAddress: '0x0e97C887b61cCd952a53578B04763E7134429e05'
+            }
+        });
+        modal.getKyberZapService().fetchOutQuote = fetchOutQuote;
 
-        const conversion = modal.getRemoveLiquidityConversionTokens(modal.removeLiquidityPreview);
+        modal.setRemoveLiquidityOutputToken(LIB_TOKEN_ADDRESS);
+        await vi.runAllTimersAsync();
 
-        expect(conversion).toEqual(expect.objectContaining({
-            fromToken: expect.objectContaining({ address: LIB_TOKEN_ADDRESS }),
-            toToken: expect.objectContaining({ address: USDT_TOKEN_ADDRESS }),
-            path: [LIB_TOKEN_ADDRESS, USDT_TOKEN_ADDRESS]
+        expect(modal.removeLiquiditySelectedOutputToken).toEqual(expect.objectContaining({ address: LIB_TOKEN_ADDRESS }));
+        expect(fetchOutQuote).toHaveBeenCalledWith(expect.objectContaining({
+            lpTokenAddress: '0xlp',
+            walletAddress: '0xwallet',
+            tokenOutAddress: LIB_TOKEN_ADDRESS,
+            liquidityRaw: expect.objectContaining({ value: '1' }),
+            slippageBps: 50
         }));
     });
 
-    it('rejects spoofed LIB and USDT symbols for remove-liquidity conversion', async () => {
+    it('custom output token can be added and used for zap-out quote', async () => {
+        vi.useFakeTimers();
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal);
-        modal.removeLiquidityPreview.token0 = {
-            ...modal.removeLiquidityPreview.token0,
+        modal.removeLiquidityZapOutEnabled = true;
+        modal.removeLiquidityPreview = null;
+        modal.removeLiquidityCustomOutputTokenAddress = '0x1111111111111111111111111111111111111111';
+        modal.userBalanceRaw = { gte: vi.fn(() => true) };
+        modal.getTokenMetadata = vi.fn().mockResolvedValue({ symbol: 'ABC', name: 'ABC Token', decimals: 18 });
+        modal.loadRemoveLiquidityCustomOutputTokenIcon = vi.fn().mockResolvedValue(false);
+        globalThis.walletManager = { address: '0xwallet', provider: {} };
+        globalThis.contractManager = { provider: {} };
+        const fetchOutQuote = vi.fn().mockResolvedValue({
+            data: {
+                route: '0xroute',
+                routerAddress: '0x0e97C887b61cCd952a53578B04763E7134429e05'
+            }
+        });
+        modal.getKyberZapService().fetchOutQuote = fetchOutQuote;
+
+        await modal.addRemoveLiquidityCustomOutputToken();
+        await vi.runAllTimersAsync();
+
+        expect(modal.removeLiquiditySelectedOutputToken).toEqual(expect.objectContaining({
             address: '0x1111111111111111111111111111111111111111',
-            symbol: 'LIB'
-        };
-        modal.removeLiquidityPreview.token1 = {
-            ...modal.removeLiquidityPreview.token1,
-            address: '0x2222222222222222222222222222222222222222',
-            symbol: 'USDT'
-        };
-
-        const conversion = modal.getRemoveLiquidityConversionTokens(modal.removeLiquidityPreview);
-
-        expect(conversion).toBeNull();
+            symbol: 'ABC',
+            custom: true
+        }));
+        expect(fetchOutQuote).toHaveBeenCalledWith(expect.objectContaining({
+            tokenOutAddress: '0x1111111111111111111111111111111111111111'
+        }));
     });
 
     it('keeps guided remove-liquidity controls out of the Unstake tab', async () => {
@@ -1063,26 +1112,21 @@ describe('StakingModalNew zap cleanup', () => {
         const html = modal.renderUnstakeTab();
 
         expect(html).not.toContain('id="remove-liquidity-checkbox"');
-        expect(html).not.toContain('Convert returned LIB to USDT after removing LP');
+        expect(html).not.toContain('Zap out to one token with Kyber');
         expect(html).not.toContain('remove-liquidity-preview-panel');
     });
 
-    it('shows a blocking unsupported message for unknown remove-liquidity factories', async () => {
+    it('shows a blocking zap-out quote error when Kyber cannot route the checked flow', async () => {
         const modal = await createLoadedModal();
-        modal.currentPair = { name: 'LIB/USDT', lpToken: '0xlp' };
-        modal.removeLiquidityAmount = '1';
-        modal.convertLibToUsdtEnabled = true;
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
         modal.removeLiquidityPreviewStatus = 'error';
-        modal.removeLiquidityPreviewError = 'This LP factory is not supported for guided remove liquidity.';
-        modal.removeLiquidityPreview = {
-            supported: false,
-            factoryAddress: '0x9999999999999999999999999999999999999999'
-        };
+        modal.removeLiquidityPreviewError = 'Kyber could not build a zap-out route for this LP.';
+        modal.removeLiquidityPreview = null;
 
         const html = modal.renderRemoveLiquidityTab();
 
-        expect(html).toContain('This LP factory is not supported for guided remove liquidity.');
-        expect(html).toContain('Unsupported factory 0x9999...9999');
+        expect(html).toContain('Kyber could not build a zap-out route for this LP.');
+        expect(html).toContain('<dd>Unsupported</dd>');
     });
 
     it('enables the remove-liquidity action after a supported preview loads', async () => {
@@ -1108,7 +1152,7 @@ describe('StakingModalNew zap cleanup', () => {
         const modal = await createLoadedModal();
         modal.currentPair = { name: 'LIB/USDT', lpToken: '0xlp' };
         modal.removeLiquidityAmount = '1';
-        modal.convertLibToUsdtEnabled = false;
+        modal.removeLiquidityZapOutEnabled = false;
         modal.userBalanceRaw = { gte: vi.fn(() => true) };
         const removeButton = registerRemoveLiquidityButton('Confirm the remove-liquidity details first');
 
@@ -1123,7 +1167,7 @@ describe('StakingModalNew zap cleanup', () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal);
         const readyPreview = modal.removeLiquidityPreview;
-        modal.convertLibToUsdtEnabled = false;
+        modal.removeLiquidityZapOutEnabled = false;
         modal.removeLiquidityPreview = null;
         modal.removeLiquidityPreviewStatus = 'idle';
         modal.getRemoveLiquidityAmountRaw = vi.fn(() => createAmount(1));
@@ -1237,117 +1281,85 @@ describe('StakingModalNew zap cleanup', () => {
         expect(globalThis.notificationManager.success).toHaveBeenCalledWith('Liquidity removed successfully!');
     });
 
-    it('converts returned LIB to USDT when selected', async () => {
+    it('checked execute builds Kyber out route, approves LP to Kyber, and sends one zapOutLP transaction', async () => {
+        vi.useFakeTimers();
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
         const liquidityRaw = createAmount(5);
-        const service = {
-            validateRouterFactory: vi.fn().mockResolvedValue(true),
-            getBalance: vi.fn().mockResolvedValue(createAmount(10)),
-            getAllowance: vi.fn().mockResolvedValue(createAmount(10)),
-            getTokenBalance: vi.fn()
-                .mockResolvedValueOnce(createAmount(2))
-                .mockResolvedValueOnce(createAmount(102)),
-            getTokenAllowance: vi.fn().mockResolvedValue(createAmount(0)),
-            approveTokenIfNeeded: vi.fn().mockResolvedValue({ hash: '0xapprove-lib' }),
-            getSwapQuote: vi.fn().mockResolvedValue({
-                amountIn: createAmount(100),
-                amountOut: createAmount(90),
-                path: [LIB_TOKEN_ADDRESS, USDT_TOKEN_ADDRESS]
-            }),
-            calculateMinAmount: vi.fn().mockReturnValue(createAmount(89)),
-            approveIfNeeded: vi.fn(),
-            removeLiquidity: vi.fn().mockResolvedValue({ hash: '0xremove' }),
-            swapExactTokensForTokens: vi.fn().mockResolvedValue({ hash: '0xswap' })
-        };
-        modal.removeLiquidityService = service;
-        globalThis.contractManager = {
-            provider: {},
-            ensureSigner: vi.fn().mockResolvedValue(undefined),
-            signer: {
-                provider: {},
-                getAddress: vi.fn().mockResolvedValue('0xuser')
-            },
-            executeTransactionOnce: vi.fn(async (operation) => {
-                const tx = await operation();
-                return { success: true, hash: tx.hash };
-            })
-        };
-        globalThis.walletManager = { provider: {} };
-        globalThis.notificationManager = {
-            info: vi.fn(),
-            success: vi.fn(),
-            error: vi.fn()
-        };
-
-        await modal.executeRemoveLiquidityTransaction('0xlp', liquidityRaw);
-
-        expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenNthCalledWith(1, expect.any(Function), 'removeLiquidity');
-        expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenNthCalledWith(2, expect.any(Function), 'approveRemoveLiquidityConversion');
-        expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenNthCalledWith(3, expect.any(Function), 'convertRemoveLiquidityToken');
-        expect(service.approveTokenIfNeeded).toHaveBeenCalledWith(expect.objectContaining({
-            tokenAddress: LIB_TOKEN_ADDRESS,
-            spender: '0xrouter',
-            amountRaw: expect.objectContaining({ value: 100 })
-        }));
-        expect(service.swapExactTokensForTokens).toHaveBeenCalledWith(expect.objectContaining({
-            routerAddress: '0xrouter',
-            amountIn: expect.objectContaining({ value: 100 }),
-            amountOutMin: expect.objectContaining({ value: 89 }),
-            path: [LIB_TOKEN_ADDRESS, USDT_TOKEN_ADDRESS],
-            recipient: '0xuser'
-        }));
-    });
-
-    it('marks post-remove balance read failures as partial success', async () => {
-        const modal = await createLoadedModal();
-        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
-        const liquidityRaw = createAmount(5);
-        const service = {
-            validateRouterFactory: vi.fn().mockResolvedValue(true),
-            getBalance: vi.fn().mockResolvedValue(createAmount(10)),
-            getAllowance: vi.fn().mockResolvedValue(createAmount(10)),
-            getTokenBalance: vi.fn()
-                .mockResolvedValueOnce(createAmount(2))
-                .mockRejectedValueOnce(new Error('Balance read failed')),
-            approveIfNeeded: vi.fn(),
-            removeLiquidity: vi.fn().mockResolvedValue({ hash: '0xremove' })
-        };
-        modal.removeLiquidityService = service;
-        globalThis.contractManager = {
-            provider: {},
-            ensureSigner: vi.fn().mockResolvedValue(undefined),
-            signer: {
-                provider: {},
-                getAddress: vi.fn().mockResolvedValue('0xuser')
-            },
-            executeTransactionOnce: vi.fn(async (operation) => {
-                const tx = await operation();
-                return { success: true, hash: tx.hash };
-            })
-        };
-        globalThis.walletManager = { provider: {} };
-        globalThis.notificationManager = {
-            info: vi.fn(),
-            success: vi.fn(),
-            error: vi.fn()
-        };
-
-        await expect(modal.executeRemoveLiquidityTransaction('0xlp', liquidityRaw))
-            .rejects.toMatchObject({
-                message: 'Balance read failed',
-                removeLiquidityCompleted: true
-            });
-    });
-
-    it('shows partial-success copy when conversion fails after liquidity was removed', async () => {
-        const modal = await createLoadedModal();
-        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
-        const failure = new Error('Swap reverted');
-        failure.removeLiquidityCompleted = true;
-        modal.getRemoveLiquidityAmountRaw = vi.fn(() => createAmount(1));
-        modal.executeRemoveLiquidityTransaction = vi.fn().mockRejectedValue(failure);
+        modal.getRemoveLiquidityAmountRaw = vi.fn(() => liquidityRaw);
         modal.loadUserBalances = vi.fn().mockResolvedValue(undefined);
+        modal.clearInputs = vi.fn();
+        modal.close = vi.fn();
+        const routerAddress = '0x0e97C887b61cCd952a53578B04763E7134429e05';
+        const buildOutRoute = vi.fn().mockResolvedValue({ txData: '0xzapdata', to: routerAddress, value: '0' });
+        const validateRouterAddress = vi.fn();
+        modal.getKyberZapService().buildOutRoute = buildOutRoute;
+        modal.getKyberZapService().validateRouterAddress = validateRouterAddress;
+        const approve = vi.fn().mockResolvedValue({ hash: '0xapprove-lp' });
+        const allowance = vi.fn().mockResolvedValue(createAmount(0));
+        const sendTransaction = vi.fn().mockResolvedValue({ hash: '0xzap' });
+        globalThis.contractManager = {
+            isReady: vi.fn(() => true),
+            provider: {},
+            ensureSigner: vi.fn().mockResolvedValue(undefined),
+            signer: {
+                provider: {},
+                getAddress: vi.fn().mockResolvedValue('0xwallet'),
+                sendTransaction
+            },
+            executeTransactionOnce: vi.fn(async (operation) => {
+                const tx = await operation();
+                return { success: true, hash: tx.hash };
+            })
+        };
+        globalThis.ethers.Contract = vi.fn(function(address, abi, runner) {
+            return (
+            runner === globalThis.contractManager.signer
+                ? { approve }
+                : { allowance }
+            );
+        });
+        globalThis.walletManager = { address: '0xwallet', provider: {} };
+        globalThis.notificationManager = {
+            info: vi.fn(),
+            success: vi.fn(),
+            error: vi.fn()
+        };
+        globalThis.homePage = { refreshData: vi.fn().mockResolvedValue(undefined) };
+
+        const executePromise = modal.executeRemoveLiquidity();
+        await vi.runAllTimersAsync();
+        await executePromise;
+
+        expect(buildOutRoute).toHaveBeenCalledWith(expect.objectContaining({
+            route: '0xout-route',
+            sender: '0xwallet',
+            recipient: '0xwallet'
+        }));
+        expect(validateRouterAddress).toHaveBeenCalledWith(routerAddress, expect.any(Object));
+        expect(allowance).toHaveBeenCalledWith('0xwallet', routerAddress);
+        expect(approve).toHaveBeenCalledWith(routerAddress, liquidityRaw);
+        expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenNthCalledWith(1, expect.any(Function), 'approveRemoveLiquidityZapOut');
+        expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenNthCalledWith(2, expect.any(Function), 'zapOutLP');
+        expect(sendTransaction).toHaveBeenCalledWith(expect.objectContaining({
+            to: routerAddress,
+            data: '0xzapdata'
+        }));
+        expect(globalThis.notificationManager.success).toHaveBeenCalledWith('LP tokens zapped out successfully!');
+    });
+
+    it('unchecked execute still calls direct removeLiquidity and skips Kyber zap-out endpoints', async () => {
+        vi.useFakeTimers();
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.getRemoveLiquidityAmountRaw = vi.fn(() => createAmount(1));
+        modal.executeRemoveLiquidityTransaction = vi.fn().mockResolvedValue({ success: true, hash: '0xremove' });
+        modal.executeRemoveLiquidityZapOutTransaction = vi.fn();
+        modal.getKyberZapService().fetchOutQuote = vi.fn();
+        modal.getKyberZapService().buildOutRoute = vi.fn();
+        modal.loadUserBalances = vi.fn().mockResolvedValue(undefined);
+        modal.clearInputs = vi.fn();
+        modal.close = vi.fn();
         globalThis.contractManager = {
             isReady: vi.fn(() => true)
         };
@@ -1356,14 +1368,97 @@ describe('StakingModalNew zap cleanup', () => {
             success: vi.fn(),
             error: vi.fn()
         };
+        globalThis.homePage = { refreshData: vi.fn().mockResolvedValue(undefined) };
+
+        const executePromise = modal.executeRemoveLiquidity();
+        await vi.runAllTimersAsync();
+        await executePromise;
+
+        expect(modal.executeRemoveLiquidityTransaction).toHaveBeenCalledWith('0xlp', expect.objectContaining({ value: 1 }));
+        expect(modal.executeRemoveLiquidityZapOutTransaction).not.toHaveBeenCalled();
+        expect(modal.getKyberZapService().fetchOutQuote).not.toHaveBeenCalled();
+        expect(modal.getKyberZapService().buildOutRoute).not.toHaveBeenCalled();
+    });
+
+    it('router mismatch blocks checked zap-out before LP approval or transaction send', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
+        modal.getKyberZapService().buildOutRoute = vi.fn().mockResolvedValue({
+            txData: '0xzapdata',
+            to: '0x1111111111111111111111111111111111111111'
+        });
+        const sendTransaction = vi.fn();
+        globalThis.ethers.Contract = vi.fn();
+        globalThis.contractManager = {
+            provider: {},
+            ensureSigner: vi.fn().mockResolvedValue(undefined),
+            signer: {
+                getAddress: vi.fn().mockResolvedValue('0xwallet'),
+                sendTransaction
+            },
+            executeTransactionOnce: vi.fn()
+        };
+        globalThis.walletManager = { address: '0xwallet', provider: {} };
+
+        await expect(modal.executeRemoveLiquidityZapOutTransaction('0xlp', createAmount(5)))
+            .rejects.toThrow('Kyber returned an unexpected zap router');
+
+        expect(globalThis.ethers.Contract).not.toHaveBeenCalled();
+        expect(globalThis.contractManager.executeTransactionOnce).not.toHaveBeenCalled();
+        expect(sendTransaction).not.toHaveBeenCalled();
+    });
+
+    it('quote failures show errors and leave remove-liquidity inputs intact', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.removeLiquidityZapOutEnabled = true;
+        modal.removeLiquidityPreview = null;
+        modal.removeLiquidityPreviewStatus = 'idle';
+        modal.removeLiquidityAmount = '2';
+        modal.userBalanceRaw = { gte: vi.fn(() => true) };
+        globalThis.walletManager = { address: '0xwallet', provider: {} };
+        globalThis.contractManager = { provider: {} };
+        modal.getKyberZapService().fetchOutQuote = vi.fn().mockRejectedValue(new Error('Kyber quote failed'));
+
+        await modal.fetchRemoveLiquidityPreview({ force: true });
+
+        expect(modal.removeLiquidityPreviewStatus).toBe('error');
+        expect(modal.removeLiquidityPreviewError).toBe('Kyber quote failed');
+        expect(modal.removeLiquidityAmount).toBe('2');
+        expect(modal.removeLiquiditySelectedOutputToken).toEqual(expect.objectContaining({ address: USDT_TOKEN_ADDRESS }));
+    });
+
+    it('build failures show errors and leave checked zap-out inputs intact', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
+        modal.getRemoveLiquidityAmountRaw = vi.fn(() => createAmount(1));
+        modal.loadUserBalances = vi.fn().mockResolvedValue(undefined);
+        modal.clearInputs = vi.fn();
+        modal.close = vi.fn();
+        modal.getKyberZapService().buildOutRoute = vi.fn().mockRejectedValue(new Error('Kyber build failed'));
+        globalThis.contractManager = {
+            isReady: vi.fn(() => true),
+            provider: {},
+            ensureSigner: vi.fn().mockResolvedValue(undefined),
+            signer: {
+                getAddress: vi.fn().mockResolvedValue('0xwallet'),
+                sendTransaction: vi.fn()
+            }
+        };
+        globalThis.walletManager = { address: '0xwallet', provider: {} };
+        globalThis.notificationManager = {
+            info: vi.fn(),
+            success: vi.fn(),
+            error: vi.fn()
+        };
 
         await modal.executeRemoveLiquidity();
 
-        expect(globalThis.notificationManager.error).toHaveBeenCalledWith(
-            expect.stringContaining('Liquidity was removed, but LIB conversion failed. Your returned tokens remain in your wallet.'),
-            { title: 'Conversion failed' }
-        );
-        expect(globalThis.notificationManager.error.mock.calls[0][0]).toContain('Details: Swap reverted');
+        expect(globalThis.notificationManager.error).toHaveBeenCalledWith('Kyber build failed', { title: undefined });
+        expect(modal.removeLiquidityAmount).toBe('1');
+        expect(modal.removeLiquiditySelectedOutputToken).toEqual(expect.objectContaining({ address: USDT_TOKEN_ADDRESS }));
+        expect(modal.clearInputs).not.toHaveBeenCalled();
+        expect(modal.close).not.toHaveBeenCalled();
     });
 
     it('approves the router when needed before removing liquidity', async () => {

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -215,10 +215,10 @@ function arrangeReadyZapQuote(modal, data = { route: '0xroute' }) {
     modal.zapQuote = { data };
 }
 
-function arrangeReadyRemoveLiquidityPreview(modal) {
+function arrangeReadyRemoveLiquidityPreview(modal, { convert = false } = {}) {
     modal.currentPair = { name: 'LIB/USDT', lpToken: '0xlp', address: '0xlp' };
     modal.removeLiquidityAmount = '1';
-    modal.removeLiquidityEnabled = true;
+    modal.convertLibToUsdtEnabled = convert;
     modal.removeLiquidityPreviewStatus = 'ready';
     modal.removeLiquidityPreview = {
         supported: true,
@@ -242,6 +242,20 @@ function arrangeReadyRemoveLiquidityPreview(modal) {
             minAmount: { raw: '49750000000000000000', formatted: '49.75' }
         }
     };
+
+    if (convert) {
+        modal.removeLiquidityPreview.conversion = {
+            supported: true,
+            fromToken: modal.removeLiquidityPreview.token0,
+            toToken: modal.removeLiquidityPreview.token1,
+            path: ['0xlib', '0xusdt'],
+            amountIn: { raw: '100000000000000000000', formatted: '100' },
+            amountOut: { raw: '90000000000000000000', formatted: '90' },
+            minAmountOut: { raw: '89550000000000000000', formatted: '89.55' },
+            finalAmount: { raw: '140000000000000000000', formatted: '140' },
+            finalMinAmount: { raw: '139300000000000000000', formatted: '139.3' }
+        };
+    }
 }
 
 function registerRemoveLiquidityButton(title = 'Wait for a supported remove-liquidity preview.') {
@@ -262,7 +276,10 @@ function createAmount(value) {
     return {
         value,
         lt: other => Number(value) < Number(other?.value ?? other),
+        lte: other => Number(value) <= Number(other?.value ?? other),
         gte: other => Number(value) >= Number(other?.value ?? other),
+        add: other => createAmount(Number(value) + Number(other?.value ?? other)),
+        sub: other => createAmount(Number(value) - Number(other?.value ?? other)),
         toString: () => String(value)
     };
 }
@@ -967,7 +984,7 @@ describe('StakingModalNew zap cleanup', () => {
 
     it('renders guided remove-liquidity controls and preview on the Remove LP tab', async () => {
         const modal = await createLoadedModal();
-        arrangeReadyRemoveLiquidityPreview(modal);
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
         modal.userBalance = '10';
         modal.currentPair = { ...modal.currentPair, tvlUsd: 1000, tvl: 100 };
 
@@ -978,8 +995,11 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('id="remove-liquidity-usd-estimate"');
         expect(html).toContain('id="remove-liquidity-checkbox"');
         expect(html).toContain('remove-liquidity-action-btn');
-        expect(html).toContain('Show pair-token return preview and settings');
+        expect(html).toContain('Convert returned LIB to USDT after removing LP');
         expect(html).toContain('LIB + USDT via Uniswap V2');
+        expect(html).toContain('LIB to USDT');
+        expect(html).toContain('140 USDT');
+        expect(html).toContain('139.3 USDT');
         expect(html).toContain('<dt>Minimum token0</dt>');
         expect(html).toContain('99.5 LIB');
         expect(html).toContain('49.75 USDT');
@@ -993,7 +1013,7 @@ describe('StakingModalNew zap cleanup', () => {
         const html = modal.renderUnstakeTab();
 
         expect(html).not.toContain('id="remove-liquidity-checkbox"');
-        expect(html).not.toContain('Show pair-token return preview and settings');
+        expect(html).not.toContain('Convert returned LIB to USDT after removing LP');
         expect(html).not.toContain('remove-liquidity-preview-panel');
     });
 
@@ -1001,7 +1021,7 @@ describe('StakingModalNew zap cleanup', () => {
         const modal = await createLoadedModal();
         modal.currentPair = { name: 'LIB/USDT', lpToken: '0xlp' };
         modal.removeLiquidityAmount = '1';
-        modal.removeLiquidityEnabled = true;
+        modal.convertLibToUsdtEnabled = true;
         modal.removeLiquidityPreviewStatus = 'error';
         modal.removeLiquidityPreviewError = 'This LP factory is not supported for guided remove liquidity.';
         modal.removeLiquidityPreview = {
@@ -1038,7 +1058,7 @@ describe('StakingModalNew zap cleanup', () => {
         const modal = await createLoadedModal();
         modal.currentPair = { name: 'LIB/USDT', lpToken: '0xlp' };
         modal.removeLiquidityAmount = '1';
-        modal.removeLiquidityEnabled = false;
+        modal.convertLibToUsdtEnabled = false;
         modal.userBalanceRaw = { gte: vi.fn(() => true) };
         const removeButton = registerRemoveLiquidityButton('Confirm the remove-liquidity details first');
 
@@ -1053,7 +1073,7 @@ describe('StakingModalNew zap cleanup', () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal);
         const readyPreview = modal.removeLiquidityPreview;
-        modal.removeLiquidityEnabled = false;
+        modal.convertLibToUsdtEnabled = false;
         modal.removeLiquidityPreview = null;
         modal.removeLiquidityPreviewStatus = 'idle';
         modal.getRemoveLiquidityAmountRaw = vi.fn(() => createAmount(1));
@@ -1087,7 +1107,7 @@ describe('StakingModalNew zap cleanup', () => {
     it('valid custom remove-liquidity slippage applies bps and refreshes the preview', async () => {
         vi.useFakeTimers();
         const modal = await createLoadedModal();
-        arrangeReadyRemoveLiquidityPreview(modal);
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
         modal.fetchRemoveLiquidityPreview = vi.fn();
 
         const sanitizedValue = modal.setRemoveLiquidityCustomSlippageInput('2.345');
@@ -1165,6 +1185,68 @@ describe('StakingModalNew zap cleanup', () => {
         expect(modal.clearInputs).toHaveBeenCalled();
         expect(modal.close).toHaveBeenCalled();
         expect(globalThis.notificationManager.success).toHaveBeenCalledWith('Liquidity removed successfully!');
+    });
+
+    it('converts returned LIB to USDT when selected', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
+        const liquidityRaw = createAmount(5);
+        const service = {
+            validateRouterFactory: vi.fn().mockResolvedValue(true),
+            getBalance: vi.fn().mockResolvedValue(createAmount(10)),
+            getAllowance: vi.fn().mockResolvedValue(createAmount(10)),
+            getTokenBalance: vi.fn()
+                .mockResolvedValueOnce(createAmount(2))
+                .mockResolvedValueOnce(createAmount(102)),
+            getTokenAllowance: vi.fn().mockResolvedValue(createAmount(0)),
+            approveTokenIfNeeded: vi.fn().mockResolvedValue({ hash: '0xapprove-lib' }),
+            getSwapQuote: vi.fn().mockResolvedValue({
+                amountIn: createAmount(100),
+                amountOut: createAmount(90),
+                path: ['0xlib', '0xusdt']
+            }),
+            calculateMinAmount: vi.fn().mockReturnValue(createAmount(89)),
+            approveIfNeeded: vi.fn(),
+            removeLiquidity: vi.fn().mockResolvedValue({ hash: '0xremove' }),
+            swapExactTokensForTokens: vi.fn().mockResolvedValue({ hash: '0xswap' })
+        };
+        modal.removeLiquidityService = service;
+        globalThis.contractManager = {
+            provider: {},
+            ensureSigner: vi.fn().mockResolvedValue(undefined),
+            signer: {
+                provider: {},
+                getAddress: vi.fn().mockResolvedValue('0xuser')
+            },
+            executeTransactionOnce: vi.fn(async (operation) => {
+                const tx = await operation();
+                return { success: true, hash: tx.hash };
+            })
+        };
+        globalThis.walletManager = { provider: {} };
+        globalThis.notificationManager = {
+            info: vi.fn(),
+            success: vi.fn(),
+            error: vi.fn()
+        };
+
+        await modal.executeRemoveLiquidityTransaction('0xlp', liquidityRaw);
+
+        expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenNthCalledWith(1, expect.any(Function), 'removeLiquidity');
+        expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenNthCalledWith(2, expect.any(Function), 'approveRemoveLiquidityConversion');
+        expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenNthCalledWith(3, expect.any(Function), 'convertRemoveLiquidityToken');
+        expect(service.approveTokenIfNeeded).toHaveBeenCalledWith(expect.objectContaining({
+            tokenAddress: '0xlib',
+            spender: '0xrouter',
+            amountRaw: expect.objectContaining({ value: 100 })
+        }));
+        expect(service.swapExactTokensForTokens).toHaveBeenCalledWith(expect.objectContaining({
+            routerAddress: '0xrouter',
+            amountIn: expect.objectContaining({ value: 100 }),
+            amountOutMin: expect.objectContaining({ value: 89 }),
+            path: ['0xlib', '0xusdt'],
+            recipient: '0xuser'
+        }));
     });
 
     it('approves the router when needed before removing liquidity', async () => {

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1069,7 +1069,7 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('100 LIB + 50 USDT');
         expect(html).toContain('Minimum received');
         expect(html).toContain('99.5 LIB + 49.75 USDT');
-        expect(html).toContain('DEX');
+        expect(html).not.toContain('<dt>DEX</dt>');
         expect(html).not.toContain('id="remove-liquidity-deadline-input"');
         expect(html).not.toContain('<dt>Kyber Router</dt>');
     });
@@ -1105,7 +1105,7 @@ describe('StakingModalNew zap cleanup', () => {
 
         expect(html).toContain('id="remove-liquidity-balance-error"');
         expect(html).toContain('Amount exceeds available LP balance (1.0 LP).');
-        expect(html).toContain('<dd>Unsupported</dd>');
+        expect(html).not.toContain('aria-label="DEX:');
         expect(html).not.toContain('remove liquidity = 2000000000000000000');
         expect(modal.canFetchRemoveLiquidityPreview()).toBe(false);
     });

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1076,6 +1076,10 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('Custom');
         expect(html).toContain('id="remove-liquidity-deadline-input"');
         expect(html).toContain('Transaction time limit');
+        expect(html).toContain('data-tooltip="Maximum output movement allowed before the transaction reverts."');
+        expect(html).toContain('data-tooltip="Latest time this transaction can execute before it reverts."');
+        expect(html).toContain('aria-label="Max Slippage: Maximum output movement allowed before the transaction reverts."');
+        expect(html).not.toContain('class="remove-liquidity-settings-label"\n                            title=');
     });
 
     it('shows a readable over-balance warning on unchecked remove liquidity', async () => {

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1723,4 +1723,50 @@ describe('StakingModalNew zap cleanup', () => {
             recipient: '0xuser'
         }));
     });
+
+    it('continues removing liquidity when approval becomes sufficient before approval transaction', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        const liquidityRaw = createAmount(5);
+        const service = {
+            validateRouterFactory: vi.fn().mockResolvedValue(true),
+            getBalance: vi.fn().mockResolvedValue(createAmount(10)),
+            getAllowance: vi.fn().mockResolvedValue(createAmount(1)),
+            approveIfNeeded: vi.fn().mockResolvedValue(null),
+            removeLiquidity: vi.fn().mockResolvedValue({ hash: '0xremove' })
+        };
+        modal.removeLiquidityService = service;
+        globalThis.contractManager = {
+            provider: {},
+            ensureSigner: vi.fn().mockResolvedValue(undefined),
+            signer: {
+                provider: {},
+                getAddress: vi.fn().mockResolvedValue('0xuser')
+            },
+            executeTransactionOnce: vi.fn(async (operation) => {
+                const tx = await operation();
+                return { success: true, hash: tx.hash };
+            })
+        };
+        globalThis.walletManager = { provider: {} };
+        globalThis.notificationManager = {
+            info: vi.fn(),
+            success: vi.fn(),
+            error: vi.fn()
+        };
+
+        await modal.executeRemoveLiquidityTransaction('0xlp', liquidityRaw);
+
+        expect(service.approveIfNeeded).toHaveBeenCalledWith(expect.objectContaining({
+            lpTokenAddress: '0xlp',
+            spender: '0xrouter',
+            liquidityRaw
+        }));
+        expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenCalledTimes(1);
+        expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenCalledWith(expect.any(Function), 'removeLiquidity');
+        expect(service.removeLiquidity).toHaveBeenCalledWith(expect.objectContaining({
+            routerAddress: '0xrouter',
+            recipient: '0xuser'
+        }));
+    });
 });

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -669,12 +669,28 @@ describe('StakingModalNew zap cleanup', () => {
         expect(sanitizedValue).toBe('0');
         expect(modal.zapSlippageBps).toBe(50);
         expect(modal.zapQuote).toBeNull();
-        expect(modal.zapQuoteStatus).toBe('error');
-        expect(modal.zapQuoteError).toContain('Enter a custom slippage');
+        expect(modal.zapQuoteStatus).toBe('idle');
+        expect(modal.zapQuoteError).toBe('');
         expect(modal.canFetchZapQuote()).toBe(false);
         expect(customButton).not.toContain('active');
         expect(html).toContain('aria-invalid="true"');
         expect(html).toContain('zap-custom-slippage-error');
+        expect(html.match(/Enter a custom slippage between 0\.01% and 100%\./g)).toHaveLength(1);
+    });
+
+    it('does not carry the Create LP custom slippage error into Remove LP', async () => {
+        const StakingModalNew = await loadStakingModalClass();
+        const modal = new StakingModalNew();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        const tabContent = document.registerElement(createElement({ id: 'tab-content' }));
+
+        modal.setZapCustomSlippageInput('101');
+        modal.currentTab = 'remove-liquidity';
+        modal.renderTabContent();
+
+        expect(modal.zapCustomSlippageError).toBe('Enter a custom slippage between 0.01% and 100%.');
+        expect(tabContent.innerHTML).not.toContain('zap-custom-slippage-error');
+        expect(tabContent.innerHTML).not.toContain('id="zap-custom-slippage-error"');
     });
 
     it('clearInputs resets invalid custom zap slippage state', async () => {

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1075,6 +1075,20 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).not.toContain('<dt>Kyber Router</dt>');
     });
 
+    it('flags high slippage in unchecked remove-liquidity previews', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.removeLiquiditySlippageBps = 10000;
+
+        const html = modal.renderRemoveLiquidityPreviewPanel();
+
+        expect(html).toContain('zap-quote-row zap-risk-high');
+        expect(html).toContain('Slippage');
+        expect(html).toContain('100.00%');
+        expect(html).toContain('High slippage tolerance. This transaction may execute at a much worse rate.');
+        expect(html).not.toContain('Price impact');
+    });
+
     it('opens remove-liquidity slippage and deadline controls from the compact dropdown', async () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal);

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -244,6 +244,20 @@ function arrangeReadyRemoveLiquidityPreview(modal) {
     };
 }
 
+function registerRemoveLiquidityButton(title = 'Wait for a supported remove-liquidity preview.') {
+    const icon = { textContent: 'swap_horiz' };
+    const text = { textContent: ' Remove LP Liquidity' };
+    const button = createElement({ classes: ['btn', 'btn-primary', 'remove-liquidity-action-btn'] });
+    button.disabled = true;
+    button.title = title;
+    button.childNodes = [icon, text];
+    button.querySelector = vi.fn(selector => selector === '.material-icons' ? icon : null);
+    globalThis.document.querySelector = vi.fn(selector => (
+        selector.includes('safeModalExecuteRemoveLiquidity') ? button : null
+    ));
+    return button;
+}
+
 function createAmount(value) {
     return {
         value,
@@ -1005,17 +1019,7 @@ describe('StakingModalNew zap cleanup', () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal);
         const readyPreview = modal.removeLiquidityPreview;
-        const icon = { textContent: 'swap_horiz' };
-        const buttonText = { textContent: ' Remove LP Liquidity' };
-        const removeButton = createElement({ classes: ['btn', 'btn-primary', 'remove-liquidity-action-btn'] });
-        removeButton.disabled = true;
-        removeButton.title = 'Wait for a supported remove-liquidity preview.';
-        removeButton.childNodes = [icon, buttonText];
-        removeButton.querySelector = vi.fn(selector => selector === '.material-icons' ? icon : null);
-
-        globalThis.document.querySelector = vi.fn(selector => (
-            selector.includes('safeModalExecuteRemoveLiquidity') ? removeButton : null
-        ));
+        const removeButton = registerRemoveLiquidityButton();
         globalThis.contractManager = { provider: {} };
         modal.userBalanceRaw = { gte: vi.fn(() => true) };
         modal.removeLiquidityPreview = null;
@@ -1036,14 +1040,7 @@ describe('StakingModalNew zap cleanup', () => {
         modal.removeLiquidityAmount = '1';
         modal.removeLiquidityEnabled = false;
         modal.userBalanceRaw = { gte: vi.fn(() => true) };
-        const removeButton = createElement({ classes: ['btn', 'btn-primary', 'remove-liquidity-action-btn'] });
-        removeButton.disabled = true;
-        removeButton.title = 'Confirm the remove-liquidity details first';
-        removeButton.childNodes = [{ textContent: 'swap_horiz' }, { textContent: ' Remove LP Liquidity' }];
-        removeButton.querySelector = vi.fn(() => removeButton.childNodes[0]);
-        globalThis.document.querySelector = vi.fn(selector => (
-            selector.includes('safeModalExecuteRemoveLiquidity') ? removeButton : null
-        ));
+        const removeButton = registerRemoveLiquidityButton('Confirm the remove-liquidity details first');
 
         modal.updateRemoveLiquidityButton();
 
@@ -1082,7 +1079,7 @@ describe('StakingModalNew zap cleanup', () => {
         await vi.runAllTimersAsync();
         await executePromise;
 
-        expect(modal.fetchRemoveLiquidityPreview).toHaveBeenCalledWith({ force: true, requireDetailsOpen: false });
+        expect(modal.fetchRemoveLiquidityPreview).toHaveBeenCalledWith({ force: true });
         expect(modal.executeRemoveLiquidityTransaction).toHaveBeenCalledWith('0xlp', expect.objectContaining({ value: 1 }));
         expect(globalThis.notificationManager.error).not.toHaveBeenCalledWith('Confirm the remove-liquidity details before continuing.');
     });

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -996,13 +996,18 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('id="remove-liquidity-checkbox"');
         expect(html).toContain('remove-liquidity-action-btn');
         expect(html).toContain('Convert returned LIB to USDT after removing LP');
-        expect(html).toContain('LIB + USDT via Uniswap V2');
-        expect(html).toContain('LIB to USDT');
+        expect(html).toContain('LIB converts to USDT after LP removal');
+        expect(html).toContain('<dt>LP removal output</dt>');
+        expect(html).toContain('100 LIB + 50 USDT');
+        expect(html).toContain('<dt>LIB to convert</dt>');
+        expect(html).toContain('<dt>Estimated USDT from conversion</dt>');
+        expect(html).toContain('90 USDT');
+        expect(html).toContain('<dt>Estimated total USDT</dt>');
         expect(html).toContain('140 USDT');
+        expect(html).toContain('<dt>Minimum total USDT</dt>');
         expect(html).toContain('139.3 USDT');
-        expect(html).toContain('<dt>Minimum token0</dt>');
-        expect(html).toContain('99.5 LIB');
-        expect(html).toContain('49.75 USDT');
+        expect(html).not.toContain('<dt>Estimated token0</dt>');
+        expect(html).not.toContain('<dt>Minimum token0</dt>');
     });
 
     it('keeps guided remove-liquidity controls out of the Unstake tab', async () => {

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -217,7 +217,7 @@ function arrangeReadyZapQuote(modal, data = { route: '0xroute' }) {
 
 function arrangeReadyRemoveLiquidityPreview(modal) {
     modal.currentPair = { name: 'LIB/USDT', lpToken: '0xlp', address: '0xlp' };
-    modal.unstakeAmount = '1';
+    modal.removeLiquidityAmount = '1';
     modal.removeLiquidityEnabled = true;
     modal.removeLiquidityPreviewStatus = 'ready';
     modal.removeLiquidityPreview = {
@@ -287,6 +287,7 @@ describe('StakingModalNew zap cleanup', () => {
         delete globalThis.safeModalExecuteStake;
         delete globalThis.safeModalExecuteUnstake;
         delete globalThis.safeModalExecuteClaim;
+        delete globalThis.safeModalExecuteRemoveLiquidity;
         delete globalThis.safeModalFetchZapQuote;
         delete globalThis.safeModalExecuteZap;
         delete globalThis.safeModalAddZapCustomToken;
@@ -315,6 +316,7 @@ describe('StakingModalNew zap cleanup', () => {
         expect(modalContainer.innerHTML).toContain('<span class="material-icons" aria-hidden="true">bolt</span>');
         expect(modalContainer.innerHTML).toContain('<span class="tab-label">Create LP</span>');
         expect(modalContainer.innerHTML).toContain('<span class="tab-label">Unstake</span>');
+        expect(modalContainer.innerHTML).toContain('<span class="tab-label">Remove LP</span>');
     });
 
     it('derives LP USD estimates from pair TVL data', async () => {
@@ -949,25 +951,41 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('<dd>None</dd>');
     });
 
-    it('renders guided remove-liquidity controls and preview on the unstake tab', async () => {
+    it('renders guided remove-liquidity controls and preview on the Remove LP tab', async () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal);
-        modal.userStaked = '10';
+        modal.userBalance = '10';
+        modal.currentPair = { ...modal.currentPair, tvlUsd: 1000, tvl: 100 };
 
-        const html = modal.renderUnstakeTab();
+        const html = modal.renderRemoveLiquidityTab();
 
+        expect(html).toContain('10 LP <span class="lp-usd-estimate">($100.00)</span>');
+        expect(html).toContain('id="remove-liquidity-amount-input"');
+        expect(html).toContain('id="remove-liquidity-usd-estimate"');
         expect(html).toContain('id="remove-liquidity-checkbox"');
-        expect(html).toContain('Also remove liquidity and return pair tokens');
+        expect(html).toContain('Remove liquidity and return pair tokens');
         expect(html).toContain('LIB + USDT via Uniswap V2');
         expect(html).toContain('<dt>Minimum token0</dt>');
         expect(html).toContain('99.5 LIB');
         expect(html).toContain('49.75 USDT');
     });
 
+    it('keeps guided remove-liquidity controls out of the Unstake tab', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.userStaked = '10';
+
+        const html = modal.renderUnstakeTab();
+
+        expect(html).not.toContain('id="remove-liquidity-checkbox"');
+        expect(html).not.toContain('Remove liquidity and return pair tokens');
+        expect(html).not.toContain('remove-liquidity-preview-panel');
+    });
+
     it('shows a blocking unsupported message for unknown remove-liquidity factories', async () => {
         const modal = await createLoadedModal();
         modal.currentPair = { name: 'LIB/USDT', lpToken: '0xlp' };
-        modal.unstakeAmount = '1';
+        modal.removeLiquidityAmount = '1';
         modal.removeLiquidityEnabled = true;
         modal.removeLiquidityPreviewStatus = 'error';
         modal.removeLiquidityPreviewError = 'This LP factory is not supported for guided remove liquidity.';
@@ -976,7 +994,7 @@ describe('StakingModalNew zap cleanup', () => {
             factoryAddress: '0x9999999999999999999999999999999999999999'
         };
 
-        const html = modal.renderUnstakeTab();
+        const html = modal.renderRemoveLiquidityTab();
 
         expect(html).toContain('This LP factory is not supported for guided remove liquidity.');
         expect(html).toContain('Unsupported factory 0x9999...9999');
@@ -998,15 +1016,16 @@ describe('StakingModalNew zap cleanup', () => {
         expect(modal.fetchRemoveLiquidityPreview).toHaveBeenCalledTimes(1);
     });
 
-    it('executes unstake before the guided remove-liquidity step', async () => {
+    it('keeps executeUnstake focused on unstaking only', async () => {
         vi.useFakeTimers();
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal);
         const calls = [];
         modal.getRemoveLiquidityAmountRaw = vi.fn(() => createAmount(1));
-        modal.executeRemoveLiquidityAfterUnstake = vi.fn(async () => {
+        modal.executeRemoveLiquidityTransaction = vi.fn(async () => {
             calls.push('remove');
         });
+        modal.unstakeAmount = '1';
         modal.loadUserBalances = vi.fn().mockResolvedValue(undefined);
         modal.clearInputs = vi.fn();
         modal.close = vi.fn();
@@ -1028,10 +1047,40 @@ describe('StakingModalNew zap cleanup', () => {
         await vi.runAllTimersAsync();
         await executePromise;
 
-        expect(calls).toEqual(['unstake', 'remove']);
+        expect(calls).toEqual(['unstake']);
         expect(globalThis.contractManager.unstake).toHaveBeenCalledWith('0xlp', '1', true);
+        expect(modal.executeRemoveLiquidityTransaction).not.toHaveBeenCalled();
         expect(modal.clearInputs).toHaveBeenCalled();
         expect(modal.close).toHaveBeenCalled();
+    });
+
+    it('executes remove liquidity from the dedicated Remove LP tab', async () => {
+        vi.useFakeTimers();
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.getRemoveLiquidityAmountRaw = vi.fn(() => createAmount(1));
+        modal.executeRemoveLiquidityTransaction = vi.fn().mockResolvedValue({ success: true, hash: '0xremove' });
+        modal.loadUserBalances = vi.fn().mockResolvedValue(undefined);
+        modal.clearInputs = vi.fn();
+        modal.close = vi.fn();
+        globalThis.contractManager = {
+            isReady: vi.fn(() => true)
+        };
+        globalThis.notificationManager = {
+            info: vi.fn(),
+            success: vi.fn(),
+            error: vi.fn()
+        };
+        globalThis.homePage = { refreshData: vi.fn().mockResolvedValue(undefined) };
+
+        const executePromise = modal.executeRemoveLiquidity();
+        await vi.runAllTimersAsync();
+        await executePromise;
+
+        expect(modal.executeRemoveLiquidityTransaction).toHaveBeenCalledWith('0xlp', expect.objectContaining({ value: 1 }));
+        expect(modal.clearInputs).toHaveBeenCalled();
+        expect(modal.close).toHaveBeenCalled();
+        expect(globalThis.notificationManager.success).toHaveBeenCalledWith('Liquidity removed successfully!');
     });
 
     it('approves the router when needed before removing liquidity', async () => {
@@ -1065,7 +1114,7 @@ describe('StakingModalNew zap cleanup', () => {
             error: vi.fn()
         };
 
-        await modal.executeRemoveLiquidityAfterUnstake('0xlp', liquidityRaw);
+        await modal.executeRemoveLiquidityTransaction('0xlp', liquidityRaw);
 
         expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenNthCalledWith(1, expect.any(Function), 'approveRemoveLiquidity');
         expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenNthCalledWith(2, expect.any(Function), 'removeLiquidity');

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1085,6 +1085,47 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('$0.4');
     });
 
+    it('does not double-count repeated Kyber action amounts for checked zap-out output', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
+        const daiToken = {
+            address: '0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3',
+            symbol: 'DAI',
+            name: 'Dai Token',
+            decimals: 18
+        };
+        const daiActionToken = {
+            address: daiToken.address,
+            amount: '394877000000000000',
+            amountUsd: '0.40'
+        };
+        modal.removeLiquidityOutputTokens = [daiToken];
+        modal.removeLiquidityOutputTokenAddress = daiToken.address;
+        modal.removeLiquiditySelectedOutputToken = daiToken;
+        modal.removeLiquidityPreview = {
+            supported: true,
+            zapOut: true,
+            outputToken: daiToken,
+            data: {
+                route: '0xout-route',
+                routerAddress: '0x0e97C887b61cCd952a53578B04763E7134429e05',
+                zapDetails: {
+                    finalAmountUsd: '0.40',
+                    actions: [
+                        { aggregatorSwap: { swaps: [{ tokenOut: daiActionToken }] } },
+                        { refund: { tokens: [daiActionToken] } }
+                    ]
+                }
+            }
+        };
+
+        const html = modal.renderRemoveLiquidityPreviewPanel();
+
+        expect(html).toContain('<dt>Estimated DAI</dt>');
+        expect(html).toContain('0.394877 DAI');
+        expect(html).not.toContain('0.789754 DAI');
+    });
+
     it('configured output token selection refreshes the zap-out quote', async () => {
         vi.useFakeTimers();
         const modal = await createLoadedModal();

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1024,16 +1024,17 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('remove-liquidity-output-token-option');
         expect(html).toContain('Custom token');
         expect(html).toContain('Kyber zap-out to USDT');
-        expect(html).toContain('<dt>Route</dt>');
-        expect(html).toContain('<dt>Kyber Router</dt>');
-        expect(html).toContain('<dt>LP amount</dt>');
-        expect(html).toContain('<dt>Output token</dt>');
-        expect(html).toContain('<dt>Estimated USDT</dt>');
+        expect(html).toContain('remove-liquidity-settings-toggle');
+        expect(html).toContain('Max slippage:');
+        expect(html).not.toContain('id="remove-liquidity-deadline-input"');
+        expect(html).toContain('Estimated USDT');
         expect(html).toContain('140 USDT');
-        expect(html).toContain('<dt>Estimated value</dt>');
-        expect(html).toContain('$140');
+        expect(html).toContain('Minimum received');
+        expect(html).toContain('139.3 USDT');
+        expect(html).toContain('Price impact');
         expect(html).not.toContain('<dt>Estimated token0</dt>');
         expect(html).not.toContain('<dt>Minimum token0</dt>');
+        expect(html).not.toContain('<dt>Kyber Router</dt>');
     });
 
     it('renders direct remove-liquidity preview and safeguards when conversion is unchecked', async () => {
@@ -1046,18 +1047,31 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).not.toContain('remove-liquidity-output-token-picker');
         expect(html).not.toContain('<label class="form-label">Output Token</label>');
         expect(html).toContain('LIB + USDT via Uniswap V2');
-        expect(html).toContain('<dt>DEX</dt>');
-        expect(html).toContain('<dt>Estimated LIB</dt>');
-        expect(html).toContain('100 LIB');
-        expect(html).toContain('<dt>Estimated USDT</dt>');
-        expect(html).toContain('50 USDT');
-        expect(html).toContain('<dt>Minimum LIB</dt>');
-        expect(html).toContain('99.5 LIB');
-        expect(html).toContain('<dt>Minimum USDT</dt>');
-        expect(html).toContain('49.75 USDT');
-        expect(html).toContain('<dt>Slippage</dt>');
-        expect(html).toContain('<dt>Deadline</dt>');
+        expect(html).toContain('Max slippage:');
+        expect(html).toContain('You receive');
+        expect(html).toContain('100 LIB + 50 USDT');
+        expect(html).toContain('Minimum received');
+        expect(html).toContain('99.5 LIB + 49.75 USDT');
+        expect(html).toContain('DEX');
+        expect(html).not.toContain('id="remove-liquidity-deadline-input"');
         expect(html).not.toContain('<dt>Kyber Router</dt>');
+    });
+
+    it('opens remove-liquidity slippage and deadline controls from the compact dropdown', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.removeLiquiditySettingsOpen = true;
+
+        const html = modal.renderRemoveLiquidityTab();
+
+        expect(html).toContain('aria-expanded="true"');
+        expect(html).toContain('0.05%');
+        expect(html).toContain('0.1%');
+        expect(html).toContain('0.5%');
+        expect(html).toContain('1.0%');
+        expect(html).toContain('Custom');
+        expect(html).toContain('id="remove-liquidity-deadline-input"');
+        expect(html).toContain('Transaction time limit');
     });
 
     it('shows a readable over-balance warning on unchecked remove liquidity', async () => {
@@ -1115,10 +1129,10 @@ describe('StakingModalNew zap cleanup', () => {
 
         const html = modal.renderRemoveLiquidityPreviewPanel();
 
-        expect(html).toContain('<dt>Estimated BNB</dt>');
+        expect(html).toContain('Estimated BNB');
         expect(html).toContain('0.00123 BNB');
-        expect(html).toContain('<dt>Estimated value</dt>');
-        expect(html).toContain('$0.4');
+        expect(html).toContain('Minimum received');
+        expect(html).toContain('Price impact');
     });
 
     it('does not double-count repeated Kyber action amounts for checked zap-out output', async () => {
@@ -1157,7 +1171,7 @@ describe('StakingModalNew zap cleanup', () => {
 
         const html = modal.renderRemoveLiquidityPreviewPanel();
 
-        expect(html).toContain('<dt>Estimated DAI</dt>');
+        expect(html).toContain('Estimated DAI');
         expect(html).toContain('0.394877 DAI');
         expect(html).not.toContain('0.789754 DAI');
     });

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -963,6 +963,7 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('id="remove-liquidity-amount-input"');
         expect(html).toContain('id="remove-liquidity-usd-estimate"');
         expect(html).toContain('id="remove-liquidity-checkbox"');
+        expect(html).toContain('remove-liquidity-action-btn');
         expect(html).toContain('Remove liquidity and return pair tokens');
         expect(html).toContain('LIB + USDT via Uniswap V2');
         expect(html).toContain('<dt>Minimum token0</dt>');

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1020,6 +1020,7 @@ describe('StakingModalNew zap cleanup', () => {
 
         expect(html).toContain('10 LP <span class="lp-usd-estimate">($100.00)</span>');
         expect(html).toContain('id="remove-liquidity-amount-input"');
+        expect(html).toContain('remove-liquidity-meta-row');
         expect(html).toContain('id="remove-liquidity-usd-estimate"');
         expect(html).toContain('id="remove-liquidity-checkbox"');
         expect(html).toContain('remove-liquidity-action-btn');
@@ -1042,7 +1043,7 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).not.toContain('<dt>Kyber Router</dt>');
     });
 
-    it('renders remove-liquidity slider and preset state from the saved amount', async () => {
+    it('renders remove-liquidity compact percentage buttons from the saved amount', async () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
         modal.userBalance = '5';
@@ -1050,9 +1051,10 @@ describe('StakingModalNew zap cleanup', () => {
 
         const html = modal.renderRemoveLiquidityTab();
 
-        expect(html).toContain('id="remove-liquidity-slider"');
-        expect(html).toContain('value="50"');
-        expect(html).toContain('<button class="percentage-btn active" data-percentage="50">50%</button>');
+        expect(html).toContain('zap-label-row zap-amount-label-row');
+        expect(html).toContain('zap-percentage-buttons');
+        expect(html).not.toContain('id="remove-liquidity-slider"');
+        expect(html).toContain('class="zap-percentage-btn remove-liquidity-percentage-btn active" data-percentage="50"');
     });
 
     it('renders direct remove-liquidity preview and safeguards when conversion is unchecked', async () => {

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1110,6 +1110,30 @@ describe('StakingModalNew zap cleanup', () => {
         expect(modal.canFetchRemoveLiquidityPreview()).toBe(false);
     });
 
+    it('shows a clear checked zap-out message above the LP balance without calling Kyber', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
+        modal.removeLiquidityZapOutEnabled = true;
+        modal.removeLiquidityAmount = '2';
+        modal.userBalance = '1.0';
+        modal.userBalanceRaw = { gte: vi.fn(() => false) };
+        modal.removeLiquidityPreview = null;
+        modal.removeLiquidityPreviewStatus = 'idle';
+        const fetchOutQuote = vi.fn();
+        modal.getKyberZapService().fetchOutQuote = fetchOutQuote;
+
+        await modal.fetchRemoveLiquidityPreview({ force: true });
+        const html = modal.renderRemoveLiquidityTab();
+
+        expect(fetchOutQuote).not.toHaveBeenCalled();
+        expect(html).toContain('Amount exceeds available LP balance (1.0 LP).');
+        expect(html).toContain('Kyber cannot quote more LP than your available balance.');
+        expect(html).toContain('Kyber quote');
+        expect(html).toContain('Unavailable above LP balance');
+        expect(html).not.toContain('Route</dt>');
+        expect(html).not.toContain('Unsupported</dd>');
+    });
+
     it('derives checked remove-liquidity output amount from Kyber zap-out actions', async () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
@@ -1612,6 +1636,28 @@ describe('StakingModalNew zap cleanup', () => {
             data: '0xzapdata'
         }));
         expect(globalThis.notificationManager.success).toHaveBeenCalledWith('LP tokens zapped out successfully!');
+    });
+
+    it('blocks checked zap-out execution when the amount exceeds the LP balance', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
+        modal.removeLiquidityAmount = '2';
+        modal.userBalance = '1.0';
+        modal.userBalanceRaw = { gte: vi.fn(() => false) };
+        modal.executeRemoveLiquidityZapOutTransaction = vi.fn();
+        globalThis.contractManager = {
+            isReady: vi.fn(() => true)
+        };
+        globalThis.notificationManager = {
+            info: vi.fn(),
+            success: vi.fn(),
+            error: vi.fn()
+        };
+
+        await modal.executeRemoveLiquidity();
+
+        expect(modal.executeRemoveLiquidityZapOutTransaction).not.toHaveBeenCalled();
+        expect(globalThis.notificationManager.error).toHaveBeenCalledWith('Amount exceeds available LP balance (1.0 LP).');
     });
 
     it('unchecked execute still calls direct removeLiquidity and skips Kyber zap-out endpoints', async () => {

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1143,6 +1143,54 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('Price impact');
     });
 
+    it('renders Kyber Zap Fee when checked remove-liquidity route returns a protocol fee', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
+        const daiToken = {
+            address: '0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3',
+            symbol: 'DAI',
+            name: 'Dai Token',
+            decimals: 18
+        };
+        modal.removeLiquidityOutputTokens = [daiToken];
+        modal.removeLiquidityOutputTokenAddress = daiToken.address;
+        modal.removeLiquiditySelectedOutputToken = daiToken;
+        modal.removeLiquidityPreview = {
+            supported: true,
+            zapOut: true,
+            outputToken: daiToken,
+            data: {
+                route: '0xout-route',
+                routerAddress: '0x0e97C887b61cCd952a53578B04763E7134429e05',
+                zapDetails: {
+                    finalAmount: '394877000000000000',
+                    protocolFee: {
+                        tokens: [{
+                            address: daiToken.address,
+                            amount: '2500000000000000',
+                            symbol: 'DAI',
+                            decimals: 18
+                        }]
+                    }
+                }
+            }
+        };
+
+        const html = modal.renderRemoveLiquidityPreviewPanel();
+
+        expect(html).toContain('Kyber Zap Fee');
+        expect(html).toContain('0.0025 DAI');
+    });
+
+    it('does not render Kyber Zap Fee for unchecked remove liquidity', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: false });
+
+        const html = modal.renderRemoveLiquidityPreviewPanel();
+
+        expect(html).not.toContain('Kyber Zap Fee');
+    });
+
     it('does not double-count repeated Kyber action amounts for checked zap-out output', async () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal, { convert: true });

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -93,6 +93,18 @@ async function loadStakingModalClass() {
             }
         }
     };
+    globalThis.CONFIG.DEX_REMOVE_LIQUIDITY = {
+        56: {
+            wrappedNative: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
+            factories: {
+                '0x8909dc15e40173ff4699343b6eb8132c65e18ec6': {
+                    name: 'Uniswap V2',
+                    type: 'uniswapV2',
+                    router: '0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24'
+                }
+            }
+        }
+    };
     globalThis.ethers = {
         BigNumber: {
             from: vi.fn(value => ({ value, toString: () => String(value) }))
@@ -113,6 +125,7 @@ async function loadStakingModalClass() {
 
     await import('../js/services/kyber-zap-rate-limiter.js');
     await import('../js/services/kyber-zap-service.js');
+    await import('../js/services/v2-remove-liquidity-service.js');
     await import('../js/components/staking-modal-new.js');
     return globalThis.StakingModalNew;
 }
@@ -202,6 +215,44 @@ function arrangeReadyZapQuote(modal, data = { route: '0xroute' }) {
     modal.zapQuote = { data };
 }
 
+function arrangeReadyRemoveLiquidityPreview(modal) {
+    modal.currentPair = { name: 'LIB/USDT', lpToken: '0xlp', address: '0xlp' };
+    modal.unstakeAmount = '1';
+    modal.removeLiquidityEnabled = true;
+    modal.removeLiquidityPreviewStatus = 'ready';
+    modal.removeLiquidityPreview = {
+        supported: true,
+        adapter: {
+            name: 'Uniswap V2',
+            routerAddress: '0xrouter',
+            factoryAddress: '0xfactory'
+        },
+        token0: {
+            address: '0xlib',
+            symbol: 'LIB',
+            decimals: 18,
+            amount: { raw: '100000000000000000000', formatted: '100' },
+            minAmount: { raw: '99500000000000000000', formatted: '99.5' }
+        },
+        token1: {
+            address: '0xusdt',
+            symbol: 'USDT',
+            decimals: 18,
+            amount: { raw: '50000000000000000000', formatted: '50' },
+            minAmount: { raw: '49750000000000000000', formatted: '49.75' }
+        }
+    };
+}
+
+function createAmount(value) {
+    return {
+        value,
+        lt: other => Number(value) < Number(other?.value ?? other),
+        gte: other => Number(value) >= Number(other?.value ?? other),
+        toString: () => String(value)
+    };
+}
+
 describe('StakingModalNew zap cleanup', () => {
     beforeEach(() => {
         vi.useRealTimers();
@@ -227,6 +278,7 @@ describe('StakingModalNew zap cleanup', () => {
         delete globalThis.KyberZapRateLimitError;
         delete globalThis.KyberZapQuoteRateLimiter;
         delete globalThis.KyberZapService;
+        delete globalThis.V2RemoveLiquidityService;
         delete globalThis.StakingModalNew;
         delete globalThis.stakingModal;
         delete globalThis.stakingModalNew;
@@ -238,6 +290,7 @@ describe('StakingModalNew zap cleanup', () => {
         delete globalThis.safeModalFetchZapQuote;
         delete globalThis.safeModalExecuteZap;
         delete globalThis.safeModalAddZapCustomToken;
+        delete globalThis.safeModalFetchRemoveLiquidityPreview;
     });
 
     it('clearInputs removes active zap percentage button state', async () => {
@@ -894,5 +947,140 @@ describe('StakingModalNew zap cleanup', () => {
 
         expect(html).toContain('<dt>Kyber Zap Fee</dt>');
         expect(html).toContain('<dd>None</dd>');
+    });
+
+    it('renders guided remove-liquidity controls and preview on the unstake tab', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.userStaked = '10';
+
+        const html = modal.renderUnstakeTab();
+
+        expect(html).toContain('id="remove-liquidity-checkbox"');
+        expect(html).toContain('Also remove liquidity and return pair tokens');
+        expect(html).toContain('LIB + USDT via Uniswap V2');
+        expect(html).toContain('<dt>Minimum token0</dt>');
+        expect(html).toContain('99.5 LIB');
+        expect(html).toContain('49.75 USDT');
+    });
+
+    it('shows a blocking unsupported message for unknown remove-liquidity factories', async () => {
+        const modal = await createLoadedModal();
+        modal.currentPair = { name: 'LIB/USDT', lpToken: '0xlp' };
+        modal.unstakeAmount = '1';
+        modal.removeLiquidityEnabled = true;
+        modal.removeLiquidityPreviewStatus = 'error';
+        modal.removeLiquidityPreviewError = 'This LP factory is not supported for guided remove liquidity.';
+        modal.removeLiquidityPreview = {
+            supported: false,
+            factoryAddress: '0x9999999999999999999999999999999999999999'
+        };
+
+        const html = modal.renderUnstakeTab();
+
+        expect(html).toContain('This LP factory is not supported for guided remove liquidity.');
+        expect(html).toContain('Unsupported factory 0x9999...9999');
+    });
+
+    it('valid custom remove-liquidity slippage applies bps and refreshes the preview', async () => {
+        vi.useFakeTimers();
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.fetchRemoveLiquidityPreview = vi.fn();
+
+        const sanitizedValue = modal.setRemoveLiquidityCustomSlippageInput('2.345');
+        await vi.advanceTimersByTimeAsync(400);
+
+        expect(sanitizedValue).toBe('2.34');
+        expect(modal.removeLiquiditySlippageBps).toBe(234);
+        expect(modal.removeLiquidityCustomSlippageError).toBe('');
+        expect(modal.removeLiquidityPreview).toBeNull();
+        expect(modal.fetchRemoveLiquidityPreview).toHaveBeenCalledTimes(1);
+    });
+
+    it('executes unstake before the guided remove-liquidity step', async () => {
+        vi.useFakeTimers();
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        const calls = [];
+        modal.getRemoveLiquidityAmountRaw = vi.fn(() => createAmount(1));
+        modal.executeRemoveLiquidityAfterUnstake = vi.fn(async () => {
+            calls.push('remove');
+        });
+        modal.loadUserBalances = vi.fn().mockResolvedValue(undefined);
+        modal.clearInputs = vi.fn();
+        modal.close = vi.fn();
+        globalThis.contractManager = {
+            isReady: vi.fn(() => true),
+            unstake: vi.fn(async () => {
+                calls.push('unstake');
+                return { success: true, hash: '0xunstake' };
+            })
+        };
+        globalThis.notificationManager = {
+            info: vi.fn(),
+            success: vi.fn(),
+            error: vi.fn()
+        };
+        globalThis.homePage = { refreshData: vi.fn().mockResolvedValue(undefined) };
+
+        const executePromise = modal.executeUnstake();
+        await vi.runAllTimersAsync();
+        await executePromise;
+
+        expect(calls).toEqual(['unstake', 'remove']);
+        expect(globalThis.contractManager.unstake).toHaveBeenCalledWith('0xlp', '1', true);
+        expect(modal.clearInputs).toHaveBeenCalled();
+        expect(modal.close).toHaveBeenCalled();
+    });
+
+    it('approves the router when needed before removing liquidity', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        const liquidityRaw = createAmount(5);
+        const service = {
+            validateRouterFactory: vi.fn().mockResolvedValue(true),
+            getBalance: vi.fn().mockResolvedValue(createAmount(10)),
+            getAllowance: vi.fn().mockResolvedValue(createAmount(1)),
+            approveIfNeeded: vi.fn().mockResolvedValue({ hash: '0xapprove' }),
+            removeLiquidity: vi.fn().mockResolvedValue({ hash: '0xremove' })
+        };
+        modal.removeLiquidityService = service;
+        globalThis.contractManager = {
+            provider: {},
+            ensureSigner: vi.fn().mockResolvedValue(undefined),
+            signer: {
+                provider: {},
+                getAddress: vi.fn().mockResolvedValue('0xuser')
+            },
+            executeTransactionOnce: vi.fn(async (operation) => {
+                const tx = await operation();
+                return { success: true, hash: tx.hash };
+            })
+        };
+        globalThis.walletManager = { provider: {} };
+        globalThis.notificationManager = {
+            info: vi.fn(),
+            success: vi.fn(),
+            error: vi.fn()
+        };
+
+        await modal.executeRemoveLiquidityAfterUnstake('0xlp', liquidityRaw);
+
+        expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenNthCalledWith(1, expect.any(Function), 'approveRemoveLiquidity');
+        expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenNthCalledWith(2, expect.any(Function), 'removeLiquidity');
+        expect(service.approveIfNeeded).toHaveBeenCalledWith(expect.objectContaining({
+            lpTokenAddress: '0xlp',
+            spender: '0xrouter',
+            liquidityRaw
+        }));
+        expect(service.removeLiquidity).toHaveBeenCalledWith(expect.objectContaining({
+            routerAddress: '0xrouter',
+            token0: '0xlib',
+            token1: '0xusdt',
+            amount0Min: '99500000000000000000',
+            amount1Min: '49750000000000000000',
+            recipient: '0xuser'
+        }));
     });
 });

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -950,6 +950,20 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('High slippage tolerance. This transaction may execute at a much worse rate.');
     });
 
+    it('shows the high slippage warning while the zap quote is waiting to refresh', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyZapQuote(modal);
+        modal.zapQuoteStatus = 'idle';
+        modal.zapQuote = null;
+        modal.zapSlippageBps = 500;
+
+        const html = modal.renderZapQuotePanel();
+
+        expect(html).toContain('zap-quote-row zap-risk-high');
+        expect(html).toContain('5.00%');
+        expect(html).toContain('High slippage tolerance. This transaction may execute at a much worse rate.');
+    });
+
     it('highlights very high price impact in the zap quote panel', async () => {
         const modal = await createLoadedModal();
         arrangeReadyZapQuote(modal, {
@@ -1107,6 +1121,20 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).not.toContain('Price impact');
     });
 
+    it('shows the high slippage warning while remove-liquidity preview is waiting to refresh', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.removeLiquidityPreviewStatus = 'idle';
+        modal.removeLiquidityPreview = null;
+        modal.removeLiquiditySlippageBps = 500;
+
+        const html = modal.renderRemoveLiquidityPreviewPanel();
+
+        expect(html).toContain('zap-quote-row zap-risk-high');
+        expect(html).toContain('5.00%');
+        expect(html).toContain('High slippage tolerance. This transaction may execute at a much worse rate.');
+    });
+
     it('opens remove-liquidity slippage and deadline controls from the compact dropdown', async () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal);
@@ -1176,6 +1204,8 @@ describe('StakingModalNew zap cleanup', () => {
 
         expect(modal.removeLiquidityCustomSlippageError).toBe('Enter a custom slippage between 0.01% and 100%.');
         expect(modal.removeLiquidityPreviewError).toBe('');
+        expect(html).toContain('Enter a valid custom slippage to preview remove liquidity.');
+        expect(html).not.toContain('Checking remove liquidity support...');
         expect(html.match(/Enter a custom slippage between 0\.01% and 100%\./g)).toHaveLength(1);
     });
 

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -116,7 +116,7 @@ async function loadStakingModalClass() {
     };
     globalThis.ethers = {
         BigNumber: {
-            from: vi.fn(value => ({ value, toString: () => String(value) }))
+            from: vi.fn(value => createAmount(value))
         },
         utils: {
             isAddress: vi.fn(value => /^0x[a-fA-F0-9]{40}$/.test(String(value))),
@@ -229,6 +229,8 @@ function arrangeReadyZapQuote(modal, data = { route: '0xroute' }) {
 function arrangeReadyRemoveLiquidityPreview(modal, { convert = false } = {}) {
     modal.currentPair = { name: 'LIB/USDT', lpToken: '0xlp', address: '0xlp' };
     modal.removeLiquidityAmount = '1';
+    modal.userBalance = '10';
+    modal.userBalanceRaw = createAmount(10);
     modal.removeLiquidityZapOutEnabled = convert;
     modal.removeLiquidityOutputTokens = [
         { address: LIB_TOKEN_ADDRESS, symbol: 'LIB', name: 'Liberdus', decimals: 18 },
@@ -297,6 +299,8 @@ function registerRemoveLiquidityButton(title = 'Wait for a supported remove-liqu
 function createAmount(value) {
     return {
         value,
+        mul: other => createAmount(Number(value) * Number(other?.value ?? other)),
+        div: other => createAmount(Number(value) / Number(other?.value ?? other)),
         lt: other => Number(value) < Number(other?.value ?? other),
         lte: other => Number(value) <= Number(other?.value ?? other),
         gte: other => Number(value) >= Number(other?.value ?? other),

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1001,6 +1001,35 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('Unsupported factory 0x9999...9999');
     });
 
+    it('enables the remove-liquidity action after a supported preview loads', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        const readyPreview = modal.removeLiquidityPreview;
+        const icon = { textContent: 'swap_horiz' };
+        const buttonText = { textContent: ' Remove LP Liquidity' };
+        const removeButton = createElement({ classes: ['btn', 'btn-primary', 'remove-liquidity-action-btn'] });
+        removeButton.disabled = true;
+        removeButton.title = 'Wait for a supported remove-liquidity preview.';
+        removeButton.childNodes = [icon, buttonText];
+        removeButton.querySelector = vi.fn(selector => selector === '.material-icons' ? icon : null);
+
+        globalThis.document.querySelector = vi.fn(selector => (
+            selector.includes('safeModalExecuteRemoveLiquidity') ? removeButton : null
+        ));
+        globalThis.contractManager = { provider: {} };
+        modal.userBalanceRaw = { gte: vi.fn(() => true) };
+        modal.removeLiquidityPreview = null;
+        modal.removeLiquidityPreviewStatus = 'idle';
+        modal.getRemoveLiquidityService = vi.fn(() => ({
+            getPreview: vi.fn().mockResolvedValue(readyPreview)
+        }));
+
+        await modal.fetchRemoveLiquidityPreview({ force: true });
+
+        expect(removeButton.disabled).toBe(false);
+        expect(removeButton.title).toBe('Remove LP liquidity');
+    });
+
     it('valid custom remove-liquidity slippage applies bps and refreshes the preview', async () => {
         vi.useFakeTimers();
         const modal = await createLoadedModal();

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const LIB_TOKEN_ADDRESS = '0x05A4cfAF5a8f939d61E4Ec6D6287c9a065d6574c';
+const USDT_TOKEN_ADDRESS = '0x55d398326f99059fF775485246999027B3197955';
+
 function createClassList(initialClasses = []) {
     const classes = new Set(initialClasses);
 
@@ -73,6 +76,9 @@ async function loadStakingModalClass() {
     globalThis.removeEventListener = vi.fn();
     globalThis.dispatchEvent = vi.fn();
     globalThis.document = createDocumentMock();
+    globalThis.networkSelector = {
+        getCurrentChainId: vi.fn(() => 56)
+    };
     globalThis.CONFIG = {
         KYBER_ZAP: {
             DEFAULT_SLIPPAGE_BPS: 50,
@@ -91,11 +97,18 @@ async function loadStakingModalClass() {
                     WRAPPED_NATIVE_TOKEN_ADDRESS: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c'
                 }
             }
+        },
+        DEFAULTS: {
+            REWARD_TOKEN: LIB_TOKEN_ADDRESS
         }
     };
     globalThis.CONFIG.DEX_REMOVE_LIQUIDITY = {
         56: {
             wrappedNative: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
+            libToUsdtConversion: {
+                fromToken: LIB_TOKEN_ADDRESS,
+                toToken: USDT_TOKEN_ADDRESS
+            },
             factories: {
                 '0x8909dc15e40173ff4699343b6eb8132c65e18ec6': {
                     name: 'Uniswap V2',
@@ -228,14 +241,14 @@ function arrangeReadyRemoveLiquidityPreview(modal, { convert = false } = {}) {
             factoryAddress: '0xfactory'
         },
         token0: {
-            address: '0xlib',
+            address: LIB_TOKEN_ADDRESS,
             symbol: 'LIB',
             decimals: 18,
             amount: { raw: '100000000000000000000', formatted: '100' },
             minAmount: { raw: '99500000000000000000', formatted: '99.5' }
         },
         token1: {
-            address: '0xusdt',
+            address: USDT_TOKEN_ADDRESS,
             symbol: 'USDT',
             decimals: 18,
             amount: { raw: '50000000000000000000', formatted: '50' },
@@ -248,7 +261,7 @@ function arrangeReadyRemoveLiquidityPreview(modal, { convert = false } = {}) {
             supported: true,
             fromToken: modal.removeLiquidityPreview.token0,
             toToken: modal.removeLiquidityPreview.token1,
-            path: ['0xlib', '0xusdt'],
+            path: [LIB_TOKEN_ADDRESS, USDT_TOKEN_ADDRESS],
             amountIn: { raw: '100000000000000000000', formatted: '100' },
             amountOut: { raw: '90000000000000000000', formatted: '90' },
             minAmountOut: { raw: '89550000000000000000', formatted: '89.55' },
@@ -1010,6 +1023,38 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).not.toContain('<dt>Minimum token0</dt>');
     });
 
+    it('matches remove-liquidity conversion tokens by configured address', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+
+        const conversion = modal.getRemoveLiquidityConversionTokens(modal.removeLiquidityPreview);
+
+        expect(conversion).toEqual(expect.objectContaining({
+            fromToken: expect.objectContaining({ address: LIB_TOKEN_ADDRESS }),
+            toToken: expect.objectContaining({ address: USDT_TOKEN_ADDRESS }),
+            path: [LIB_TOKEN_ADDRESS, USDT_TOKEN_ADDRESS]
+        }));
+    });
+
+    it('rejects spoofed LIB and USDT symbols for remove-liquidity conversion', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.removeLiquidityPreview.token0 = {
+            ...modal.removeLiquidityPreview.token0,
+            address: '0x1111111111111111111111111111111111111111',
+            symbol: 'LIB'
+        };
+        modal.removeLiquidityPreview.token1 = {
+            ...modal.removeLiquidityPreview.token1,
+            address: '0x2222222222222222222222222222222222222222',
+            symbol: 'USDT'
+        };
+
+        const conversion = modal.getRemoveLiquidityConversionTokens(modal.removeLiquidityPreview);
+
+        expect(conversion).toBeNull();
+    });
+
     it('keeps guided remove-liquidity controls out of the Unstake tab', async () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal);
@@ -1208,7 +1253,7 @@ describe('StakingModalNew zap cleanup', () => {
             getSwapQuote: vi.fn().mockResolvedValue({
                 amountIn: createAmount(100),
                 amountOut: createAmount(90),
-                path: ['0xlib', '0xusdt']
+                path: [LIB_TOKEN_ADDRESS, USDT_TOKEN_ADDRESS]
             }),
             calculateMinAmount: vi.fn().mockReturnValue(createAmount(89)),
             approveIfNeeded: vi.fn(),
@@ -1241,7 +1286,7 @@ describe('StakingModalNew zap cleanup', () => {
         expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenNthCalledWith(2, expect.any(Function), 'approveRemoveLiquidityConversion');
         expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenNthCalledWith(3, expect.any(Function), 'convertRemoveLiquidityToken');
         expect(service.approveTokenIfNeeded).toHaveBeenCalledWith(expect.objectContaining({
-            tokenAddress: '0xlib',
+            tokenAddress: LIB_TOKEN_ADDRESS,
             spender: '0xrouter',
             amountRaw: expect.objectContaining({ value: 100 })
         }));
@@ -1249,9 +1294,76 @@ describe('StakingModalNew zap cleanup', () => {
             routerAddress: '0xrouter',
             amountIn: expect.objectContaining({ value: 100 }),
             amountOutMin: expect.objectContaining({ value: 89 }),
-            path: ['0xlib', '0xusdt'],
+            path: [LIB_TOKEN_ADDRESS, USDT_TOKEN_ADDRESS],
             recipient: '0xuser'
         }));
+    });
+
+    it('marks post-remove balance read failures as partial success', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
+        const liquidityRaw = createAmount(5);
+        const service = {
+            validateRouterFactory: vi.fn().mockResolvedValue(true),
+            getBalance: vi.fn().mockResolvedValue(createAmount(10)),
+            getAllowance: vi.fn().mockResolvedValue(createAmount(10)),
+            getTokenBalance: vi.fn()
+                .mockResolvedValueOnce(createAmount(2))
+                .mockRejectedValueOnce(new Error('Balance read failed')),
+            approveIfNeeded: vi.fn(),
+            removeLiquidity: vi.fn().mockResolvedValue({ hash: '0xremove' })
+        };
+        modal.removeLiquidityService = service;
+        globalThis.contractManager = {
+            provider: {},
+            ensureSigner: vi.fn().mockResolvedValue(undefined),
+            signer: {
+                provider: {},
+                getAddress: vi.fn().mockResolvedValue('0xuser')
+            },
+            executeTransactionOnce: vi.fn(async (operation) => {
+                const tx = await operation();
+                return { success: true, hash: tx.hash };
+            })
+        };
+        globalThis.walletManager = { provider: {} };
+        globalThis.notificationManager = {
+            info: vi.fn(),
+            success: vi.fn(),
+            error: vi.fn()
+        };
+
+        await expect(modal.executeRemoveLiquidityTransaction('0xlp', liquidityRaw))
+            .rejects.toMatchObject({
+                message: 'Balance read failed',
+                removeLiquidityCompleted: true
+            });
+    });
+
+    it('shows partial-success copy when conversion fails after liquidity was removed', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
+        const failure = new Error('Swap reverted');
+        failure.removeLiquidityCompleted = true;
+        modal.getRemoveLiquidityAmountRaw = vi.fn(() => createAmount(1));
+        modal.executeRemoveLiquidityTransaction = vi.fn().mockRejectedValue(failure);
+        modal.loadUserBalances = vi.fn().mockResolvedValue(undefined);
+        globalThis.contractManager = {
+            isReady: vi.fn(() => true)
+        };
+        globalThis.notificationManager = {
+            info: vi.fn(),
+            success: vi.fn(),
+            error: vi.fn()
+        };
+
+        await modal.executeRemoveLiquidity();
+
+        expect(globalThis.notificationManager.error).toHaveBeenCalledWith(
+            expect.stringContaining('Liquidity was removed, but LIB conversion failed. Your returned tokens remain in your wallet.'),
+            { title: 'Conversion failed' }
+        );
+        expect(globalThis.notificationManager.error.mock.calls[0][0]).toContain('Details: Swap reverted');
     });
 
     it('approves the router when needed before removing liquidity', async () => {
@@ -1296,8 +1408,8 @@ describe('StakingModalNew zap cleanup', () => {
         }));
         expect(service.removeLiquidity).toHaveBeenCalledWith(expect.objectContaining({
             routerAddress: '0xrouter',
-            token0: '0xlib',
-            token1: '0xusdt',
+            token0: LIB_TOKEN_ADDRESS,
+            token1: USDT_TOKEN_ADDRESS,
             amount0Min: '99500000000000000000',
             amount1Min: '49750000000000000000',
             recipient: '0xuser'

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -50,8 +50,9 @@ function createDocumentMock() {
         getElementById: vi.fn(id => elements.get(id) || null),
         querySelector: vi.fn(() => null),
         querySelectorAll: vi.fn(selector => {
-            if (selector === '.zap-percentage-btn') {
-                return allElements.filter(element => element.classList.contains('zap-percentage-btn'));
+            if (selector.startsWith('.') && !selector.includes(' ')) {
+                const className = selector.slice(1).split('[')[0];
+                return allElements.filter(element => element.classList.contains(className));
             }
 
             return [];
@@ -1092,6 +1093,45 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('data-tooltip="Latest time this transaction can execute before it reverts."');
         expect(html).toContain('aria-label="Max Slippage: Maximum output movement allowed before the transaction reverts."');
         expect(html).not.toContain('class="remove-liquidity-settings-label"\n                            title=');
+    });
+
+    it('highlights custom remove-liquidity slippage when selected before typing a value', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.removeLiquiditySettingsOpen = true;
+
+        modal.setRemoveLiquiditySlippage('custom');
+        const html = modal.renderRemoveLiquidityTab();
+        const slippageButtons = [...html.matchAll(/<button[\s\S]*?class="([^"]*)"[\s\S]*?data-slippage="([^"]+)"[\s\S]*?>/g)]
+            .filter(([, className]) => className.includes('remove-liquidity-slippage-btn'));
+        const defaultButton = slippageButtons.find(([, , value]) => value === '50');
+        const customButton = slippageButtons.find(([, , value]) => value === 'custom');
+
+        expect(modal.removeLiquidityCustomSlippageSelected).toBe(true);
+        expect(defaultButton?.[1]).not.toContain('active');
+        expect(customButton?.[1]).toContain('active');
+    });
+
+    it('highlights custom remove-liquidity slippage when the input is focused', async () => {
+        const modal = await createLoadedModal();
+        const defaultButton = document.registerElement(createElement({
+            classes: ['zap-slippage-btn', 'remove-liquidity-slippage-btn', 'active']
+        }));
+        defaultButton.dataset.slippage = '50';
+        const customButton = document.registerElement(createElement({
+            classes: ['zap-slippage-btn', 'remove-liquidity-slippage-btn']
+        }));
+        customButton.dataset.slippage = 'custom';
+        const customInput = document.registerElement(createElement({
+            id: 'remove-liquidity-custom-slippage-input'
+        }));
+        const focusHandler = document.addEventListener.mock.calls.find(([eventName]) => eventName === 'focusin')?.[1];
+
+        focusHandler({ target: customInput });
+
+        expect(modal.removeLiquidityCustomSlippageSelected).toBe(true);
+        expect(defaultButton.classList.contains('active')).toBe(false);
+        expect(customButton.classList.contains('active')).toBe(true);
     });
 
     it('shows a readable over-balance warning on unchecked remove liquidity', async () => {

--- a/tests/v2-remove-liquidity-service.test.js
+++ b/tests/v2-remove-liquidity-service.test.js
@@ -82,7 +82,9 @@ const addresses = {
     token0: '0x2222222222222222222222222222222222222222',
     token1: '0x3333333333333333333333333333333333333333',
     factory: '0x8909dc15e40173ff4699343b6eb8132c65e18ec6',
+    factory97: '0x5555555555555555555555555555555555555555',
     router: '0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24',
+    router97: '0x6666666666666666666666666666666666666666',
     unknownFactory: '0x9999999999999999999999999999999999999999',
     user: '0x4444444444444444444444444444444444444444'
 };
@@ -99,6 +101,16 @@ async function loadService(contracts = {}) {
                         name: 'Uniswap V2',
                         type: 'uniswapV2',
                         router: addresses.router
+                    }
+                }
+            },
+            97: {
+                wrappedNative: '0xae13d989dac2f0debff460ac112a837c89baa7cd',
+                factories: {
+                    [addresses.factory97]: {
+                        name: 'PancakeSwap V2',
+                        type: 'uniswapV2',
+                        router: addresses.router97
                     }
                 }
             }
@@ -152,6 +164,10 @@ function createFixtures({ factory = addresses.factory, routerFactory = addresses
         },
         [addresses.router]: {
             factory: vi.fn().mockResolvedValue(routerFactory),
+            removeLiquidity
+        },
+        [addresses.router97]: {
+            factory: vi.fn().mockResolvedValue(addresses.factory97),
             removeLiquidity
         },
         approve,
@@ -208,6 +224,32 @@ describe('V2RemoveLiquidityService', () => {
         expect(adapter.supported).toBe(false);
         expect(adapter.factoryAddress).toBe(addresses.unknownFactory);
         expect(adapter.reason).toContain('not supported');
+    });
+
+    it('keeps pair metadata cache entries separate by chain', async () => {
+        const fixtures = createFixtures();
+        fixtures[addresses.lp].factory
+            .mockResolvedValueOnce(addresses.factory)
+            .mockResolvedValueOnce(addresses.factory97);
+        const V2RemoveLiquidityService = await loadService(fixtures);
+        const service = new V2RemoveLiquidityService();
+
+        const mainnetAdapter = await service.getMatchedAdapter({
+            chainId: 56,
+            lpTokenAddress: addresses.lp,
+            provider: {}
+        });
+        const testnetAdapter = await service.getMatchedAdapter({
+            chainId: 97,
+            lpTokenAddress: addresses.lp,
+            provider: {}
+        });
+
+        expect(mainnetAdapter.supported).toBe(true);
+        expect(mainnetAdapter.factoryAddress).toBe(addresses.factory);
+        expect(testnetAdapter.supported).toBe(true);
+        expect(testnetAdapter.factoryAddress).toBe(addresses.factory97);
+        expect(fixtures[addresses.lp].factory).toHaveBeenCalledTimes(2);
     });
 
     it('rejects configured routers whose factory does not match the LP factory', async () => {

--- a/tests/v2-remove-liquidity-service.test.js
+++ b/tests/v2-remove-liquidity-service.test.js
@@ -127,8 +127,6 @@ async function loadService(contracts = {}) {
 function createFixtures({ factory = addresses.factory, routerFactory = addresses.factory, allowance = unit(0) } = {}) {
     const approve = vi.fn().mockResolvedValue({ hash: '0xapprove', wait: vi.fn() });
     const removeLiquidity = vi.fn().mockResolvedValue({ hash: '0xremove', wait: vi.fn() });
-    const getAmountsOut = vi.fn().mockResolvedValue([bn(unit(10)), bn(unit(9))]);
-    const swapExactTokensForTokens = vi.fn().mockResolvedValue({ hash: '0xswap', wait: vi.fn() });
 
     return {
         [addresses.lp]: {
@@ -154,14 +152,10 @@ function createFixtures({ factory = addresses.factory, routerFactory = addresses
         },
         [addresses.router]: {
             factory: vi.fn().mockResolvedValue(routerFactory),
-            removeLiquidity,
-            getAmountsOut,
-            swapExactTokensForTokens
+            removeLiquidity
         },
         approve,
-        removeLiquidity,
-        getAmountsOut,
-        swapExactTokensForTokens
+        removeLiquidity
     };
 }
 
@@ -276,35 +270,4 @@ describe('V2RemoveLiquidityService', () => {
         );
     });
 
-    it('quotes and swaps returned tokens through the matched V2 router', async () => {
-        const fixtures = createFixtures();
-        const V2RemoveLiquidityService = await loadService(fixtures);
-        const service = new V2RemoveLiquidityService();
-
-        const quote = await service.getSwapQuote({
-            routerAddress: addresses.router,
-            amountIn: bn(unit(10)),
-            path: [addresses.token0, addresses.token1],
-            provider: {}
-        });
-        const tx = await service.swapExactTokensForTokens({
-            routerAddress: addresses.router,
-            amountIn: bn(unit(10)),
-            amountOutMin: service.calculateMinAmount(quote.amountOut, 50),
-            path: [addresses.token0, addresses.token1],
-            recipient: addresses.user,
-            deadline: 1777306663,
-            signer: {}
-        });
-
-        expect(quote.amountOut.toString()).toBe(unit(9).toString());
-        expect(tx.hash).toBe('0xswap');
-        expect(fixtures.swapExactTokensForTokens).toHaveBeenCalledWith(
-            expect.objectContaining({ value: unit(10) }),
-            expect.objectContaining({ value: 8955000000000000000n }),
-            [addresses.token0, addresses.token1],
-            addresses.user,
-            1777306663
-        );
-    });
 });

--- a/tests/v2-remove-liquidity-service.test.js
+++ b/tests/v2-remove-liquidity-service.test.js
@@ -23,12 +23,24 @@ class MockBigNumber {
         return new MockBigNumber(this.value / toBigIntValue(other));
     }
 
+    add(other) {
+        return new MockBigNumber(this.value + toBigIntValue(other));
+    }
+
+    sub(other) {
+        return new MockBigNumber(this.value - toBigIntValue(other));
+    }
+
     gte(other) {
         return this.value >= toBigIntValue(other);
     }
 
     lt(other) {
         return this.value < toBigIntValue(other);
+    }
+
+    lte(other) {
+        return this.value <= toBigIntValue(other);
     }
 
     eq(other) {
@@ -115,6 +127,8 @@ async function loadService(contracts = {}) {
 function createFixtures({ factory = addresses.factory, routerFactory = addresses.factory, allowance = unit(0) } = {}) {
     const approve = vi.fn().mockResolvedValue({ hash: '0xapprove', wait: vi.fn() });
     const removeLiquidity = vi.fn().mockResolvedValue({ hash: '0xremove', wait: vi.fn() });
+    const getAmountsOut = vi.fn().mockResolvedValue([bn(unit(10)), bn(unit(9))]);
+    const swapExactTokensForTokens = vi.fn().mockResolvedValue({ hash: '0xswap', wait: vi.fn() });
 
     return {
         [addresses.lp]: {
@@ -140,10 +154,14 @@ function createFixtures({ factory = addresses.factory, routerFactory = addresses
         },
         [addresses.router]: {
             factory: vi.fn().mockResolvedValue(routerFactory),
-            removeLiquidity
+            removeLiquidity,
+            getAmountsOut,
+            swapExactTokensForTokens
         },
         approve,
-        removeLiquidity
+        removeLiquidity,
+        getAmountsOut,
+        swapExactTokensForTokens
     };
 }
 
@@ -253,6 +271,38 @@ describe('V2RemoveLiquidityService', () => {
             expect.objectContaining({ value: unit(10) }),
             expect.objectContaining({ value: unit(99) }),
             expect.objectContaining({ value: unit(49) }),
+            addresses.user,
+            1777306663
+        );
+    });
+
+    it('quotes and swaps returned tokens through the matched V2 router', async () => {
+        const fixtures = createFixtures();
+        const V2RemoveLiquidityService = await loadService(fixtures);
+        const service = new V2RemoveLiquidityService();
+
+        const quote = await service.getSwapQuote({
+            routerAddress: addresses.router,
+            amountIn: bn(unit(10)),
+            path: [addresses.token0, addresses.token1],
+            provider: {}
+        });
+        const tx = await service.swapExactTokensForTokens({
+            routerAddress: addresses.router,
+            amountIn: bn(unit(10)),
+            amountOutMin: service.calculateMinAmount(quote.amountOut, 50),
+            path: [addresses.token0, addresses.token1],
+            recipient: addresses.user,
+            deadline: 1777306663,
+            signer: {}
+        });
+
+        expect(quote.amountOut.toString()).toBe(unit(9).toString());
+        expect(tx.hash).toBe('0xswap');
+        expect(fixtures.swapExactTokensForTokens).toHaveBeenCalledWith(
+            expect.objectContaining({ value: unit(10) }),
+            expect.objectContaining({ value: 8955000000000000000n }),
+            [addresses.token0, addresses.token1],
             addresses.user,
             1777306663
         );

--- a/tests/v2-remove-liquidity-service.test.js
+++ b/tests/v2-remove-liquidity-service.test.js
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function toBigIntValue(value) {
+    if (value instanceof MockBigNumber) {
+        return value.value;
+    }
+    if (typeof value === 'bigint') {
+        return value;
+    }
+    return BigInt(String(value));
+}
+
+class MockBigNumber {
+    constructor(value) {
+        this.value = BigInt(value);
+    }
+
+    mul(other) {
+        return new MockBigNumber(this.value * toBigIntValue(other));
+    }
+
+    div(other) {
+        return new MockBigNumber(this.value / toBigIntValue(other));
+    }
+
+    gte(other) {
+        return this.value >= toBigIntValue(other);
+    }
+
+    lt(other) {
+        return this.value < toBigIntValue(other);
+    }
+
+    eq(other) {
+        return this.value === toBigIntValue(other);
+    }
+
+    isZero() {
+        return this.value === 0n;
+    }
+
+    toString() {
+        return this.value.toString();
+    }
+}
+
+function bn(value) {
+    return new MockBigNumber(value);
+}
+
+function unit(value, decimals = 18) {
+    return BigInt(value) * (10n ** BigInt(decimals));
+}
+
+function formatUnits(value, decimals = 18) {
+    const raw = toBigIntValue(value);
+    const divisor = 10n ** BigInt(decimals);
+    const integer = raw / divisor;
+    const fraction = raw % divisor;
+    if (fraction === 0n) {
+        return integer.toString();
+    }
+
+    const fractionText = fraction.toString().padStart(decimals, '0').replace(/0+$/, '');
+    return `${integer}.${fractionText}`;
+}
+
+const addresses = {
+    lp: '0x1111111111111111111111111111111111111111',
+    token0: '0x2222222222222222222222222222222222222222',
+    token1: '0x3333333333333333333333333333333333333333',
+    factory: '0x8909dc15e40173ff4699343b6eb8132c65e18ec6',
+    router: '0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24',
+    unknownFactory: '0x9999999999999999999999999999999999999999',
+    user: '0x4444444444444444444444444444444444444444'
+};
+
+async function loadService(contracts = {}) {
+    vi.resetModules();
+    globalThis.window = globalThis;
+    globalThis.CONFIG = {
+        DEX_REMOVE_LIQUIDITY: {
+            56: {
+                wrappedNative: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
+                factories: {
+                    [addresses.factory]: {
+                        name: 'Uniswap V2',
+                        type: 'uniswapV2',
+                        router: addresses.router
+                    }
+                }
+            }
+        }
+    };
+    const Contract = vi.fn(function(address) {
+        const contract = contracts[String(address).toLowerCase()];
+        if (!contract) {
+            throw new Error(`Missing contract fixture for ${address}`);
+        }
+        return contract;
+    });
+
+    globalThis.ethers = {
+        BigNumber: { from: value => bn(value) },
+        utils: { formatUnits },
+        Contract
+    };
+    globalThis.console = console;
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await import('../js/services/v2-remove-liquidity-service.js');
+    return globalThis.V2RemoveLiquidityService;
+}
+
+function createFixtures({ factory = addresses.factory, routerFactory = addresses.factory, allowance = unit(0) } = {}) {
+    const approve = vi.fn().mockResolvedValue({ hash: '0xapprove', wait: vi.fn() });
+    const removeLiquidity = vi.fn().mockResolvedValue({ hash: '0xremove', wait: vi.fn() });
+
+    return {
+        [addresses.lp]: {
+            factory: vi.fn().mockResolvedValue(factory),
+            token0: vi.fn().mockResolvedValue(addresses.token0),
+            token1: vi.fn().mockResolvedValue(addresses.token1),
+            getReserves: vi.fn().mockResolvedValue([bn(unit(10000)), bn(unit(5000)), 0]),
+            totalSupply: vi.fn().mockResolvedValue(bn(unit(1000))),
+            decimals: vi.fn().mockResolvedValue(18),
+            allowance: vi.fn().mockResolvedValue(bn(allowance)),
+            balanceOf: vi.fn().mockResolvedValue(bn(unit(10))),
+            approve
+        },
+        [addresses.token0]: {
+            symbol: vi.fn().mockResolvedValue('LIB'),
+            name: vi.fn().mockResolvedValue('Liberdus'),
+            decimals: vi.fn().mockResolvedValue(18)
+        },
+        [addresses.token1]: {
+            symbol: vi.fn().mockResolvedValue('USDT'),
+            name: vi.fn().mockResolvedValue('Tether USD'),
+            decimals: vi.fn().mockResolvedValue(18)
+        },
+        [addresses.router]: {
+            factory: vi.fn().mockResolvedValue(routerFactory),
+            removeLiquidity
+        },
+        approve,
+        removeLiquidity
+    };
+}
+
+describe('V2RemoveLiquidityService', () => {
+    beforeEach(() => {
+        vi.useRealTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        delete globalThis.window;
+        delete globalThis.CONFIG;
+        delete globalThis.ethers;
+        delete globalThis.V2RemoveLiquidityService;
+    });
+
+    it('matches an allowlisted factory and calculates output previews', async () => {
+        const fixtures = createFixtures();
+        const V2RemoveLiquidityService = await loadService(fixtures);
+        const service = new V2RemoveLiquidityService();
+
+        const preview = await service.getPreview({
+            chainId: 56,
+            lpTokenAddress: addresses.lp,
+            liquidityRaw: bn(unit(10)),
+            slippageBps: 50,
+            provider: {}
+        });
+
+        expect(preview.supported).toBe(true);
+        expect(preview.adapter.routerAddress).toBe(addresses.router);
+        expect(preview.token0.amount.formatted).toBe('100');
+        expect(preview.token1.amount.formatted).toBe('50');
+        expect(preview.token0.minAmount.formatted).toBe('99.5');
+        expect(preview.token1.minAmount.formatted).toBe('49.75');
+    });
+
+    it('returns unsupported metadata for unknown factories', async () => {
+        const fixtures = createFixtures({ factory: addresses.unknownFactory });
+        const V2RemoveLiquidityService = await loadService(fixtures);
+        const service = new V2RemoveLiquidityService();
+
+        const adapter = await service.getMatchedAdapter({
+            chainId: 56,
+            lpTokenAddress: addresses.lp,
+            provider: {}
+        });
+
+        expect(adapter.supported).toBe(false);
+        expect(adapter.factoryAddress).toBe(addresses.unknownFactory);
+        expect(adapter.reason).toContain('not supported');
+    });
+
+    it('rejects configured routers whose factory does not match the LP factory', async () => {
+        const fixtures = createFixtures({ routerFactory: addresses.unknownFactory });
+        const V2RemoveLiquidityService = await loadService(fixtures);
+        const service = new V2RemoveLiquidityService();
+
+        await expect(service.getMatchedAdapter({
+            chainId: 56,
+            lpTokenAddress: addresses.lp,
+            provider: {}
+        })).rejects.toThrow('router does not match');
+    });
+
+    it('approves the router only when allowance is insufficient', async () => {
+        const fixtures = createFixtures({ allowance: unit(1) });
+        const V2RemoveLiquidityService = await loadService(fixtures);
+        const service = new V2RemoveLiquidityService();
+        const signer = { provider: {}, getAddress: vi.fn().mockResolvedValue(addresses.user) };
+
+        const tx = await service.approveIfNeeded({
+            lpTokenAddress: addresses.lp,
+            spender: addresses.router,
+            liquidityRaw: bn(unit(10)),
+            signer
+        });
+
+        expect(tx.hash).toBe('0xapprove');
+        expect(fixtures.approve).toHaveBeenCalledWith(addresses.router, expect.objectContaining({
+            value: unit(10)
+        }));
+    });
+
+    it('builds removeLiquidity transactions with token and min-output arguments', async () => {
+        const fixtures = createFixtures();
+        const V2RemoveLiquidityService = await loadService(fixtures);
+        const service = new V2RemoveLiquidityService();
+
+        const tx = await service.removeLiquidity({
+            routerAddress: addresses.router,
+            token0: addresses.token0,
+            token1: addresses.token1,
+            liquidityRaw: bn(unit(10)),
+            amount0Min: bn(unit(99)),
+            amount1Min: bn(unit(49)),
+            recipient: addresses.user,
+            deadline: 1777306663,
+            signer: {}
+        });
+
+        expect(tx.hash).toBe('0xremove');
+        expect(fixtures.removeLiquidity).toHaveBeenCalledWith(
+            addresses.token0,
+            addresses.token1,
+            expect.objectContaining({ value: unit(10) }),
+            expect.objectContaining({ value: unit(99) }),
+            expect.objectContaining({ value: unit(49) }),
+            addresses.user,
+            1777306663
+        );
+    });
+});

--- a/tests/v2-remove-liquidity-service.test.js
+++ b/tests/v2-remove-liquidity-service.test.js
@@ -252,6 +252,55 @@ describe('V2RemoveLiquidityService', () => {
         expect(fixtures[addresses.lp].factory).toHaveBeenCalledTimes(2);
     });
 
+    it('keeps token metadata cache entries separate by chain', async () => {
+        const fixtures = createFixtures();
+        fixtures[addresses.lp].factory
+            .mockResolvedValueOnce(addresses.factory)
+            .mockResolvedValueOnce(addresses.factory97);
+        fixtures[addresses.token0].symbol
+            .mockResolvedValueOnce('LIB')
+            .mockResolvedValueOnce('TLIB');
+        fixtures[addresses.token0].name
+            .mockResolvedValueOnce('Liberdus')
+            .mockResolvedValueOnce('Test Liberdus');
+        fixtures[addresses.token0].decimals
+            .mockResolvedValueOnce(18)
+            .mockResolvedValueOnce(6);
+        fixtures[addresses.token1].symbol
+            .mockResolvedValueOnce('USDT')
+            .mockResolvedValueOnce('TUSDT');
+        fixtures[addresses.token1].name
+            .mockResolvedValueOnce('Tether USD')
+            .mockResolvedValueOnce('Test Tether USD');
+        fixtures[addresses.token1].decimals
+            .mockResolvedValueOnce(18)
+            .mockResolvedValueOnce(6);
+        const V2RemoveLiquidityService = await loadService(fixtures);
+        const service = new V2RemoveLiquidityService();
+
+        const mainnetPreview = await service.getPreview({
+            chainId: 56,
+            lpTokenAddress: addresses.lp,
+            liquidityRaw: bn(unit(10)),
+            provider: {}
+        });
+        const testnetPreview = await service.getPreview({
+            chainId: 97,
+            lpTokenAddress: addresses.lp,
+            liquidityRaw: bn(unit(10)),
+            provider: {}
+        });
+
+        expect(mainnetPreview.token0.symbol).toBe('LIB');
+        expect(mainnetPreview.token0.decimals).toBe(18);
+        expect(testnetPreview.token0.symbol).toBe('TLIB');
+        expect(testnetPreview.token0.decimals).toBe(6);
+        expect(testnetPreview.token1.symbol).toBe('TUSDT');
+        expect(testnetPreview.token1.decimals).toBe(6);
+        expect(fixtures[addresses.token0].symbol).toHaveBeenCalledTimes(2);
+        expect(fixtures[addresses.token1].symbol).toHaveBeenCalledTimes(2);
+    });
+
     it('rejects configured routers whose factory does not match the LP factory', async () => {
         const fixtures = createFixtures({ routerFactory: addresses.unknownFactory });
         const V2RemoveLiquidityService = await loadService(fixtures);


### PR DESCRIPTION
## What Changed

This PR adds a guided V2 remove-liquidity flow for supported LP pools from the staking modal.

- `V2RemoveLiquidityService` reads LP metadata, validates the allowlisted factory/router pairing, calculates token output previews, checks balances/allowances, and executes V2 `removeLiquidity`.
- `StakingModalNew` adds a dedicated `Remove LP` tab with amount controls, slippage/deadline settings, previews, router approvals, remove-liquidity execution, and Kyber zap-out support for converting removed liquidity to one output token.
- `CONFIG.DEX_REMOVE_LIQUIDITY` defines the BSC factory/router allowlist for Uniswap V2 and PancakeSwap V2 compatible pools.
- Kyber zap-out quote/build helpers support the optional one-token exit path, including clearer preview errors for zero-liquidity Kyber responses.
- Tests cover service adapter matching, preview math, unsupported factories, router validation, approvals, remove-liquidity execution, Kyber zap-out handling, and modal state behavior.

## Fixed Flow

1. User opens a supported LP pair in the staking modal and selects `Remove LP`.
2. User enters a wallet LP amount and optionally enables conversion to a preferred output token.
3. The app previews the expected outputs, validates router/factory safety, and blocks unsupported routes with a clear message.
4. On execution, the app requests any needed approval, removes liquidity through the matched V2 router, optionally performs zap-out conversion, then refreshes balances.

## Why

Users could unstake LP tokens but had no guided in-app path to exit the underlying V2 LP position. This keeps unstaking separate from LP removal while adding the frontend orchestration needed for safe router matching, output previews, approvals, execution, and clear unsupported/error states.

## Validation

- `npm test -- --run tests/kyber-zap-service.test.js tests/v2-remove-liquidity-service.test.js tests/staking-modal-new.test.js`

Closes #231
