### PR TITLE
Split Remove LP 04: plain V2 execution

### DIFF
--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -68,7 +68,9 @@ class StakingModalNew {
             unstake: 'idle',
             claim: 'idle',
             approveZap: 'idle',
-            zap: 'idle'
+            zap: 'idle',
+            approveRemoveLiquidity: 'idle',
+            removeLiquidity: 'idle'
         };
         this.pendingOperations = {
             approve: false,
@@ -76,7 +78,9 @@ class StakingModalNew {
             unstake: false,
             claim: false,
             approveZap: false,
-            zap: false
+            zap: false,
+            approveRemoveLiquidity: false,
+            removeLiquidity: false
         };
 
         // Execution guards
@@ -115,6 +119,10 @@ class StakingModalNew {
                 return 'approveZap';
             case 'zapIntoLP':
                 return 'zap';
+            case 'approveRemoveLiquidity':
+                return 'approveRemoveLiquidity';
+            case 'removeLiquidity':
+                return 'removeLiquidity';
             default:
                 return null;
         }
@@ -155,6 +163,10 @@ class StakingModalNew {
 
         if (action === 'approveZap' || action === 'zap') {
             this.updateZapButton();
+        }
+
+        if (action === 'approveRemoveLiquidity' || action === 'removeLiquidity') {
+            this.updateRemoveLiquidityButton();
         }
     }
 
@@ -2304,22 +2316,43 @@ class StakingModalNew {
         const removeButton = document.querySelector('.modal-actions .btn-primary[onclick*="safeModalExecuteRemoveLiquidity"]');
         if (!removeButton) return;
 
+        const buttonIcon = removeButton.querySelector('.material-icons');
+        const buttonText = removeButton.childNodes[removeButton.childNodes.length - 1];
         const amount = parseFloat(this.removeLiquidityAmount) || 0;
         const hasAmount = amount > 0;
+        const balanceRaw = this.userBalanceRaw || window.ethers.BigNumber.from(0);
+        const removeUnits = window.ethers.utils.parseUnits(this.removeLiquidityAmount || '0', this.userBalanceDecimals);
+        const hasSufficientBalance = balanceRaw.gte(removeUnits);
         const hasValidPreview = this.removeLiquidityPreviewStatus === 'ready'
             && this.removeLiquidityPreview?.supported;
-        const balanceError = this.getRemoveLiquidityBalanceError();
+        const approvePhase = this.actionPhases?.approveRemoveLiquidity || 'idle';
+        const removePhase = this.actionPhases?.removeLiquidity || 'idle';
+        const activePhase = approvePhase !== 'idle' ? approvePhase : removePhase;
 
-        removeButton.disabled = true;
-        if (balanceError && hasAmount) {
-            removeButton.title = balanceError;
+        if (activePhase !== 'idle') {
+            removeButton.disabled = true;
+            if (buttonIcon) buttonIcon.textContent = 'hourglass_empty';
+            if (buttonText) buttonText.textContent = this.getPhaseLabel(activePhase) || ' Processing Transaction...';
+            return;
+        }
+
+        const shouldDisable = this.isExecutingRemoveLiquidity
+            || !hasAmount
+            || !hasSufficientBalance
+            || !hasValidPreview;
+        removeButton.disabled = shouldDisable;
+        if (!hasSufficientBalance && hasAmount) {
+            removeButton.title = 'Insufficient LP token balance.';
         } else if (!hasAmount) {
             removeButton.title = 'Enter an LP amount to preview removal.';
         } else if (!hasValidPreview) {
             removeButton.title = this.removeLiquidityPreviewError || 'Wait for a supported remove-liquidity preview.';
         } else {
-            removeButton.title = 'Remove LP execution is added in the next PR.';
+            removeButton.title = 'Remove LP liquidity';
         }
+
+        if (buttonIcon) buttonIcon.textContent = 'swap_horiz';
+        if (buttonText) buttonText.textContent = ' Remove LP Liquidity';
     }
 
     /**
@@ -2834,7 +2867,7 @@ class StakingModalNew {
 
             <div class="modal-actions">
                 <button class="btn btn-secondary" onclick="safeModalClose()">Cancel</button>
-                <button class="btn btn-primary remove-liquidity-action-btn" onclick="safeModalExecuteRemoveLiquidity()" disabled title="Remove LP execution is added in the next PR.">
+                <button class="btn btn-primary remove-liquidity-action-btn" onclick="safeModalExecuteRemoveLiquidity()" ${!this.removeLiquidityAmount || parseFloat(this.removeLiquidityAmount) === 0 ? 'disabled' : ''}>
                     <span class="material-icons">swap_horiz</span>
                     Remove LP Liquidity
                 </button>
@@ -3574,6 +3607,157 @@ class StakingModalNew {
             this.isExecutingZap = false;
             this.updateZapButton();
             this.syncZapQuoteAutoRefresh();
+        }
+    }
+
+    async executeRemoveLiquidityTransaction(lpTokenAddress, liquidityRaw) {
+        const service = this.getRemoveLiquidityService();
+        const provider = window.contractManager?.provider || window.walletManager?.provider;
+
+        await window.contractManager.ensureSigner();
+        const signer = window.contractManager.signer;
+        const userAddress = await signer.getAddress();
+
+        if (!this.removeLiquidityPreview?.supported) {
+            await this.fetchRemoveLiquidityPreview({ force: true });
+        }
+
+        const preview = this.removeLiquidityPreview;
+        if (!preview?.supported) {
+            throw new Error(this.removeLiquidityPreviewError || 'Remove liquidity is not supported for this pool.');
+        }
+
+        await service.validateRouterFactory({
+            routerAddress: preview.adapter.routerAddress,
+            factoryAddress: preview.adapter.factoryAddress,
+            provider
+        });
+
+        const lpBalance = await service.getBalance({
+            lpTokenAddress,
+            owner: userAddress,
+            provider
+        });
+        if (lpBalance.lt(liquidityRaw)) {
+            throw new Error('Insufficient LP token balance.');
+        }
+
+        const allowance = await service.getAllowance({
+            lpTokenAddress,
+            owner: userAddress,
+            spender: preview.adapter.routerAddress,
+            provider
+        });
+
+        if (allowance.lt(liquidityRaw)) {
+            this.pendingOperations.approveRemoveLiquidity = true;
+            this.setActionPhase('approveRemoveLiquidity', 'userApproval');
+            window.notificationManager?.info('Approving router to spend LP tokens...');
+
+            const approvalTx = await service.approveIfNeeded({
+                lpTokenAddress,
+                spender: preview.adapter.routerAddress,
+                liquidityRaw,
+                signer
+            });
+
+            if (approvalTx) {
+                await window.contractManager.executeTransactionOnce(async () => {
+                    console.log(`✅ Remove-liquidity approval sent: ${approvalTx.hash}`);
+                    return approvalTx;
+                }, 'approveRemoveLiquidity');
+            }
+
+            this.pendingOperations.approveRemoveLiquidity = false;
+            this.setActionPhase('approveRemoveLiquidity', 'idle');
+        }
+
+        const deadlineSeconds = Math.floor(Date.now() / 1000) + (Number(this.removeLiquidityDeadlineMinutes) || 20) * 60;
+        this.pendingOperations.removeLiquidity = true;
+        this.setActionPhase('removeLiquidity', 'userApproval');
+        window.notificationManager?.info('Removing liquidity...');
+
+        return window.contractManager.executeTransactionOnce(async () => {
+            const tx = await service.removeLiquidity({
+                routerAddress: preview.adapter.routerAddress,
+                token0: preview.token0.address,
+                token1: preview.token1.address,
+                liquidityRaw,
+                amount0Min: preview.token0.minAmount.raw,
+                amount1Min: preview.token1.minAmount.raw,
+                recipient: userAddress,
+                deadline: deadlineSeconds,
+                signer
+            });
+            console.log(`✅ Remove liquidity transaction sent: ${tx.hash}`);
+            return tx;
+        }, 'removeLiquidity');
+    }
+
+    async executeRemoveLiquidity() {
+        if (this.isExecutingRemoveLiquidity) {
+            console.log('⚠️ Remove liquidity already in progress, ignoring duplicate call');
+            return;
+        }
+
+        if (!this.removeLiquidityAmount || parseFloat(this.removeLiquidityAmount) === 0) return;
+
+        try {
+            this.isExecutingRemoveLiquidity = true;
+            this.updateRemoveLiquidityButton();
+
+            if (!window.contractManager || !window.contractManager.isReady()) {
+                window.notificationManager?.error('Contract manager not ready. Please connect your wallet first.');
+                return;
+            }
+
+            const slippageError = this.getRemoveLiquidityCustomSlippageError();
+            if (slippageError) {
+                this.updateRemoveLiquidityPreviewPanel();
+                this.updateRemoveLiquidityButton();
+                window.notificationManager?.error(slippageError);
+                return;
+            }
+
+            if (!this.removeLiquidityPreview?.supported) {
+                await this.fetchRemoveLiquidityPreview({ force: true });
+            }
+
+            if (!this.removeLiquidityPreview?.supported) {
+                window.notificationManager?.error(this.removeLiquidityPreviewError || 'Remove liquidity is not supported for this pool.');
+                return;
+            }
+
+            window.notificationManager?.info('Removing LP liquidity...');
+            const lpTokenAddress = this.currentPair.lpToken || this.currentPair.address;
+            const liquidityRaw = this.getRemoveLiquidityAmountRaw();
+            await this.executeRemoveLiquidityTransaction(lpTokenAddress, liquidityRaw);
+            window.notificationManager?.success('Liquidity removed successfully!');
+
+            this.clearInputs();
+            this.close();
+
+            await new Promise(resolve => setTimeout(resolve, 2000));
+
+            if (window.homePage?.refreshData) {
+                await window.homePage.refreshData();
+            } else if (window.homePage?.loadData) {
+                await window.homePage.loadData();
+            }
+        } catch (error) {
+            console.error('❌ Remove liquidity failed:', error);
+            const errorMessage = error?.userMessage?.message || error?.message || 'Remove liquidity failed. Your LP tokens remain in your wallet.';
+            window.notificationManager?.error(errorMessage, {title: error?.userMessage?.title});
+            await this.loadUserBalances().catch(loadError => {
+                console.warn('Unable to refresh balances after remove-liquidity failure:', loadError.message);
+            });
+        } finally {
+            this.pendingOperations.approveRemoveLiquidity = false;
+            this.pendingOperations.removeLiquidity = false;
+            this.setActionPhase('approveRemoveLiquidity', 'idle');
+            this.setActionPhase('removeLiquidity', 'idle');
+            this.isExecutingRemoveLiquidity = false;
+            this.updateRemoveLiquidityButton();
         }
     }
 

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -202,6 +202,46 @@ function arrangeReadyZapQuote(modal, data = { route: '0xroute' }) {
     modal.zapQuote = { data };
 }
 
+function createComparableAmount(value) {
+    return {
+        value,
+        gte: other => Number(value) >= Number(other?.value ?? other),
+        lt: other => Number(value) < Number(other?.value ?? other),
+        toString: () => String(value)
+    };
+}
+
+function arrangeReadyRemoveLiquidityPreview(modal) {
+    modal.currentPair = { name: 'LIB/USDT', lpToken: '0xlp' };
+    modal.removeLiquidityAmount = '1';
+    modal.userBalance = '2';
+    modal.userBalanceRaw = createComparableAmount(2);
+    modal.userBalanceDecimals = 18;
+    modal.removeLiquidityPreviewStatus = 'ready';
+    modal.removeLiquidityPreview = {
+        supported: true,
+        adapter: {
+            name: 'Uniswap V2',
+            routerAddress: '0xrouter',
+            factoryAddress: '0xfactory'
+        },
+        token0: {
+            address: '0xlib',
+            symbol: 'LIB',
+            decimals: 18,
+            amount: { raw: '1000000000000000000' },
+            minAmount: { raw: '995000000000000000' }
+        },
+        token1: {
+            address: '0xusdt',
+            symbol: 'USDT',
+            decimals: 18,
+            amount: { raw: '2000000000000000000' },
+            minAmount: { raw: '1990000000000000000' }
+        }
+    };
+}
+
 describe('StakingModalNew zap cleanup', () => {
     beforeEach(() => {
         vi.useRealTimers();
@@ -396,7 +436,7 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('Max slippage:');
         expect(html).toContain('id="remove-liquidity-preview-panel"');
         expect(html).toContain('Remove LP Liquidity');
-        expect(html).toContain('disabled title="Remove LP execution is added in the next PR."');
+        expect(html).toContain('onclick="safeModalExecuteRemoveLiquidity()"');
         expect(html).not.toContain('remove-liquidity-checkbox');
     });
 
@@ -499,6 +539,113 @@ describe('StakingModalNew zap cleanup', () => {
         expect(estimateElement.textContent).toBe('$10.00');
         expect(deadlineValue).toBe('45');
         expect(modal.removeLiquidityDeadlineMinutes).toBe(45);
+    });
+
+    it('enables the Remove LP button only after a supported preview is ready', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        const button = {
+            disabled: true,
+            title: '',
+            querySelector: vi.fn(() => null),
+            childNodes: []
+        };
+        document.querySelector = vi.fn(() => button);
+
+        modal.updateRemoveLiquidityButton();
+
+        expect(button.disabled).toBe(false);
+        expect(button.title).toBe('Remove LP liquidity');
+    });
+
+    it('executes plain V2 remove liquidity with approval when allowance is insufficient', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-05-13T12:00:00Z'));
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.close = vi.fn();
+        modal.clearInputs = vi.fn();
+        modal.updateRemoveLiquidityButton = vi.fn();
+        const service = {
+            validateRouterFactory: vi.fn().mockResolvedValue(true),
+            getBalance: vi.fn().mockResolvedValue(createComparableAmount(2)),
+            getAllowance: vi.fn().mockResolvedValue(createComparableAmount(0)),
+            approveIfNeeded: vi.fn().mockResolvedValue({ hash: '0xapprove' }),
+            removeLiquidity: vi.fn().mockResolvedValue({ hash: '0xremove' })
+        };
+        modal.removeLiquidityService = service;
+        const signer = { getAddress: vi.fn().mockResolvedValue('0xuser') };
+        globalThis.contractManager = {
+            isReady: vi.fn(() => true),
+            provider: { name: 'provider' },
+            signer,
+            ensureSigner: vi.fn().mockResolvedValue(undefined),
+            executeTransactionOnce: vi.fn(async operation => {
+                await operation();
+                return { success: true, hash: '0xreceipt' };
+            })
+        };
+        globalThis.notificationManager = { info: vi.fn(), success: vi.fn(), error: vi.fn() };
+        globalThis.homePage = { refreshData: vi.fn().mockResolvedValue(undefined) };
+
+        const promise = modal.executeRemoveLiquidity();
+        await vi.runAllTimersAsync();
+        await promise;
+
+        expect(service.approveIfNeeded).toHaveBeenCalledWith(expect.objectContaining({
+            lpTokenAddress: '0xlp',
+            spender: '0xrouter',
+            signer
+        }));
+        expect(service.removeLiquidity).toHaveBeenCalledWith(expect.objectContaining({
+            routerAddress: '0xrouter',
+            token0: '0xlib',
+            token1: '0xusdt',
+            amount0Min: '995000000000000000',
+            amount1Min: '1990000000000000000',
+            recipient: '0xuser',
+            deadline: 1778674800
+        }));
+        expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenCalledWith(expect.any(Function), 'approveRemoveLiquidity');
+        expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenCalledWith(expect.any(Function), 'removeLiquidity');
+        expect(globalThis.notificationManager.success).toHaveBeenCalledWith('Liquidity removed successfully!');
+        expect(globalThis.homePage.refreshData).toHaveBeenCalled();
+    });
+
+    it('skips Remove LP approval when allowance is sufficient', async () => {
+        vi.useFakeTimers();
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.close = vi.fn();
+        modal.clearInputs = vi.fn();
+        modal.updateRemoveLiquidityButton = vi.fn();
+        const service = {
+            validateRouterFactory: vi.fn().mockResolvedValue(true),
+            getBalance: vi.fn().mockResolvedValue(createComparableAmount(2)),
+            getAllowance: vi.fn().mockResolvedValue(createComparableAmount(2)),
+            approveIfNeeded: vi.fn(),
+            removeLiquidity: vi.fn().mockResolvedValue({ hash: '0xremove' })
+        };
+        modal.removeLiquidityService = service;
+        globalThis.contractManager = {
+            isReady: vi.fn(() => true),
+            provider: { name: 'provider' },
+            signer: { getAddress: vi.fn().mockResolvedValue('0xuser') },
+            ensureSigner: vi.fn().mockResolvedValue(undefined),
+            executeTransactionOnce: vi.fn(async operation => {
+                await operation();
+                return { success: true, hash: '0xreceipt' };
+            })
+        };
+        globalThis.notificationManager = { info: vi.fn(), success: vi.fn(), error: vi.fn() };
+
+        const promise = modal.executeRemoveLiquidity();
+        await vi.runAllTimersAsync();
+        await promise;
+
+        expect(service.approveIfNeeded).not.toHaveBeenCalled();
+        expect(service.removeLiquidity).toHaveBeenCalled();
+        expect(globalThis.contractManager.executeTransactionOnce).toHaveBeenCalledTimes(1);
     });
 
     it('startZapQuoteAutoRefresh stops instead of refreshing while zap is executing', async () => {


### PR DESCRIPTION
## Base branch
`split/remove-lp-03-v2-preview`

## What to review
- Enables the plain V2 Remove LP action once a supported preview is ready.
- Validates router/factory, checks LP wallet balance, checks allowance, approves the router only when needed, then calls V2 `removeLiquidity`.
- Adds refresh and notification handling for success/failure.
- Keeps failure behavior scoped so LP tokens remain in the wallet if approve/remove fails.

## Flow added
This PR makes the unchecked/plain V2 flow usable end to end. The modal only executes after a supported preview exists, then performs the approval gate and router removal.

```mermaid
flowchart LR
    A[Supported V2 preview ready] --> B[Click Remove LP]
    B --> C[Validate router factory]
    C --> D[Check wallet LP balance]
    D --> E{Router allowance enough?}
    E -- no --> F[Approve router for LP]
    E -- yes --> G[Skip approval]
    F --> H[Call router.removeLiquidity]
    G --> H
    H --> I[Refresh balances/home data]
    H -- failure --> J[Show error; LP remains in wallet]
```

## Intentionally deferred
- No Kyber zap-out service usage from the modal.
- No output-token selector or checked conversion flow.

## Tests
- `npm test -- tests/staking-modal-new.test.js tests/v2-remove-liquidity-service.test.js`