### PR TITLE
Split Remove LP 01: V2 service foundation

### DIFF
--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -198,6 +198,26 @@ window.CONFIG = {
         }
     },
 
+    // Explicit V2 DEX allowlist for guided remove-liquidity flows.
+    // Routers are intentionally configured here because they cannot be safely discovered from LP pairs.
+    DEX_REMOVE_LIQUIDITY: {
+        56: {
+            wrappedNative: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
+            factories: {
+                '0x8909dc15e40173ff4699343b6eb8132c65e18ec6': {
+                    name: 'Uniswap V2',
+                    type: 'uniswapV2',
+                    router: '0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24'
+                },
+                '0xca143ce32fe78f1f7019d7d551a6402fc5350c73': {
+                    name: 'PancakeSwap V2',
+                    type: 'uniswapV2',
+                    router: '0x10ed43c718714eb63d5aa57b78b54704e256024e'
+                }
+            }
+        }
+    },
+
     // Platform Configuration
     PLATFORMS: {
         // Available platforms for dropdown (matches contract values)

--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -170,6 +170,7 @@ class MasterInitializer {
             'js/components/home-page.js',
             'js/services/kyber-zap-rate-limiter.js',
             'js/services/kyber-zap-service.js',
+            'js/services/v2-remove-liquidity-service.js',
             'js/components/staking-modal-new.js'
         ];
         console.log('Loading homepage UI components');

--- a/js/services/v2-remove-liquidity-service.js
+++ b/js/services/v2-remove-liquidity-service.js
@@ -1,0 +1,424 @@
+/**
+ * V2RemoveLiquidityService - Uniswap V2-compatible remove-liquidity helpers.
+ *
+ * The router allowlist is explicit by chain/factory because LP pairs do not expose
+ * a trusted router address.
+ */
+(function(global) {
+    'use strict';
+
+    if (global.V2RemoveLiquidityService) {
+        console.warn('V2RemoveLiquidityService already exists, skipping redeclaration');
+        return;
+    }
+
+    class V2RemoveLiquidityService {
+        constructor(options = {}) {
+            this.global = options.global || global;
+            this.pairMetaCache = new Map();
+            this.tokenMetaCache = new Map();
+        }
+
+        getConfig() {
+            return this.global.CONFIG?.DEX_REMOVE_LIQUIDITY || {};
+        }
+
+        getEthers() {
+            const ethers = this.global.ethers;
+            if (!ethers) {
+                throw new Error('Ethers.js is not available.');
+            }
+            return ethers;
+        }
+
+        getProvider(provider) {
+            return provider
+                || this.global.contractManager?.provider
+                || this.global.walletManager?.provider
+                || null;
+        }
+
+        getCurrentChainId() {
+            const chainId = this.global.networkSelector?.getCurrentChainId?.()
+                ?? this.global.contractManager?.getCurrentChainIdSafe?.()
+                ?? this.global.walletManager?.networkManager?.getCurrentChainId?.();
+            const parsed = typeof chainId === 'string' ? Number(chainId) : chainId;
+            return Number.isFinite(parsed) ? parsed : null;
+        }
+
+        getChainConfig(chainId = this.getCurrentChainId()) {
+            if (chainId === null || chainId === undefined) {
+                return null;
+            }
+
+            return this.getConfig()?.[String(chainId)] || this.getConfig()?.[Number(chainId)] || null;
+        }
+
+        normalizeAddress(address) {
+            return typeof address === 'string' ? address.toLowerCase() : '';
+        }
+
+        getPairMetaCacheKey(lpTokenAddress, chainId = this.getCurrentChainId()) {
+            const parsedChainId = typeof chainId === 'string' ? Number(chainId) : chainId;
+            const chainKey = Number.isFinite(parsedChainId) ? String(parsedChainId) : 'unknown';
+            return `${chainKey}:${this.normalizeAddress(lpTokenAddress)}`;
+        }
+
+        getTokenMetaCacheKey(address, chainId = this.getCurrentChainId()) {
+            const parsedChainId = typeof chainId === 'string' ? Number(chainId) : chainId;
+            const chainKey = Number.isFinite(parsedChainId) ? String(parsedChainId) : 'unknown';
+            return `${chainKey}:${this.normalizeAddress(address)}`;
+        }
+
+        toBigNumber(value) {
+            const ethers = this.getEthers();
+            return ethers.BigNumber?.from ? ethers.BigNumber.from(value) : BigInt(value);
+        }
+
+        formatUnits(value, decimals = 18) {
+            const ethers = this.getEthers();
+            if (ethers.utils?.formatUnits) {
+                return ethers.utils.formatUnits(value, decimals);
+            }
+            if (ethers.formatUnits) {
+                return ethers.formatUnits(value, decimals);
+            }
+            return String(value);
+        }
+
+        getPairAbi() {
+            return [
+                'function factory() view returns (address)',
+                'function token0() view returns (address)',
+                'function token1() view returns (address)',
+                'function getReserves() view returns (uint112,uint112,uint32)',
+                'function totalSupply() view returns (uint256)',
+                'function decimals() view returns (uint8)'
+            ];
+        }
+
+        getRouterAbi() {
+            return [
+                'function factory() view returns (address)',
+                'function removeLiquidity(address tokenA,address tokenB,uint256 liquidity,uint256 amountAMin,uint256 amountBMin,address to,uint256 deadline) returns (uint256 amountA,uint256 amountB)'
+            ];
+        }
+
+        getErc20Abi() {
+            return [
+                'function allowance(address owner,address spender) view returns (uint256)',
+                'function approve(address spender,uint256 amount) returns (bool)',
+                'function balanceOf(address owner) view returns (uint256)',
+                'function decimals() view returns (uint8)',
+                'function symbol() view returns (string)',
+                'function name() view returns (string)'
+            ];
+        }
+
+        createContract(address, abi, runner) {
+            const ethers = this.getEthers();
+            return new ethers.Contract(address, abi, runner);
+        }
+
+        async readPairMeta(lpTokenAddress, provider = this.getProvider(), chainId = this.getCurrentChainId()) {
+            if (!lpTokenAddress || !provider) {
+                throw new Error('LP token address and provider are required.');
+            }
+
+            const cacheKey = this.getPairMetaCacheKey(lpTokenAddress, chainId);
+            if (this.pairMetaCache.has(cacheKey)) {
+                return this.pairMetaCache.get(cacheKey);
+            }
+
+            const pairContract = this.createContract(lpTokenAddress, this.getPairAbi(), provider);
+            const [factoryAddress, token0Address, token1Address, lpDecimals] = await Promise.all([
+                pairContract.factory(),
+                pairContract.token0(),
+                pairContract.token1(),
+                pairContract.decimals().catch(() => 18)
+            ]);
+
+            const pairMeta = {
+                lpTokenAddress,
+                factoryAddress,
+                token0Address,
+                token1Address,
+                lpDecimals: Number(lpDecimals) || 18
+            };
+
+            this.pairMetaCache.set(cacheKey, pairMeta);
+            return pairMeta;
+        }
+
+        async validateRouterFactory({ routerAddress, factoryAddress, provider = this.getProvider() }) {
+            if (!routerAddress || !factoryAddress || !provider) {
+                throw new Error('Router, factory, and provider are required for router validation.');
+            }
+
+            const routerContract = this.createContract(routerAddress, this.getRouterAbi(), provider);
+            const routerFactory = await routerContract.factory();
+            if (this.normalizeAddress(routerFactory) !== this.normalizeAddress(factoryAddress)) {
+                throw new Error('Configured remove-liquidity router does not match the LP factory.');
+            }
+
+            return true;
+        }
+
+        async getMatchedAdapter({ chainId = this.getCurrentChainId(), lpTokenAddress, provider = this.getProvider() }) {
+            const resolvedChainId = Number(chainId);
+            if (!Number.isFinite(resolvedChainId)) {
+                return {
+                    supported: false,
+                    reason: 'Unable to determine the selected chain.'
+                };
+            }
+
+            const chainConfig = this.getChainConfig(resolvedChainId);
+            if (!chainConfig) {
+                return {
+                    supported: false,
+                    chainId: resolvedChainId,
+                    reason: 'Remove liquidity is not configured for this network.'
+                };
+            }
+
+            const pairMeta = await this.readPairMeta(lpTokenAddress, provider, resolvedChainId);
+            const factoryKey = this.normalizeAddress(pairMeta.factoryAddress);
+            const factoryConfig = chainConfig.factories?.[factoryKey] || null;
+
+            if (!factoryConfig?.router) {
+                return {
+                    supported: false,
+                    chainId: resolvedChainId,
+                    factoryAddress: pairMeta.factoryAddress,
+                    reason: 'This LP factory is not supported for guided remove liquidity.'
+                };
+            }
+
+            await this.validateRouterFactory({
+                routerAddress: factoryConfig.router,
+                factoryAddress: pairMeta.factoryAddress,
+                provider
+            });
+
+            return {
+                supported: true,
+                chainId: resolvedChainId,
+                wrappedNative: chainConfig.wrappedNative,
+                factoryAddress: pairMeta.factoryAddress,
+                routerAddress: factoryConfig.router,
+                name: factoryConfig.name,
+                type: factoryConfig.type,
+                pairMeta
+            };
+        }
+
+        async getTokenMetadata(address, provider = this.getProvider(), chainId = this.getCurrentChainId()) {
+            const cacheKey = this.getTokenMetaCacheKey(address, chainId);
+            if (this.tokenMetaCache.has(cacheKey)) {
+                return this.tokenMetaCache.get(cacheKey);
+            }
+
+            const tokenContract = this.createContract(address, this.getErc20Abi(), provider);
+            const [symbol, name, decimals] = await Promise.all([
+                tokenContract.symbol().catch(() => 'TOKEN'),
+                tokenContract.name().catch(() => 'Token'),
+                tokenContract.decimals().catch(() => 18)
+            ]);
+
+            const metadata = {
+                address,
+                symbol: typeof symbol === 'string' && symbol.trim() ? symbol.trim() : 'TOKEN',
+                name: typeof name === 'string' && name.trim() ? name.trim() : 'Token',
+                decimals: Number(decimals) || 18
+            };
+
+            this.tokenMetaCache.set(cacheKey, metadata);
+            return metadata;
+        }
+
+        calculateMinAmount(amount, slippageBps) {
+            const bps = Number(slippageBps);
+            if (!Number.isFinite(bps) || bps < 0 || bps > 10000) {
+                throw new Error('Slippage must be between 0 and 10000 bps.');
+            }
+
+            return amount.mul(10000 - Math.trunc(bps)).div(10000);
+        }
+
+        async getPreview({ chainId = this.getCurrentChainId(), lpTokenAddress, liquidityRaw, slippageBps = 50, provider = this.getProvider() }) {
+            if (!liquidityRaw) {
+                throw new Error('Liquidity amount is required.');
+            }
+
+            const adapter = await this.getMatchedAdapter({ chainId, lpTokenAddress, provider });
+            if (!adapter.supported) {
+                return adapter;
+            }
+
+            const pairContract = this.createContract(lpTokenAddress, this.getPairAbi(), provider);
+            const [reserves, totalSupplyRaw] = await Promise.all([
+                pairContract.getReserves(),
+                pairContract.totalSupply()
+            ]);
+
+            const reserve0 = this.toBigNumber(reserves[0]);
+            const reserve1 = this.toBigNumber(reserves[1]);
+            const totalSupply = this.toBigNumber(totalSupplyRaw);
+            const liquidity = this.toBigNumber(liquidityRaw);
+
+            if (totalSupply.isZero?.() || totalSupply.eq?.(0)) {
+                throw new Error('LP total supply is zero.');
+            }
+
+            const amount0 = liquidity.mul(reserve0).div(totalSupply);
+            const amount1 = liquidity.mul(reserve1).div(totalSupply);
+            const amount0Min = this.calculateMinAmount(amount0, slippageBps);
+            const amount1Min = this.calculateMinAmount(amount1, slippageBps);
+            const [token0Meta, token1Meta] = await Promise.all([
+                this.getTokenMetadata(adapter.pairMeta.token0Address, provider, adapter.chainId),
+                this.getTokenMetadata(adapter.pairMeta.token1Address, provider, adapter.chainId)
+            ]);
+
+            return {
+                supported: true,
+                adapter,
+                lpToken: {
+                    address: lpTokenAddress,
+                    decimals: adapter.pairMeta.lpDecimals,
+                    liquidity: {
+                        raw: liquidity.toString(),
+                        formatted: this.formatUnits(liquidity, adapter.pairMeta.lpDecimals)
+                    },
+                    totalSupply: {
+                        raw: totalSupply.toString(),
+                        formatted: this.formatUnits(totalSupply, adapter.pairMeta.lpDecimals)
+                    }
+                },
+                token0: {
+                    ...token0Meta,
+                    reserve: {
+                        raw: reserve0.toString(),
+                        formatted: this.formatUnits(reserve0, token0Meta.decimals)
+                    },
+                    amount: {
+                        raw: amount0.toString(),
+                        formatted: this.formatUnits(amount0, token0Meta.decimals)
+                    },
+                    minAmount: {
+                        raw: amount0Min.toString(),
+                        formatted: this.formatUnits(amount0Min, token0Meta.decimals)
+                    }
+                },
+                token1: {
+                    ...token1Meta,
+                    reserve: {
+                        raw: reserve1.toString(),
+                        formatted: this.formatUnits(reserve1, token1Meta.decimals)
+                    },
+                    amount: {
+                        raw: amount1.toString(),
+                        formatted: this.formatUnits(amount1, token1Meta.decimals)
+                    },
+                    minAmount: {
+                        raw: amount1Min.toString(),
+                        formatted: this.formatUnits(amount1Min, token1Meta.decimals)
+                    }
+                },
+                slippageBps: Number(slippageBps)
+            };
+        }
+
+        async getAllowance({ lpTokenAddress, owner, spender, provider = this.getProvider() }) {
+            if (!lpTokenAddress || !owner || !spender || !provider) {
+                throw new Error('LP token, owner, spender, and provider are required for allowance checks.');
+            }
+
+            return this.getTokenAllowance({ tokenAddress: lpTokenAddress, owner, spender, provider });
+        }
+
+        async getBalance({ lpTokenAddress, owner, provider = this.getProvider() }) {
+            if (!lpTokenAddress || !owner || !provider) {
+                throw new Error('LP token, owner, and provider are required for balance checks.');
+            }
+
+            return this.getTokenBalance({ tokenAddress: lpTokenAddress, owner, provider });
+        }
+
+        async getTokenAllowance({ tokenAddress, owner, spender, provider = this.getProvider() }) {
+            if (!tokenAddress || !owner || !spender || !provider) {
+                throw new Error('Token, owner, spender, and provider are required for allowance checks.');
+            }
+
+            const tokenContract = this.createContract(tokenAddress, this.getErc20Abi(), provider);
+            return tokenContract.allowance(owner, spender);
+        }
+
+        async getTokenBalance({ tokenAddress, owner, provider = this.getProvider() }) {
+            if (!tokenAddress || !owner || !provider) {
+                throw new Error('Token, owner, and provider are required for balance checks.');
+            }
+
+            const tokenContract = this.createContract(tokenAddress, this.getErc20Abi(), provider);
+            return tokenContract.balanceOf(owner);
+        }
+
+        async approveIfNeeded({ lpTokenAddress, spender, liquidityRaw, signer }) {
+            if (!lpTokenAddress || !spender || !liquidityRaw || !signer) {
+                throw new Error('LP token, spender, liquidity amount, and signer are required for approval.');
+            }
+
+            return this.approveTokenIfNeeded({
+                tokenAddress: lpTokenAddress,
+                spender,
+                amountRaw: liquidityRaw,
+                signer
+            });
+        }
+
+        async approveTokenIfNeeded({ tokenAddress, spender, amountRaw, signer }) {
+            if (!tokenAddress || !spender || !amountRaw || !signer) {
+                throw new Error('Token, spender, amount, and signer are required for approval.');
+            }
+
+            const owner = await signer.getAddress();
+            const allowance = await this.getTokenAllowance({
+                tokenAddress,
+                owner,
+                spender,
+                provider: signer.provider || this.getProvider()
+            });
+            const amount = this.toBigNumber(amountRaw);
+
+            if (allowance.gte(amount)) {
+                return null;
+            }
+
+            const tokenContract = this.createContract(tokenAddress, this.getErc20Abi(), signer);
+            return tokenContract.approve(spender, amount);
+        }
+
+        async removeLiquidity({ routerAddress, token0, token1, liquidityRaw, amount0Min, amount1Min, recipient, deadline, signer }) {
+            if (!routerAddress || !token0 || !token1 || !liquidityRaw || !recipient || !deadline || !signer) {
+                throw new Error('Router, tokens, liquidity amount, recipient, deadline, and signer are required.');
+            }
+
+            const routerContract = this.createContract(routerAddress, this.getRouterAbi(), signer);
+            return routerContract.removeLiquidity(
+                token0,
+                token1,
+                this.toBigNumber(liquidityRaw),
+                this.toBigNumber(amount0Min),
+                this.toBigNumber(amount1Min),
+                recipient,
+                deadline
+            );
+        }
+    }
+
+    global.V2RemoveLiquidityService = V2RemoveLiquidityService;
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = { V2RemoveLiquidityService };
+    }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/tests/v2-remove-liquidity-service.test.js
+++ b/tests/v2-remove-liquidity-service.test.js
@@ -1,0 +1,364 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function toBigIntValue(value) {
+    if (value instanceof MockBigNumber) {
+        return value.value;
+    }
+    if (typeof value === 'bigint') {
+        return value;
+    }
+    return BigInt(String(value));
+}
+
+class MockBigNumber {
+    constructor(value) {
+        this.value = BigInt(value);
+    }
+
+    mul(other) {
+        return new MockBigNumber(this.value * toBigIntValue(other));
+    }
+
+    div(other) {
+        return new MockBigNumber(this.value / toBigIntValue(other));
+    }
+
+    add(other) {
+        return new MockBigNumber(this.value + toBigIntValue(other));
+    }
+
+    sub(other) {
+        return new MockBigNumber(this.value - toBigIntValue(other));
+    }
+
+    gte(other) {
+        return this.value >= toBigIntValue(other);
+    }
+
+    lt(other) {
+        return this.value < toBigIntValue(other);
+    }
+
+    lte(other) {
+        return this.value <= toBigIntValue(other);
+    }
+
+    eq(other) {
+        return this.value === toBigIntValue(other);
+    }
+
+    isZero() {
+        return this.value === 0n;
+    }
+
+    toString() {
+        return this.value.toString();
+    }
+}
+
+function bn(value) {
+    return new MockBigNumber(value);
+}
+
+function unit(value, decimals = 18) {
+    return BigInt(value) * (10n ** BigInt(decimals));
+}
+
+function formatUnits(value, decimals = 18) {
+    const raw = toBigIntValue(value);
+    const divisor = 10n ** BigInt(decimals);
+    const integer = raw / divisor;
+    const fraction = raw % divisor;
+    if (fraction === 0n) {
+        return integer.toString();
+    }
+
+    const fractionText = fraction.toString().padStart(decimals, '0').replace(/0+$/, '');
+    return `${integer}.${fractionText}`;
+}
+
+const addresses = {
+    lp: '0x1111111111111111111111111111111111111111',
+    token0: '0x2222222222222222222222222222222222222222',
+    token1: '0x3333333333333333333333333333333333333333',
+    factory: '0x8909dc15e40173ff4699343b6eb8132c65e18ec6',
+    factory97: '0x5555555555555555555555555555555555555555',
+    router: '0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24',
+    router97: '0x6666666666666666666666666666666666666666',
+    unknownFactory: '0x9999999999999999999999999999999999999999',
+    user: '0x4444444444444444444444444444444444444444'
+};
+
+async function loadService(contracts = {}) {
+    vi.resetModules();
+    globalThis.window = globalThis;
+    globalThis.CONFIG = {
+        DEX_REMOVE_LIQUIDITY: {
+            56: {
+                wrappedNative: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
+                factories: {
+                    [addresses.factory]: {
+                        name: 'Uniswap V2',
+                        type: 'uniswapV2',
+                        router: addresses.router
+                    }
+                }
+            },
+            97: {
+                wrappedNative: '0xae13d989dac2f0debff460ac112a837c89baa7cd',
+                factories: {
+                    [addresses.factory97]: {
+                        name: 'PancakeSwap V2',
+                        type: 'uniswapV2',
+                        router: addresses.router97
+                    }
+                }
+            }
+        }
+    };
+    const Contract = vi.fn(function(address) {
+        const contract = contracts[String(address).toLowerCase()];
+        if (!contract) {
+            throw new Error(`Missing contract fixture for ${address}`);
+        }
+        return contract;
+    });
+
+    globalThis.ethers = {
+        BigNumber: { from: value => bn(value) },
+        utils: { formatUnits },
+        Contract
+    };
+    globalThis.console = console;
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await import('../js/services/v2-remove-liquidity-service.js');
+    return globalThis.V2RemoveLiquidityService;
+}
+
+function createFixtures({ factory = addresses.factory, routerFactory = addresses.factory, allowance = unit(0) } = {}) {
+    const approve = vi.fn().mockResolvedValue({ hash: '0xapprove', wait: vi.fn() });
+    const removeLiquidity = vi.fn().mockResolvedValue({ hash: '0xremove', wait: vi.fn() });
+
+    return {
+        [addresses.lp]: {
+            factory: vi.fn().mockResolvedValue(factory),
+            token0: vi.fn().mockResolvedValue(addresses.token0),
+            token1: vi.fn().mockResolvedValue(addresses.token1),
+            getReserves: vi.fn().mockResolvedValue([bn(unit(10000)), bn(unit(5000)), 0]),
+            totalSupply: vi.fn().mockResolvedValue(bn(unit(1000))),
+            decimals: vi.fn().mockResolvedValue(18),
+            allowance: vi.fn().mockResolvedValue(bn(allowance)),
+            balanceOf: vi.fn().mockResolvedValue(bn(unit(10))),
+            approve
+        },
+        [addresses.token0]: {
+            symbol: vi.fn().mockResolvedValue('LIB'),
+            name: vi.fn().mockResolvedValue('Liberdus'),
+            decimals: vi.fn().mockResolvedValue(18)
+        },
+        [addresses.token1]: {
+            symbol: vi.fn().mockResolvedValue('USDT'),
+            name: vi.fn().mockResolvedValue('Tether USD'),
+            decimals: vi.fn().mockResolvedValue(18)
+        },
+        [addresses.router]: {
+            factory: vi.fn().mockResolvedValue(routerFactory),
+            removeLiquidity
+        },
+        [addresses.router97]: {
+            factory: vi.fn().mockResolvedValue(addresses.factory97),
+            removeLiquidity
+        },
+        approve,
+        removeLiquidity
+    };
+}
+
+describe('V2RemoveLiquidityService', () => {
+    beforeEach(() => {
+        vi.useRealTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        delete globalThis.window;
+        delete globalThis.CONFIG;
+        delete globalThis.ethers;
+        delete globalThis.V2RemoveLiquidityService;
+    });
+
+    it('matches an allowlisted factory and calculates output previews', async () => {
+        const fixtures = createFixtures();
+        const V2RemoveLiquidityService = await loadService(fixtures);
+        const service = new V2RemoveLiquidityService();
+
+        const preview = await service.getPreview({
+            chainId: 56,
+            lpTokenAddress: addresses.lp,
+            liquidityRaw: bn(unit(10)),
+            slippageBps: 50,
+            provider: {}
+        });
+
+        expect(preview.supported).toBe(true);
+        expect(preview.adapter.routerAddress).toBe(addresses.router);
+        expect(preview.token0.amount.formatted).toBe('100');
+        expect(preview.token1.amount.formatted).toBe('50');
+        expect(preview.token0.minAmount.formatted).toBe('99.5');
+        expect(preview.token1.minAmount.formatted).toBe('49.75');
+    });
+
+    it('returns unsupported metadata for unknown factories', async () => {
+        const fixtures = createFixtures({ factory: addresses.unknownFactory });
+        const V2RemoveLiquidityService = await loadService(fixtures);
+        const service = new V2RemoveLiquidityService();
+
+        const adapter = await service.getMatchedAdapter({
+            chainId: 56,
+            lpTokenAddress: addresses.lp,
+            provider: {}
+        });
+
+        expect(adapter.supported).toBe(false);
+        expect(adapter.factoryAddress).toBe(addresses.unknownFactory);
+        expect(adapter.reason).toContain('not supported');
+    });
+
+    it('keeps pair metadata cache entries separate by chain', async () => {
+        const fixtures = createFixtures();
+        fixtures[addresses.lp].factory
+            .mockResolvedValueOnce(addresses.factory)
+            .mockResolvedValueOnce(addresses.factory97);
+        const V2RemoveLiquidityService = await loadService(fixtures);
+        const service = new V2RemoveLiquidityService();
+
+        const mainnetAdapter = await service.getMatchedAdapter({
+            chainId: 56,
+            lpTokenAddress: addresses.lp,
+            provider: {}
+        });
+        const testnetAdapter = await service.getMatchedAdapter({
+            chainId: 97,
+            lpTokenAddress: addresses.lp,
+            provider: {}
+        });
+
+        expect(mainnetAdapter.supported).toBe(true);
+        expect(mainnetAdapter.factoryAddress).toBe(addresses.factory);
+        expect(testnetAdapter.supported).toBe(true);
+        expect(testnetAdapter.factoryAddress).toBe(addresses.factory97);
+        expect(fixtures[addresses.lp].factory).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps token metadata cache entries separate by chain', async () => {
+        const fixtures = createFixtures();
+        fixtures[addresses.lp].factory
+            .mockResolvedValueOnce(addresses.factory)
+            .mockResolvedValueOnce(addresses.factory97);
+        fixtures[addresses.token0].symbol
+            .mockResolvedValueOnce('LIB')
+            .mockResolvedValueOnce('TLIB');
+        fixtures[addresses.token0].name
+            .mockResolvedValueOnce('Liberdus')
+            .mockResolvedValueOnce('Test Liberdus');
+        fixtures[addresses.token0].decimals
+            .mockResolvedValueOnce(18)
+            .mockResolvedValueOnce(6);
+        fixtures[addresses.token1].symbol
+            .mockResolvedValueOnce('USDT')
+            .mockResolvedValueOnce('TUSDT');
+        fixtures[addresses.token1].name
+            .mockResolvedValueOnce('Tether USD')
+            .mockResolvedValueOnce('Test Tether USD');
+        fixtures[addresses.token1].decimals
+            .mockResolvedValueOnce(18)
+            .mockResolvedValueOnce(6);
+        const V2RemoveLiquidityService = await loadService(fixtures);
+        const service = new V2RemoveLiquidityService();
+
+        const mainnetPreview = await service.getPreview({
+            chainId: 56,
+            lpTokenAddress: addresses.lp,
+            liquidityRaw: bn(unit(10)),
+            provider: {}
+        });
+        const testnetPreview = await service.getPreview({
+            chainId: 97,
+            lpTokenAddress: addresses.lp,
+            liquidityRaw: bn(unit(10)),
+            provider: {}
+        });
+
+        expect(mainnetPreview.token0.symbol).toBe('LIB');
+        expect(mainnetPreview.token0.decimals).toBe(18);
+        expect(testnetPreview.token0.symbol).toBe('TLIB');
+        expect(testnetPreview.token0.decimals).toBe(6);
+        expect(testnetPreview.token1.symbol).toBe('TUSDT');
+        expect(testnetPreview.token1.decimals).toBe(6);
+        expect(fixtures[addresses.token0].symbol).toHaveBeenCalledTimes(2);
+        expect(fixtures[addresses.token1].symbol).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects configured routers whose factory does not match the LP factory', async () => {
+        const fixtures = createFixtures({ routerFactory: addresses.unknownFactory });
+        const V2RemoveLiquidityService = await loadService(fixtures);
+        const service = new V2RemoveLiquidityService();
+
+        await expect(service.getMatchedAdapter({
+            chainId: 56,
+            lpTokenAddress: addresses.lp,
+            provider: {}
+        })).rejects.toThrow('router does not match');
+    });
+
+    it('approves the router only when allowance is insufficient', async () => {
+        const fixtures = createFixtures({ allowance: unit(1) });
+        const V2RemoveLiquidityService = await loadService(fixtures);
+        const service = new V2RemoveLiquidityService();
+        const signer = { provider: {}, getAddress: vi.fn().mockResolvedValue(addresses.user) };
+
+        const tx = await service.approveIfNeeded({
+            lpTokenAddress: addresses.lp,
+            spender: addresses.router,
+            liquidityRaw: bn(unit(10)),
+            signer
+        });
+
+        expect(tx.hash).toBe('0xapprove');
+        expect(fixtures.approve).toHaveBeenCalledWith(addresses.router, expect.objectContaining({
+            value: unit(10)
+        }));
+    });
+
+    it('builds removeLiquidity transactions with token and min-output arguments', async () => {
+        const fixtures = createFixtures();
+        const V2RemoveLiquidityService = await loadService(fixtures);
+        const service = new V2RemoveLiquidityService();
+
+        const tx = await service.removeLiquidity({
+            routerAddress: addresses.router,
+            token0: addresses.token0,
+            token1: addresses.token1,
+            liquidityRaw: bn(unit(10)),
+            amount0Min: bn(unit(99)),
+            amount1Min: bn(unit(49)),
+            recipient: addresses.user,
+            deadline: 1777306663,
+            signer: {}
+        });
+
+        expect(tx.hash).toBe('0xremove');
+        expect(fixtures.removeLiquidity).toHaveBeenCalledWith(
+            addresses.token0,
+            addresses.token1,
+            expect.objectContaining({ value: unit(10) }),
+            expect.objectContaining({ value: unit(99) }),
+            expect.objectContaining({ value: unit(49) }),
+            addresses.user,
+            1777306663
+        );
+    });
+
+});


### PR DESCRIPTION
## Base branch
`main`

## What to review
- Adds `CONFIG.DEX_REMOVE_LIQUIDITY` for the allowlisted BSC V2 factories/routers.
- Loads `js/services/v2-remove-liquidity-service.js` before the staking modal.
- Adds `V2RemoveLiquidityService` with adapter matching, router factory validation, preview math, allowance helpers, approval helper, and `removeLiquidity` call construction.
- Adds isolated V2 service coverage.

## Flow added
This PR adds the trusted read/write service foundation. Nothing renders in the modal yet; callers can now resolve whether an LP belongs to a supported V2 factory, validate the matched router, estimate pair-token outputs, and prepare approval/remove calls.

```mermaid
flowchart LR
    A[LP token address] --> B[Read pair factory, token0, token1]
    B --> C{chainId + factory allowlisted?}
    C -- no --> D[Unsupported result]
    C -- yes --> E[Validate router.factory]
    E --> F[Read reserves + totalSupply]
    F --> G[Calculate expected + min outputs]
    G --> H[Expose allowance, approve, removeLiquidity helpers]
```

## Intentionally deferred
- No Remove LP modal UI.
- No preview wiring in the staking modal.
- No transactions from the modal.
- No Kyber zap-out behavior.

## Tests
- `npm test -- tests/v2-remove-liquidity-service.test.js`