### PR TITLE
Split Remove LP 02: tab shell

### DIFF
--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -106,7 +106,7 @@
 /* Modal Tabs */
 .modal-tabs {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(5, minmax(0, 1fr));
     border-bottom: 1px solid var(--divider);
 }
 
@@ -850,6 +850,15 @@
     flex: 1;
     padding: var(--spacing-2);
     font-size: var(--font-size);
+}
+
+.remove-liquidity-action-btn,
+.remove-liquidity-action-btn:not(:disabled):hover {
+    box-shadow: none;
+}
+
+.remove-liquidity-action-btn:disabled {
+    opacity: 0.5;
 }
 
 /* Responsive */

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -10,6 +10,7 @@ class StakingModalNew {
         this.currentTab = 'stake';
         this.stakeAmount = '';
         this.unstakeAmount = '';
+        this.removeLiquidityAmount = '';
         this.userBalance = '0.00';
         this.userStaked = '0.00';
         this.pendingRewards = '0.00';
@@ -227,6 +228,10 @@ class StakingModalNew {
                             <span class="material-icons" aria-hidden="true">redeem</span>
                             <span class="tab-label">Claim</span>
                         </button>
+                        <button class="tab-button" aria-label="Remove LP" data-tab="remove-liquidity">
+                            <span class="material-icons" aria-hidden="true">swap_horiz</span>
+                            <span class="tab-label">Remove LP</span>
+                        </button>
                     </div>
                     
                     <div class="modal-body">
@@ -422,6 +427,7 @@ class StakingModalNew {
         // Reset form inputs
         this.stakeAmount = '';
         this.unstakeAmount = '';
+        this.removeLiquidityAmount = '';
         this.zapInputAmount = '';
         this.zapQuote = null;
         this.zapQuoteStatus = 'idle';
@@ -479,7 +485,7 @@ class StakingModalNew {
      */
     async show(pair, initialTab = 0) {
         // Convert numeric tab index to string tab name
-        const tabNames = ['stake', 'unstake', 'claim', 'zap'];
+        const tabNames = ['stake', 'unstake', 'claim', 'zap', 'remove-liquidity'];
         const tabName = tabNames[initialTab] || 'stake';
 
         console.log(`🎯 Opening modal for ${pair.name}, tab: ${tabName} (index: ${initialTab})`);
@@ -2095,6 +2101,7 @@ class StakingModalNew {
         // Clear state
         this.stakeAmount = '';
         this.unstakeAmount = '';
+        this.removeLiquidityAmount = '';
         this.zapInputAmount = '';
         this.zapQuote = null;
         this.zapQuoteStatus = 'idle';
@@ -2111,8 +2118,8 @@ class StakingModalNew {
         this.needsApproval = false;
         this.resetActionStates(false);
         
-        // Clear DOM inputs and sliders for both stake and unstake
-        ['stake', 'unstake'].forEach(type => {
+        // Clear DOM inputs and sliders for LP amount tabs
+        ['stake', 'unstake', 'remove-liquidity'].forEach(type => {
             const input = document.getElementById(`${type}-amount-input`);
             const slider = document.getElementById(`${type}-slider`);
             if (input) input.value = '';
@@ -2120,6 +2127,7 @@ class StakingModalNew {
         });
         this.updateStakeUsdEstimate();
         this.updateUnstakeUsdEstimate();
+        this.updateRemoveLiquidityUsdEstimate();
 
         const zapInput = document.getElementById('zap-amount-input');
         if (zapInput) zapInput.value = '';
@@ -2184,6 +2192,9 @@ class StakingModalNew {
                 break;
             case 'claim':
                 tabContent.innerHTML = this.renderClaimTab();
+                break;
+            case 'remove-liquidity':
+                tabContent.innerHTML = this.renderRemoveLiquidityTab();
                 break;
             case 'zap':
                 tabContent.innerHTML = this.renderZapTab();
@@ -2429,6 +2440,58 @@ class StakingModalNew {
                 </button>
             </div>
         `;
+    }
+
+    renderRemoveLiquidityTab() {
+        return `
+            <div class="balance-info">
+                <span class="balance-label">Available LP Tokens:</span>
+                <span class="balance-value">${this.escapeHtml(this.userBalance)} LP${this.renderInlineLpUsdEstimate(this.userBalance)}</span>
+            </div>
+
+            <div class="form-group">
+                <label class="form-label">Amount of LP to Remove</label>
+                <input
+                    type="number"
+                    id="remove-liquidity-amount-input"
+                    class="form-input"
+                    placeholder="0.00"
+                    value="${this.escapeHtml(this.removeLiquidityAmount)}"
+                    min="0"
+                    inputmode="decimal"
+                >
+                ${this.renderLpUsdEstimateElement('remove-liquidity-usd-estimate', this.removeLiquidityAmount)}
+                <div class="slider-container">
+                    <input
+                        type="range"
+                        class="slider amount-slider"
+                        id="remove-liquidity-slider"
+                        min="0"
+                        max="100"
+                        value="0"
+                        data-type="remove-liquidity"
+                    >
+                </div>
+                <div class="percentage-buttons">
+                    <button class="percentage-btn" data-percentage="25">25%</button>
+                    <button class="percentage-btn" data-percentage="50">50%</button>
+                    <button class="percentage-btn" data-percentage="75">75%</button>
+                    <button class="percentage-btn" data-percentage="100">MAX</button>
+                </div>
+            </div>
+
+            <div class="modal-actions">
+                <button class="btn btn-secondary" onclick="safeModalClose()">Cancel</button>
+                <button class="btn btn-primary remove-liquidity-action-btn" disabled title="Remove LP execution is added in a later PR">
+                    <span class="material-icons">swap_horiz</span>
+                    Remove LP Liquidity
+                </button>
+            </div>
+        `;
+    }
+
+    updateRemoveLiquidityUsdEstimate() {
+        this.updateLpUsdEstimate('remove-liquidity-usd-estimate', this.removeLiquidityAmount);
     }
 
     renderZapTab() {

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -262,6 +262,8 @@ describe('StakingModalNew zap cleanup', () => {
         expect(modalContainer.innerHTML).toContain('<span class="material-icons" aria-hidden="true">bolt</span>');
         expect(modalContainer.innerHTML).toContain('<span class="tab-label">Create LP</span>');
         expect(modalContainer.innerHTML).toContain('<span class="tab-label">Unstake</span>');
+        expect(modalContainer.innerHTML).toContain('aria-label="Remove LP"');
+        expect(modalContainer.innerHTML).toContain('<span class="tab-label">Remove LP</span>');
     });
 
     it('derives LP USD estimates from pair TVL data', async () => {
@@ -373,6 +375,26 @@ describe('StakingModalNew zap cleanup', () => {
         const html = modal.renderClaimTab();
 
         expect(html).toContain('4 LP <span class="lp-usd-estimate">($80.00)</span>');
+    });
+
+    it('renders a disabled Remove LP tab shell with LP balance and amount controls', async () => {
+        const modal = await createLoadedModal();
+        modal.currentPair = { tvlUsd: 2000, tvl: 100 };
+        modal.userBalance = '4';
+        modal.removeLiquidityAmount = '1.5';
+
+        const html = modal.renderRemoveLiquidityTab();
+
+        expect(html).toContain('4 LP <span class="lp-usd-estimate">($80.00)</span>');
+        expect(html).toContain('id="remove-liquidity-amount-input"');
+        expect(html).toContain('id="remove-liquidity-usd-estimate"');
+        expect(html).toContain('$30.00');
+        expect(html).toContain('id="remove-liquidity-slider"');
+        expect(html).toContain('data-type="remove-liquidity"');
+        expect(html).toContain('Remove LP Liquidity');
+        expect(html).toContain('disabled title="Remove LP execution is added in a later PR"');
+        expect(html).not.toContain('remove-liquidity-checkbox');
+        expect(html).not.toContain('remove-liquidity-preview');
     });
 
     it('startZapQuoteAutoRefresh stops instead of refreshing while zap is executing', async () => {


### PR DESCRIPTION
## Base branch
`split/remove-lp-01-foundation`

## What to review
- Adds the visible `Remove LP` tab next to the existing staking modal tabs.
- Renders the available LP balance and USD estimate.
- Renders the LP amount input, USD estimate, slider, percentage controls, and static action area.
- Adds the minimal CSS needed for the shell and five-tab layout.

## Flow added
This PR adds only the visible tab shell. Users can see their wallet LP balance and enter/select an LP amount, but the action remains static and non-destructive.

```mermaid
flowchart LR
    A[Open staking modal] --> B[Select Remove LP tab]
    B --> C[Show available LP + USD estimate]
    C --> D[Enter amount or use slider/percent buttons]
    D --> E[Show amount USD estimate]
    E --> F[Disabled Remove LP action]
```

## Intentionally deferred
- No V2 preview fetching or factory support messaging.
- No slippage/deadline controls.
- No transaction execution.
- No Kyber zap-out checkbox or output-token controls.

## Tests
- `npm test -- tests/staking-modal-new.test.js tests/v2-remove-liquidity-service.test.js`