### PR TITLE
Split Remove LP 03: V2 preview wiring

### DIFF
--- a/css/staking-modal.css
+++ b/css/staking-modal.css
@@ -616,6 +616,94 @@
     padding: 0 var(--spacing-1);
 }
 
+.remove-liquidity-section {
+    margin-top: calc(var(--spacing-2) * -1);
+}
+
+.remove-liquidity-settings-summary {
+    margin-bottom: var(--spacing-1);
+}
+
+.remove-liquidity-settings-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    min-height: 30px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: var(--font-weight-semibold);
+    cursor: pointer;
+}
+
+.remove-liquidity-settings-toggle:hover {
+    color: var(--primary-main);
+}
+
+.remove-liquidity-settings-toggle .material-icons {
+    font-size: 17px;
+}
+
+.remove-liquidity-settings-label {
+    color: var(--text-secondary);
+    font-weight: var(--font-weight-normal);
+}
+
+.remove-liquidity-settings-panel {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(120px, 160px);
+    gap: var(--spacing-2);
+    align-items: start;
+    margin-bottom: var(--spacing-2);
+}
+
+.remove-liquidity-slippage-row {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(58px, 1fr)) minmax(88px, 1fr);
+    gap: var(--spacing-1);
+    align-items: center;
+}
+
+.remove-liquidity-slippage-btn {
+    min-height: 36px;
+    border: 1px solid var(--divider);
+    border-radius: var(--border-radius);
+    background: transparent;
+    color: var(--text-primary);
+    cursor: pointer;
+}
+
+.remove-liquidity-slippage-btn:hover,
+.remove-liquidity-slippage-btn.active {
+    border-color: var(--primary-main);
+    background: rgba(25, 118, 210, 0.08);
+    color: var(--primary-main);
+}
+
+.remove-liquidity-custom-slippage {
+    min-height: 36px;
+    padding: 0 var(--spacing-1);
+}
+
+.remove-liquidity-deadline-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: var(--spacing-1);
+    align-items: center;
+}
+
+.remove-liquidity-deadline-unit {
+    color: var(--text-secondary);
+    font-size: 13px;
+    white-space: nowrap;
+}
+
+.remove-liquidity-preview-list {
+    min-height: 74px;
+}
+
 .zap-quote-card {
     margin-top: 10px;
     margin-bottom: 10px;
@@ -623,6 +711,10 @@
     background: var(--action-hover);
     border: 1px solid var(--divider);
     border-radius: var(--border-radius);
+}
+
+.remove-liquidity-preview-card {
+    margin-top: 0;
 }
 
 .zap-empty-state {
@@ -898,6 +990,22 @@
 
     .zap-custom-token-row {
         grid-template-columns: 1fr;
+    }
+
+    .remove-liquidity-settings-panel {
+        grid-template-columns: 1fr;
+    }
+
+    .remove-liquidity-slippage-row {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .remove-liquidity-custom-slippage {
+        grid-column: 1 / -1;
+    }
+
+    .remove-liquidity-deadline-row {
+        grid-template-columns: minmax(0, 1fr) auto;
     }
 }
 

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -10,7 +10,18 @@ class StakingModalNew {
         this.currentTab = 'stake';
         this.stakeAmount = '';
         this.unstakeAmount = '';
+        this.removeLiquidityService = window.V2RemoveLiquidityService ? new window.V2RemoveLiquidityService() : null;
         this.removeLiquidityAmount = '';
+        this.removeLiquidityPreview = null;
+        this.removeLiquidityPreviewStatus = 'idle';
+        this.removeLiquidityPreviewError = '';
+        this.removeLiquiditySlippageBps = window.CONFIG?.KYBER_ZAP?.DEFAULT_SLIPPAGE_BPS || 50;
+        this.removeLiquidityCustomSlippage = '';
+        this.removeLiquidityCustomSlippageError = '';
+        this.removeLiquidityDeadlineMinutes = window.CONFIG?.KYBER_ZAP?.DEFAULT_DEADLINE_MINUTES || 20;
+        this.removeLiquiditySettingsOpen = false;
+        this.removeLiquidityPreviewDebounceTimer = null;
+        this.removeLiquidityPreviewRequestId = 0;
         this.userBalance = '0.00';
         this.userStaked = '0.00';
         this.pendingRewards = '0.00';
@@ -73,6 +84,7 @@ class StakingModalNew {
         this.isExecutingUnstake = false;
         this.isExecutingClaim = false;
         this.isExecutingZap = false;
+        this.isExecutingRemoveLiquidity = false;
 
         // Claim rewards on unstake
         this.claimRewardsOnUnstake = true;
@@ -265,6 +277,15 @@ class StakingModalNew {
                 this.setZapSlippage(button.dataset.slippage);
             }
 
+            if (e.target.closest('.remove-liquidity-settings-toggle')) {
+                this.toggleRemoveLiquiditySettings();
+            }
+
+            if (e.target.closest('.remove-liquidity-slippage-btn')) {
+                const button = e.target.closest('.remove-liquidity-slippage-btn');
+                this.setRemoveLiquiditySlippage(button.dataset.slippage);
+            }
+
             if (e.target.closest('.zap-percentage-btn')) {
                 const button = e.target.closest('.zap-percentage-btn');
                 this.setZapAmountPercentage(parseInt(button.dataset.percentage, 10));
@@ -309,6 +330,19 @@ class StakingModalNew {
                 this.updateUnstakeUsdEstimate();
             }
 
+            if (e.target.id === 'remove-liquidity-amount-input') {
+                const sanitizedValue = this.applyDecimalLimit(e.target.value, this.userBalanceDecimals);
+                if (sanitizedValue !== e.target.value) {
+                    e.target.value = sanitizedValue;
+                }
+                this.removeLiquidityAmount = sanitizedValue;
+                this.updateSlider('remove-liquidity');
+                this.updateRemoveLiquidityUsdEstimate();
+                this.updateRemoveLiquidityBalanceError();
+                this.resetRemoveLiquidityPreview();
+                this.debounceRemoveLiquidityPreview();
+            }
+
             if (e.target.classList.contains('amount-slider')) {
                 this.updateAmountFromSlider(e.target);
             }
@@ -338,6 +372,20 @@ class StakingModalNew {
                 this.zapCustomTokenAddress = e.target.value.trim();
                 this.zapCustomTokenError = '';
             }
+
+            if (e.target.id === 'remove-liquidity-custom-slippage-input') {
+                const sanitizedValue = this.setRemoveLiquidityCustomSlippageInput(e.target.value);
+                if (sanitizedValue !== e.target.value) {
+                    e.target.value = sanitizedValue;
+                }
+            }
+
+            if (e.target.id === 'remove-liquidity-deadline-input') {
+                const sanitizedValue = this.setRemoveLiquidityDeadlineInput(e.target.value);
+                if (sanitizedValue !== e.target.value) {
+                    e.target.value = sanitizedValue;
+                }
+            }
         });
 
         // Checkbox changes
@@ -350,7 +398,7 @@ class StakingModalNew {
 
         // Keyboard events
         document.addEventListener('keydown', (e) => {
-            if ((e.target.id === 'stake-amount-input' || e.target.id === 'unstake-amount-input') && ['-', '+', 'e', 'E'].includes(e.key)) {
+            if ((e.target.id === 'stake-amount-input' || e.target.id === 'unstake-amount-input' || e.target.id === 'remove-liquidity-amount-input') && ['-', '+', 'e', 'E'].includes(e.key)) {
                 e.preventDefault();
                 return;
             }
@@ -427,7 +475,6 @@ class StakingModalNew {
         // Reset form inputs
         this.stakeAmount = '';
         this.unstakeAmount = '';
-        this.removeLiquidityAmount = '';
         this.zapInputAmount = '';
         this.zapQuote = null;
         this.zapQuoteStatus = 'idle';
@@ -442,6 +489,7 @@ class StakingModalNew {
         this.zapCustomSlippageError = '';
         this.zapQuoteRequestId += 1;
         this.stopZapQuoteAutoRefresh();
+        this.resetRemoveLiquidityFormState();
 
         // Reset transaction progress state
         this.resetActionStates(false);
@@ -660,6 +708,282 @@ class StakingModalNew {
     async getPairTokenMetadata() {
         const lpTokenAddress = this.currentPair?.lpToken || this.currentPair?.address;
         return this.getKyberZapService().getPairTokenMetadata(lpTokenAddress);
+    }
+
+    getRemoveLiquidityService() {
+        if (!this.removeLiquidityService && window.V2RemoveLiquidityService) {
+            this.removeLiquidityService = new window.V2RemoveLiquidityService();
+        }
+
+        if (!this.removeLiquidityService) {
+            throw new Error('V2 remove liquidity service is not available.');
+        }
+
+        return this.removeLiquidityService;
+    }
+
+    getRemoveLiquidityChainId() {
+        return window.networkSelector?.getCurrentChainId?.()
+            ?? window.contractManager?.getCurrentChainIdSafe?.()
+            ?? window.walletManager?.networkManager?.getCurrentChainId?.()
+            ?? null;
+    }
+
+    clearRemoveLiquidityPreviewDebounce() {
+        if (this.removeLiquidityPreviewDebounceTimer) {
+            clearTimeout(this.removeLiquidityPreviewDebounceTimer);
+            this.removeLiquidityPreviewDebounceTimer = null;
+        }
+    }
+
+    resetRemoveLiquidityFormState() {
+        this.removeLiquidityAmount = '';
+        this.removeLiquidityPreview = null;
+        this.removeLiquidityPreviewStatus = 'idle';
+        this.removeLiquidityPreviewError = '';
+        this.removeLiquidityCustomSlippage = '';
+        this.removeLiquidityCustomSlippageError = '';
+        this.removeLiquiditySettingsOpen = false;
+        this.removeLiquidityPreviewRequestId += 1;
+        this.clearRemoveLiquidityPreviewDebounce();
+    }
+
+    resetRemoveLiquidityPreview({ status = 'idle', error = '' } = {}) {
+        this.removeLiquidityPreview = null;
+        this.removeLiquidityPreviewStatus = status;
+        this.removeLiquidityPreviewError = error;
+        this.removeLiquidityPreviewRequestId += 1;
+        this.clearRemoveLiquidityPreviewDebounce();
+        this.updateRemoveLiquidityPreviewPanel();
+        this.updateRemoveLiquidityButton();
+    }
+
+    getRemoveLiquidityPreviewErrorMessage(error) {
+        const message = error?.userMessage?.message || error?.message || 'Unable to fetch remove-liquidity preview.';
+        if (/router does not match/i.test(message)) {
+            return 'Configured router does not match this LP factory.';
+        }
+        return message;
+    }
+
+    getRemoveLiquidityAmountRaw() {
+        if (!this.removeLiquidityAmount || parseFloat(this.removeLiquidityAmount) <= 0) {
+            return window.ethers.BigNumber.from(0);
+        }
+
+        return window.ethers.utils.parseUnits(this.removeLiquidityAmount.toString(), this.userBalanceDecimals);
+    }
+
+    getRemoveLiquidityBalanceError() {
+        if (!this.removeLiquidityAmount || parseFloat(this.removeLiquidityAmount) <= 0) {
+            return '';
+        }
+
+        try {
+            const liquidityRaw = this.getRemoveLiquidityAmountRaw();
+            const balanceRaw = this.userBalanceRaw || window.ethers.BigNumber.from(0);
+            if (!balanceRaw.gte(liquidityRaw)) {
+                return 'Insufficient LP token balance.';
+            }
+        } catch (error) {
+            const amount = parseFloat(this.removeLiquidityAmount);
+            const balance = parseFloat(this.userBalance);
+            if (Number.isFinite(amount) && Number.isFinite(balance) && amount > balance) {
+                return 'Insufficient LP token balance.';
+            }
+        }
+
+        return '';
+    }
+
+    updateRemoveLiquidityBalanceError() {
+        const errorElement = document.getElementById('remove-liquidity-balance-error');
+        if (!errorElement) return;
+
+        const balanceError = this.getRemoveLiquidityBalanceError();
+        errorElement.textContent = balanceError;
+        errorElement.hidden = !balanceError;
+    }
+
+    getRemoveLiquidityCustomSlippageError(value = this.removeLiquidityCustomSlippage) {
+        if (!value) {
+            return '';
+        }
+
+        const numericValue = Number(value);
+        if (!Number.isFinite(numericValue) || numericValue <= 0 || numericValue > 100) {
+            return 'Enter a custom slippage between 0.01% and 100%.';
+        }
+
+        return '';
+    }
+
+    hasInvalidRemoveLiquidityCustomSlippage() {
+        return !!this.getRemoveLiquidityCustomSlippageError();
+    }
+
+    isRemoveLiquidityCustomSlippageActive() {
+        return !!this.removeLiquidityCustomSlippage && !this.hasInvalidRemoveLiquidityCustomSlippage();
+    }
+
+    toggleRemoveLiquiditySettings() {
+        this.removeLiquiditySettingsOpen = !this.removeLiquiditySettingsOpen;
+        this.renderTabContent();
+    }
+
+    setRemoveLiquiditySlippage(value) {
+        if (value === 'custom') {
+            const customInput = document.getElementById('remove-liquidity-custom-slippage-input');
+            if (customInput) customInput.focus?.();
+            return;
+        }
+
+        const parsed = parseInt(value, 10);
+        if (Number.isFinite(parsed) && parsed > 0) {
+            this.removeLiquiditySlippageBps = parsed;
+            this.removeLiquidityCustomSlippage = '';
+            this.removeLiquidityCustomSlippageError = '';
+            this.resetRemoveLiquidityPreview();
+            this.renderTabContent();
+            this.debounceRemoveLiquidityPreview(0);
+        }
+    }
+
+    setRemoveLiquidityCustomSlippageInput(value) {
+        const sanitizedValue = this.applyDecimalLimit(String(value ?? ''), 2);
+        this.removeLiquidityCustomSlippage = sanitizedValue;
+        this.removeLiquidityCustomSlippageError = this.getRemoveLiquidityCustomSlippageError(sanitizedValue);
+
+        if (this.removeLiquidityCustomSlippageError) {
+            this.resetRemoveLiquidityPreview({
+                status: 'error',
+                error: this.removeLiquidityCustomSlippageError
+            });
+            return sanitizedValue;
+        }
+
+        this.removeLiquidityPreviewError = '';
+        if (!sanitizedValue) {
+            if (this.removeLiquidityPreviewStatus === 'error' && !this.removeLiquidityPreview) {
+                this.removeLiquidityPreviewStatus = 'idle';
+            }
+            this.updateRemoveLiquidityPreviewPanel();
+            this.debounceRemoveLiquidityPreview();
+            this.updateRemoveLiquidityButton();
+            return sanitizedValue;
+        }
+
+        this.removeLiquiditySlippageBps = Math.round(Number(sanitizedValue) * 100);
+        this.resetRemoveLiquidityPreview();
+        this.debounceRemoveLiquidityPreview();
+        return sanitizedValue;
+    }
+
+    setRemoveLiquidityDeadlineInput(value) {
+        const sanitizedValue = String(value ?? '').replace(/[^\d]/g, '').slice(0, 4);
+        if (!sanitizedValue) {
+            this.removeLiquidityDeadlineMinutes = window.CONFIG?.KYBER_ZAP?.DEFAULT_DEADLINE_MINUTES || 20;
+            this.updateRemoveLiquidityPreviewPanel();
+            return sanitizedValue;
+        }
+
+        const parsed = Math.min(Math.max(parseInt(sanitizedValue, 10), 1), 4320);
+        this.removeLiquidityDeadlineMinutes = parsed;
+        this.updateRemoveLiquidityPreviewPanel();
+        return String(parsed);
+    }
+
+    canPrepareRemoveLiquidityPreview() {
+        return !!this.currentPair
+            && !!this.removeLiquidityAmount
+            && parseFloat(this.removeLiquidityAmount) > 0
+            && !this.getRemoveLiquidityBalanceError()
+            && !this.hasInvalidRemoveLiquidityCustomSlippage();
+    }
+
+    canFetchRemoveLiquidityPreview() {
+        return this.canPrepareRemoveLiquidityPreview();
+    }
+
+    debounceRemoveLiquidityPreview(delay = 400) {
+        this.clearRemoveLiquidityPreviewDebounce();
+
+        if (!this.canFetchRemoveLiquidityPreview()) {
+            this.updateRemoveLiquidityPreviewPanel();
+            this.updateRemoveLiquidityButton();
+            return;
+        }
+
+        this.removeLiquidityPreviewDebounceTimer = setTimeout(() => {
+            this.fetchRemoveLiquidityPreview();
+        }, delay);
+    }
+
+    async fetchRemoveLiquidityPreview({ force = false } = {}) {
+        if (!this.canPrepareRemoveLiquidityPreview()) {
+            this.updateRemoveLiquidityPreviewPanel();
+            this.updateRemoveLiquidityButton();
+            return;
+        }
+
+        if (!force && this.removeLiquidityPreviewStatus === 'ready' && this.removeLiquidityPreview?.supported) {
+            this.updateRemoveLiquidityPreviewPanel();
+            this.updateRemoveLiquidityButton();
+            return;
+        }
+
+        const requestId = ++this.removeLiquidityPreviewRequestId;
+        this.clearRemoveLiquidityPreviewDebounce();
+
+        try {
+            const chainId = this.getRemoveLiquidityChainId();
+            const lpTokenAddress = this.currentPair?.lpToken || this.currentPair?.address;
+            const liquidityRaw = this.getRemoveLiquidityAmountRaw();
+            const provider = window.contractManager?.provider || window.walletManager?.provider;
+
+            if (!lpTokenAddress || !provider) {
+                throw new Error('LP token and provider are required for remove-liquidity preview.');
+            }
+
+            this.removeLiquidityPreviewStatus = 'loading';
+            this.removeLiquidityPreviewError = '';
+            this.updateRemoveLiquidityPreviewPanel();
+            this.updateRemoveLiquidityButton();
+
+            const preview = await this.getRemoveLiquidityService().getPreview({
+                chainId,
+                lpTokenAddress,
+                liquidityRaw,
+                slippageBps: this.removeLiquiditySlippageBps,
+                provider
+            });
+
+            if (requestId !== this.removeLiquidityPreviewRequestId) {
+                return;
+            }
+
+            this.removeLiquidityPreview = preview;
+            if (preview.supported) {
+                this.removeLiquidityPreviewStatus = 'ready';
+                this.removeLiquidityPreviewError = '';
+            } else {
+                this.removeLiquidityPreviewStatus = 'error';
+                this.removeLiquidityPreviewError = preview.reason || 'Remove liquidity is not supported for this pool.';
+            }
+        } catch (error) {
+            if (requestId !== this.removeLiquidityPreviewRequestId) {
+                return;
+            }
+
+            this.removeLiquidityPreview = null;
+            this.removeLiquidityPreviewStatus = 'error';
+            this.removeLiquidityPreviewError = this.getRemoveLiquidityPreviewErrorMessage(error);
+        } finally {
+            if (requestId === this.removeLiquidityPreviewRequestId) {
+                this.updateRemoveLiquidityPreviewPanel();
+                this.updateRemoveLiquidityButton();
+            }
+        }
     }
 
     resetZapQuoteState({ status = 'idle', error = '' } = {}) {
@@ -1976,6 +2300,28 @@ class StakingModalNew {
         if (buttonText) buttonText.textContent = ' Create LP';
     }
 
+    updateRemoveLiquidityButton() {
+        const removeButton = document.querySelector('.modal-actions .btn-primary[onclick*="safeModalExecuteRemoveLiquidity"]');
+        if (!removeButton) return;
+
+        const amount = parseFloat(this.removeLiquidityAmount) || 0;
+        const hasAmount = amount > 0;
+        const hasValidPreview = this.removeLiquidityPreviewStatus === 'ready'
+            && this.removeLiquidityPreview?.supported;
+        const balanceError = this.getRemoveLiquidityBalanceError();
+
+        removeButton.disabled = true;
+        if (balanceError && hasAmount) {
+            removeButton.title = balanceError;
+        } else if (!hasAmount) {
+            removeButton.title = 'Enter an LP amount to preview removal.';
+        } else if (!hasValidPreview) {
+            removeButton.title = this.removeLiquidityPreviewError || 'Wait for a supported remove-liquidity preview.';
+        } else {
+            removeButton.title = 'Remove LP execution is added in the next PR.';
+        }
+    }
+
     /**
      * Load user balances from contract manager
      * Enhanced to use correct lpToken address from pair object
@@ -2101,7 +2447,6 @@ class StakingModalNew {
         // Clear state
         this.stakeAmount = '';
         this.unstakeAmount = '';
-        this.removeLiquidityAmount = '';
         this.zapInputAmount = '';
         this.zapQuote = null;
         this.zapQuoteStatus = 'idle';
@@ -2114,6 +2459,7 @@ class StakingModalNew {
         this.zapQuoteRequestId += 1;
         this.stopZapQuoteAutoRefresh();
         this.clearZapQuoteRateLimitTimer();
+        this.resetRemoveLiquidityFormState();
         this.isApproved = false;
         this.needsApproval = false;
         this.resetActionStates(false);
@@ -2244,6 +2590,7 @@ class StakingModalNew {
         this.updateUnstakeButton();
         this.updateClaimButton();
         this.updateZapButton();
+        this.updateRemoveLiquidityButton();
     }
 
     renderStakeTab() {
@@ -2443,6 +2790,8 @@ class StakingModalNew {
     }
 
     renderRemoveLiquidityTab() {
+        const balanceError = this.getRemoveLiquidityBalanceError();
+
         return `
             <div class="balance-info">
                 <span class="balance-label">Available LP Tokens:</span>
@@ -2461,6 +2810,7 @@ class StakingModalNew {
                     inputmode="decimal"
                 >
                 ${this.renderLpUsdEstimateElement('remove-liquidity-usd-estimate', this.removeLiquidityAmount)}
+                <div id="remove-liquidity-balance-error" class="zap-field-error zap-balance-error" aria-live="polite" ${balanceError ? '' : 'hidden'}>${this.escapeHtml(balanceError)}</div>
                 <div class="slider-container">
                     <input
                         type="range"
@@ -2480,9 +2830,11 @@ class StakingModalNew {
                 </div>
             </div>
 
+            ${this.renderRemoveLiquidityControls()}
+
             <div class="modal-actions">
                 <button class="btn btn-secondary" onclick="safeModalClose()">Cancel</button>
-                <button class="btn btn-primary remove-liquidity-action-btn" disabled title="Remove LP execution is added in a later PR">
+                <button class="btn btn-primary remove-liquidity-action-btn" onclick="safeModalExecuteRemoveLiquidity()" disabled title="Remove LP execution is added in the next PR.">
                     <span class="material-icons">swap_horiz</span>
                     Remove LP Liquidity
                 </button>
@@ -2492,6 +2844,183 @@ class StakingModalNew {
 
     updateRemoveLiquidityUsdEstimate() {
         this.updateLpUsdEstimate('remove-liquidity-usd-estimate', this.removeLiquidityAmount);
+    }
+
+    formatRemoveLiquidityTokenAmount(amount, token) {
+        if (!amount || !token) {
+            return '-';
+        }
+
+        return this.formatZapDisplayAmount(amount.raw ?? amount.formatted, token.decimals ?? 18, token.symbol || '');
+    }
+
+    renderRemoveLiquidityControls() {
+        const slippageOptions = [10, 50, 100];
+        const slippageDisplay = `${(Number(this.removeLiquiditySlippageBps) / 100).toFixed(2)}%`;
+        const settingsPanel = this.removeLiquiditySettingsOpen ? `
+                <div class="remove-liquidity-settings-panel">
+                    <div class="form-group">
+                        <label class="form-label" for="remove-liquidity-custom-slippage-input">Max Slippage</label>
+                        <div class="remove-liquidity-slippage-row">
+                            ${slippageOptions.map(option => `
+                                <button
+                                    type="button"
+                                    class="remove-liquidity-slippage-btn ${this.removeLiquiditySlippageBps === option && !this.removeLiquidityCustomSlippage ? 'active' : ''}"
+                                    data-slippage="${option}"
+                                >
+                                    ${(option / 100).toFixed(option < 10 ? 2 : 1)}%
+                                </button>
+                            `).join('')}
+                            <button
+                                type="button"
+                                class="remove-liquidity-slippage-btn ${this.isRemoveLiquidityCustomSlippageActive() ? 'active' : ''}"
+                                data-slippage="custom"
+                            >
+                                Custom
+                            </button>
+                            <input
+                                type="number"
+                                id="remove-liquidity-custom-slippage-input"
+                                class="form-input remove-liquidity-custom-slippage"
+                                placeholder="${slippageDisplay}"
+                                value="${this.escapeHtml(this.removeLiquidityCustomSlippage)}"
+                                min="0.01"
+                                max="100"
+                                step="0.01"
+                                aria-invalid="${this.removeLiquidityCustomSlippageError ? 'true' : 'false'}"
+                            >
+                        </div>
+                        ${this.removeLiquidityCustomSlippageError ? `<div class="zap-field-error">${this.escapeHtml(this.removeLiquidityCustomSlippageError)}</div>` : ''}
+                    </div>
+
+                    <div class="form-group">
+                        <label class="form-label" for="remove-liquidity-deadline-input">Transaction time limit</label>
+                        <div class="remove-liquidity-deadline-row">
+                            <input
+                                type="number"
+                                id="remove-liquidity-deadline-input"
+                                class="form-input"
+                                value="${this.escapeHtml(this.removeLiquidityDeadlineMinutes)}"
+                                min="1"
+                                max="4320"
+                                step="1"
+                                inputmode="numeric"
+                            >
+                            <span class="remove-liquidity-deadline-unit">minutes</span>
+                        </div>
+                    </div>
+                </div>
+        ` : '';
+
+        return `
+            <div class="remove-liquidity-section">
+                <div class="remove-liquidity-settings-summary">
+                    <button
+                        type="button"
+                        class="remove-liquidity-settings-toggle"
+                        aria-expanded="${this.removeLiquiditySettingsOpen ? 'true' : 'false'}"
+                        title="Adjust max slippage and transaction time limit"
+                    >
+                        <span class="remove-liquidity-settings-label">Max slippage:</span>
+                        <strong>${slippageDisplay}</strong>
+                        <span class="material-icons" aria-hidden="true">settings</span>
+                    </button>
+                </div>
+                ${settingsPanel}
+
+                <div id="remove-liquidity-preview-panel">
+                    ${this.renderRemoveLiquidityPreviewPanel()}
+                </div>
+            </div>
+        `;
+    }
+
+    renderRemoveLiquidityPreviewPanel() {
+        const balanceError = this.getRemoveLiquidityBalanceError();
+        const isLoading = this.removeLiquidityPreviewStatus === 'loading';
+        const isError = this.removeLiquidityPreviewStatus === 'error' || !!balanceError;
+        const hasPreview = this.removeLiquidityPreviewStatus === 'ready' && this.removeLiquidityPreview?.supported;
+        const pendingValue = isLoading ? '...' : '-';
+        const cardClass = [
+            'zap-quote-card',
+            'remove-liquidity-preview-card',
+            isLoading ? 'zap-quote-loading' : '',
+            isError ? 'zap-quote-error' : '',
+            !hasPreview && !isLoading && !isError ? 'zap-quote-placeholder' : ''
+        ].filter(Boolean).join(' ');
+
+        let summary = this.removeLiquidityAmount
+            ? 'Checking remove liquidity support...'
+            : 'Enter an amount to preview pair token outputs.';
+        let dexDisplay = pendingValue;
+        let token0Display = pendingValue;
+        let token1Display = pendingValue;
+        let token0MinDisplay = pendingValue;
+        let token1MinDisplay = pendingValue;
+
+        if (isLoading) {
+            summary = 'Loading LP reserves...';
+        } else if (isError) {
+            summary = balanceError || this.removeLiquidityPreviewError || 'Remove liquidity is not supported for this pool.';
+            dexDisplay = this.removeLiquidityPreview?.factoryAddress
+                ? `Unsupported factory ${String(this.removeLiquidityPreview.factoryAddress).slice(0, 6)}...${String(this.removeLiquidityPreview.factoryAddress).slice(-4)}`
+                : 'Unsupported';
+        } else if (hasPreview) {
+            const preview = this.removeLiquidityPreview;
+            dexDisplay = preview.adapter?.name || 'V2 DEX';
+            token0Display = this.formatRemoveLiquidityTokenAmount(preview.token0.amount, preview.token0);
+            token1Display = this.formatRemoveLiquidityTokenAmount(preview.token1.amount, preview.token1);
+            token0MinDisplay = this.formatRemoveLiquidityTokenAmount(preview.token0.minAmount, preview.token0);
+            token1MinDisplay = this.formatRemoveLiquidityTokenAmount(preview.token1.minAmount, preview.token1);
+            summary = `${preview.token0.symbol} + ${preview.token1.symbol} via ${dexDisplay}`;
+        }
+
+        const estimatedPairDisplay = hasPreview
+            ? `${token0Display} + ${token1Display}`
+            : pendingValue;
+        const minimumPairDisplay = hasPreview
+            ? `${token0MinDisplay} + ${token1MinDisplay}`
+            : pendingValue;
+
+        const rows = [
+            this.renderZapQuoteRow('You receive', estimatedPairDisplay),
+            this.renderZapQuoteRow('Minimum received', minimumPairDisplay),
+            this.renderZapQuoteRow('DEX', dexDisplay)
+        ];
+
+        return this.renderRemoveLiquidityPreviewCard(cardClass, summary, rows, isLoading);
+    }
+
+    renderRemoveLiquidityPreviewCard(cardClass, summary, rows, isLoading) {
+        return `
+            <div class="${cardClass}">
+                <div class="zap-quote-header">
+                    <div class="zap-route-summary">${this.escapeHtml(summary)}</div>
+                    <div class="zap-refresh-controls">
+                        <button
+                            type="button"
+                            class="zap-refresh-btn"
+                            onclick="safeModalFetchRemoveLiquidityPreview()"
+                            title="Refresh remove-liquidity preview"
+                            aria-label="Refresh remove-liquidity preview"
+                            ${!this.canFetchRemoveLiquidityPreview() || isLoading ? 'disabled' : ''}
+                        >
+                            <span class="material-icons">sync</span>
+                        </button>
+                    </div>
+                </div>
+                <dl class="zap-quote-list remove-liquidity-preview-list">
+                    ${rows.join('')}
+                </dl>
+            </div>
+        `;
+    }
+
+    updateRemoveLiquidityPreviewPanel() {
+        const panel = document.getElementById('remove-liquidity-preview-panel');
+        if (panel) {
+            panel.innerHTML = this.renderRemoveLiquidityPreviewPanel();
+        }
     }
 
     renderZapTab() {
@@ -2779,10 +3308,14 @@ class StakingModalNew {
         
         // For 100% (MAX), use the exact original value to preserve precision
         if (percentage === 100) {
-            amount = this.currentTab === 'stake' ? this.userBalance : this.userStaked;
+            amount = this.currentTab === 'stake' || this.currentTab === 'remove-liquidity'
+                ? this.userBalance
+                : this.userStaked;
         } else {
             // For other percentages, calculate the amount
-            const maxAmount = this.currentTab === 'stake' ? parseFloat(this.userBalance) : parseFloat(this.userStaked);
+            const maxAmount = this.currentTab === 'stake' || this.currentTab === 'remove-liquidity'
+                ? parseFloat(this.userBalance)
+                : parseFloat(this.userStaked);
             amount = (maxAmount * percentage / 100).toFixed(6);
         }
 
@@ -2809,6 +3342,16 @@ class StakingModalNew {
             // Update button states
             this.updateUnstakeUsdEstimate();
             this.updateButtonStates();
+        } else if (this.currentTab === 'remove-liquidity') {
+            this.removeLiquidityAmount = amount;
+            const input = document.getElementById('remove-liquidity-amount-input');
+            if (input) input.value = amount;
+            this.updateSlider('remove-liquidity');
+
+            this.updateRemoveLiquidityUsdEstimate();
+            this.updateRemoveLiquidityBalanceError();
+            this.resetRemoveLiquidityPreview();
+            this.debounceRemoveLiquidityPreview();
         }
 
         // Update percentage button states
@@ -2821,8 +3364,14 @@ class StakingModalNew {
         const slider = document.getElementById(`${type}-slider`);
         if (!slider) return;
 
-        const amount = parseFloat(type === 'stake' ? this.stakeAmount : this.unstakeAmount) || 0;
-        const maxAmount = parseFloat(type === 'stake' ? this.userBalance : this.userStaked) || 1;
+        const amount = parseFloat(
+            type === 'stake'
+                ? this.stakeAmount
+                : type === 'remove-liquidity'
+                    ? this.removeLiquidityAmount
+                    : this.unstakeAmount
+        ) || 0;
+        const maxAmount = parseFloat(type === 'stake' || type === 'remove-liquidity' ? this.userBalance : this.userStaked) || 1;
         const percentage = maxAmount > 0 ? (amount / maxAmount) * 100 : 0;
 
         slider.value = percentage;
@@ -2836,10 +3385,10 @@ class StakingModalNew {
         // For 100% (MAX), use the exact original value to preserve precision
         // This prevents rounding issues when slider is dragged to max
         if (percentage === 100) {
-            amount = type === 'stake' ? this.userBalance : this.userStaked;
+            amount = type === 'stake' || type === 'remove-liquidity' ? this.userBalance : this.userStaked;
         } else {
             // For other percentages, calculate the amount
-            const maxAmount = parseFloat(type === 'stake' ? this.userBalance : this.userStaked) || 0;
+            const maxAmount = parseFloat(type === 'stake' || type === 'remove-liquidity' ? this.userBalance : this.userStaked) || 0;
             amount = (maxAmount * percentage / 100).toFixed(6);
         }
 
@@ -2856,6 +3405,14 @@ class StakingModalNew {
             if (input) input.value = amount;
             this.updateUnstakeUsdEstimate();
             this.updateButtonStates();
+        } else if (type === 'remove-liquidity') {
+            this.removeLiquidityAmount = amount;
+            const input = document.getElementById('remove-liquidity-amount-input');
+            if (input) input.value = amount;
+            this.updateRemoveLiquidityUsdEstimate();
+            this.updateRemoveLiquidityBalanceError();
+            this.resetRemoveLiquidityPreview();
+            this.debounceRemoveLiquidityPreview();
         }
     }
 
@@ -3418,6 +3975,19 @@ window.safeModalExecuteZap = function() {
     }
 };
 
+window.safeModalExecuteRemoveLiquidity = function() {
+    try {
+        const modal = window.stakingModal || window.stakingModalNew || window.getStakingModal();
+        if (modal && typeof modal.executeRemoveLiquidity === 'function') {
+            modal.executeRemoveLiquidity();
+        } else {
+            console.warn('⚠️ Modal executeRemoveLiquidity method not available');
+        }
+    } catch (error) {
+        console.error('❌ Error executing remove liquidity:', error);
+    }
+};
+
 window.safeModalAddZapCustomToken = function() {
     try {
         const modal = window.stakingModal || window.stakingModalNew || window.getStakingModal();
@@ -3428,5 +3998,18 @@ window.safeModalAddZapCustomToken = function() {
         }
     } catch (error) {
         console.error('❌ Error adding custom zap token:', error);
+    }
+};
+
+window.safeModalFetchRemoveLiquidityPreview = function() {
+    try {
+        const modal = window.stakingModal || window.stakingModalNew || window.getStakingModal();
+        if (modal && typeof modal.fetchRemoveLiquidityPreview === 'function') {
+            modal.fetchRemoveLiquidityPreview({ force: true });
+        } else {
+            console.warn('⚠️ Modal fetchRemoveLiquidityPreview method not available');
+        }
+    } catch (error) {
+        console.error('❌ Error fetching remove-liquidity preview:', error);
     }
 };

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -238,6 +238,8 @@ describe('StakingModalNew zap cleanup', () => {
         delete globalThis.safeModalFetchZapQuote;
         delete globalThis.safeModalExecuteZap;
         delete globalThis.safeModalAddZapCustomToken;
+        delete globalThis.safeModalExecuteRemoveLiquidity;
+        delete globalThis.safeModalFetchRemoveLiquidityPreview;
     });
 
     it('clearInputs removes active zap percentage button state', async () => {
@@ -377,7 +379,7 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('4 LP <span class="lp-usd-estimate">($80.00)</span>');
     });
 
-    it('renders a disabled Remove LP tab shell with LP balance and amount controls', async () => {
+    it('renders a Remove LP tab with LP balance, amount controls, and preview panel', async () => {
         const modal = await createLoadedModal();
         modal.currentPair = { tvlUsd: 2000, tvl: 100 };
         modal.userBalance = '4';
@@ -391,10 +393,112 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('$30.00');
         expect(html).toContain('id="remove-liquidity-slider"');
         expect(html).toContain('data-type="remove-liquidity"');
+        expect(html).toContain('Max slippage:');
+        expect(html).toContain('id="remove-liquidity-preview-panel"');
         expect(html).toContain('Remove LP Liquidity');
-        expect(html).toContain('disabled title="Remove LP execution is added in a later PR"');
+        expect(html).toContain('disabled title="Remove LP execution is added in the next PR."');
         expect(html).not.toContain('remove-liquidity-checkbox');
-        expect(html).not.toContain('remove-liquidity-preview');
+    });
+
+    it('renders V2 remove-liquidity preview rows for pair tokens and minimum outputs', async () => {
+        const modal = await createLoadedModal();
+        modal.removeLiquidityAmount = '1';
+        modal.userBalance = '10';
+        modal.removeLiquidityPreviewStatus = 'ready';
+        modal.removeLiquidityPreview = {
+            supported: true,
+            adapter: { name: 'Uniswap V2' },
+            token0: {
+                symbol: 'LIB',
+                decimals: 18,
+                amount: { raw: '1000000000000000000' },
+                minAmount: { raw: '995000000000000000' }
+            },
+            token1: {
+                symbol: 'USDT',
+                decimals: 18,
+                amount: { raw: '2000000000000000000' },
+                minAmount: { raw: '1990000000000000000' }
+            }
+        };
+
+        const html = modal.renderRemoveLiquidityPreviewPanel();
+
+        expect(html).toContain('LIB + USDT via Uniswap V2');
+        expect(html).toContain('1 LIB + 2 USDT');
+        expect(html).toContain('0.995 LIB + 1.99 USDT');
+        expect(html).toContain('Uniswap V2');
+    });
+
+    it('shows unsupported remove-liquidity factories in the preview panel', async () => {
+        const modal = await createLoadedModal();
+        modal.removeLiquidityAmount = '1';
+        modal.userBalance = '10';
+        modal.removeLiquidityPreviewStatus = 'error';
+        modal.removeLiquidityPreviewError = 'This LP factory is not supported for guided remove liquidity.';
+        modal.removeLiquidityPreview = {
+            supported: false,
+            factoryAddress: '0x1234567890123456789012345678901234567890'
+        };
+
+        const html = modal.renderRemoveLiquidityPreviewPanel();
+
+        expect(html).toContain('This LP factory is not supported for guided remove liquidity.');
+        expect(html).toContain('Unsupported factory 0x1234...7890');
+    });
+
+    it('fetches a V2 remove-liquidity preview for the selected LP amount', async () => {
+        const modal = await createLoadedModal();
+        const preview = {
+            supported: true,
+            adapter: { name: 'Uniswap V2' },
+            token0: { symbol: 'LIB', decimals: 18, amount: { raw: '1' }, minAmount: { raw: '1' } },
+            token1: { symbol: 'USDT', decimals: 18, amount: { raw: '1' }, minAmount: { raw: '1' } }
+        };
+        modal.currentPair = { lpToken: '0xlp' };
+        modal.removeLiquidityAmount = '1';
+        modal.userBalanceRaw = { gte: vi.fn(() => true) };
+        modal.userBalanceDecimals = 18;
+        modal.removeLiquidityService = {
+            getPreview: vi.fn().mockResolvedValue(preview)
+        };
+        modal.updateRemoveLiquidityPreviewPanel = vi.fn();
+        modal.updateRemoveLiquidityButton = vi.fn();
+        globalThis.networkSelector = { getCurrentChainId: vi.fn(() => 56) };
+        globalThis.contractManager = { provider: { name: 'provider' } };
+
+        await modal.fetchRemoveLiquidityPreview({ force: true });
+
+        expect(modal.removeLiquidityService.getPreview).toHaveBeenCalledWith(expect.objectContaining({
+            chainId: 56,
+            lpTokenAddress: '0xlp',
+            slippageBps: 50,
+            provider: globalThis.contractManager.provider
+        }));
+        expect(modal.removeLiquidityPreview).toBe(preview);
+        expect(modal.removeLiquidityPreviewStatus).toBe('ready');
+    });
+
+    it('updates remove-liquidity slippage, deadline, and amount controls', async () => {
+        const modal = await createLoadedModal();
+        modal.currentPair = { tvlUsd: 100, tvl: 10 };
+        modal.userBalance = '4';
+        modal.currentTab = 'remove-liquidity';
+        const estimateElement = document.registerElement(createElement({ id: 'remove-liquidity-usd-estimate' }));
+        const inputElement = document.registerElement(createElement({ id: 'remove-liquidity-amount-input' }));
+        modal.fetchRemoveLiquidityPreview = vi.fn();
+
+        modal.setRemoveLiquiditySlippage('100');
+        modal.setPercentage(50);
+        modal.updateAmountFromSlider({ dataset: { type: 'remove-liquidity' }, value: '25' });
+        const deadlineValue = modal.setRemoveLiquidityDeadlineInput('45');
+
+        expect(modal.removeLiquiditySlippageBps).toBe(100);
+        expect(modal.removeLiquidityAmount).toBe('1.000000');
+        expect(inputElement.value).toBe('1.000000');
+        expect(estimateElement.textContent).toBe('$10.00');
+        expect(deadlineValue).toBe('45');
+        expect(modal.removeLiquidityDeadlineMinutes).toBe(45);
     });
 
     it('startZapQuoteAutoRefresh stops instead of refreshing while zap is executing', async () => {


### PR DESCRIPTION
## Base branch
`split/remove-lp-02-tab-shell`

## What to review
- Wires Remove LP input, slider, percentage controls, slippage, and deadline state.
- Fetches plain V2 remove-liquidity previews through `V2RemoveLiquidityService`.
- Shows pair-token output rows, minimum outputs, DEX support, and unsupported factory/network errors.
- Keeps the destructive action disabled until the execution PR.

## Flow added
This PR makes the tab read-only useful: entering an LP amount now drives preview discovery and output math, including unsupported states. It still does not send transactions.

```mermaid
flowchart LR
    A[User enters LP amount] --> B[Validate wallet LP balance]
    B --> C{Amount valid?}
    C -- no --> D[Show balance/input error]
    C -- yes --> E[Fetch V2 preview]
    E --> F{Factory/router supported?}
    F -- no --> G[Show unsupported message]
    F -- yes --> H[Show token0 + token1 expected outputs]
    H --> I[Show min outputs from slippage]
    I --> J[Action still disabled]
```

## Intentionally deferred
- No LP approval or `removeLiquidity` transaction execution.
- No Kyber zap-out checkbox, output-token selector, or zap-out quote.

## Tests
- `npm test -- tests/staking-modal-new.test.js tests/v2-remove-liquidity-service.test.js`