### PR TITLE
Split Remove LP 05: Kyber zap-out service

### DIFF
--- a/js/services/kyber-zap-service.js
+++ b/js/services/kyber-zap-service.js
@@ -306,6 +306,65 @@
             return payload;
         }
 
+        async fetchOutQuote({ networkConfig, lpTokenAddress, walletAddress, tokenOutAddress, liquidityRaw, slippageBps, platform }) {
+            const initialRateLimitWaitMs = this.getQuoteRateLimitWaitMs();
+            if (initialRateLimitWaitMs > 0) {
+                throw this.createRateLimitError(initialRateLimitWaitMs);
+            }
+
+            if (!networkConfig) {
+                throw new Error('Zap out is not available on this network.');
+            }
+
+            const baseUrl = this.getConfig()?.BASE_URL || 'https://zap-api.kyberswap.com';
+            const dexCandidates = await this.getDexCandidates({ networkConfig, poolAddress: lpTokenAddress, platform });
+            let payload = null;
+            let lastError = null;
+
+            for (const dexId of dexCandidates) {
+                const rateLimit = this.quoteRateLimiter.reserve();
+                if (!rateLimit.allowed) {
+                    throw this.createRateLimitError(rateLimit.waitMs);
+                }
+
+                const params = new URLSearchParams({
+                    dexFrom: dexId,
+                    'poolFrom.id': lpTokenAddress,
+                    'positionFrom.id': walletAddress,
+                    liquidityOut: liquidityRaw.toString(),
+                    tokenOut: tokenOutAddress,
+                    slippage: slippageBps.toString()
+                });
+
+                const url = `${baseUrl}/${networkConfig.CHAIN}/api/v1/out/route?${params.toString()}`;
+                const response = await this.fetchImpl(url, {
+                    headers: {
+                        accept: 'application/json',
+                        'x-client-id': this.getConfig()?.CLIENT_ID || 'liberdus-lp-staking'
+                    }
+                });
+                const candidatePayload = await response.json().catch(() => ({}));
+                const failed = !response.ok || (candidatePayload.code && candidatePayload.code !== 0 && candidatePayload.code !== 200);
+
+                if (!failed) {
+                    payload = candidatePayload;
+                    break;
+                }
+
+                lastError = new Error(candidatePayload.message || `Kyber zap-out quote failed with status ${response.status}`);
+                const canTryNextDex = /invalid pool|does not belong to given dex id/i.test(lastError.message);
+                if (!canTryNextDex) {
+                    break;
+                }
+            }
+
+            if (!payload) {
+                throw lastError || new Error('Unable to fetch a Kyber zap-out quote.');
+            }
+
+            return payload;
+        }
+
         async buildRoute({ networkConfig, route, sender, recipient = sender, deadline }) {
             if (!networkConfig) {
                 throw new Error('Zap is not available on this network.');
@@ -335,6 +394,40 @@
 
             if (!response.ok || (payload.code && payload.code !== 0 && payload.code !== 200)) {
                 throw new Error(payload.message || `Kyber build failed with status ${response.status}`);
+            }
+
+            return payload?.data || payload;
+        }
+
+        async buildOutRoute({ networkConfig, route, sender, recipient = sender, deadline }) {
+            if (!networkConfig) {
+                throw new Error('Zap out is not available on this network.');
+            }
+
+            if (!route) {
+                throw new Error('Kyber zap-out route is missing. Refresh the quote and try again.');
+            }
+
+            const baseUrl = this.getConfig()?.BASE_URL || 'https://zap-api.kyberswap.com';
+            const response = await this.fetchImpl(`${baseUrl}/${networkConfig.CHAIN}/api/v1/out/route/build`, {
+                method: 'POST',
+                headers: {
+                    accept: 'application/json',
+                    'content-type': 'application/json',
+                    'x-client-id': this.getConfig()?.CLIENT_ID || 'liberdus-lp-staking'
+                },
+                body: JSON.stringify({
+                    sender,
+                    recipient,
+                    route,
+                    deadline,
+                    source: this.getConfig()?.SOURCE || 'liberdus-lp-staking'
+                })
+            });
+            const payload = await response.json().catch(() => ({}));
+
+            if (!response.ok || (payload.code && payload.code !== 0 && payload.code !== 200)) {
+                throw new Error(payload.message || `Kyber zap-out build failed with status ${response.status}`);
             }
 
             return payload?.data || payload;

--- a/js/utils/version-check.js
+++ b/js/utils/version-check.js
@@ -175,6 +175,11 @@
             
             // JavaScript - Root
             `${basePath}js/master-initializer.js`,
+
+            // JavaScript - Services
+            `${basePath}js/services/kyber-zap-rate-limiter.js`,
+            `${basePath}js/services/kyber-zap-service.js`,
+            `${basePath}js/services/v2-remove-liquidity-service.js`,
             
             // JavaScript - Utils (only existing files)
             `${basePath}js/utils/admin-test.js`,
@@ -202,6 +207,7 @@
             `${basePath}css/base.css`,
             `${basePath}css/components.css`,
             `${basePath}css/network-indicator-selector.css`,
+            `${basePath}css/staking-modal.css`,
             `${basePath}css/theme-toggle.css`,
             `${basePath}css/wallet-popup.css`
         ];

--- a/tests/kyber-zap-service.test.js
+++ b/tests/kyber-zap-service.test.js
@@ -142,6 +142,99 @@ describe('KyberZapService', () => {
         );
     });
 
+    it('builds Kyber zap-out quote URLs with pool, position, liquidity, token out, and slippage', async () => {
+        const KyberZapService = await loadKyberZapService();
+        globalThis.fetch = vi.fn().mockResolvedValue(createJsonResponse({
+            payload: { data: { route: '0xout' } }
+        }));
+        const service = new KyberZapService();
+
+        const quote = await service.fetchOutQuote({
+            networkConfig: { CHAIN: 'bsc', DEX: 'DEX_UNISWAPV2' },
+            lpTokenAddress: '0xlp',
+            walletAddress: '0xwallet',
+            tokenOutAddress: '0xouttoken',
+            liquidityRaw: { toString: () => '500' },
+            slippageBps: 75,
+            platform: null
+        });
+
+        expect(quote.data.route).toBe('0xout');
+        expect(globalThis.fetch).toHaveBeenCalledWith(
+            'https://zap-api.kyberswap.com/bsc/api/v1/out/route?dexFrom=DEX_UNISWAPV2&poolFrom.id=0xlp&positionFrom.id=0xwallet&liquidityOut=500&tokenOut=0xouttoken&slippage=75',
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    accept: 'application/json',
+                    'x-client-id': 'liberdus-lp-staking'
+                })
+            })
+        );
+    });
+
+    it('tries fallback DEX candidates for Kyber zap-out quotes', async () => {
+        const KyberZapService = await loadKyberZapService();
+        globalThis.fetch = vi.fn()
+            .mockResolvedValueOnce(createJsonResponse({
+                ok: false,
+                status: 400,
+                payload: { message: 'Pool does not belong to given dex id' }
+            }))
+            .mockResolvedValueOnce(createJsonResponse({
+                payload: { data: { route: '0xout' } }
+            }));
+        const service = new KyberZapService();
+
+        const quote = await service.fetchOutQuote({
+            networkConfig: {
+                CHAIN: 'bsc',
+                DEX: 'DEX_UNISWAPV2',
+                DEX_CANDIDATES: ['DEX_PANCAKESWAPV2']
+            },
+            lpTokenAddress: '0xlp',
+            walletAddress: '0xwallet',
+            tokenOutAddress: '0xouttoken',
+            liquidityRaw: { toString: () => '500' },
+            slippageBps: 75,
+            platform: null
+        });
+
+        expect(quote.data.route).toBe('0xout');
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+        expect(globalThis.fetch.mock.calls[0][0]).toContain('dexFrom=DEX_UNISWAPV2');
+        expect(globalThis.fetch.mock.calls[1][0]).toContain('dexFrom=DEX_PANCAKESWAPV2');
+    });
+
+    it('builds Kyber zap-out routes through the out build endpoint', async () => {
+        const KyberZapService = await loadKyberZapService();
+        globalThis.fetch = vi.fn().mockResolvedValue(createJsonResponse({
+            payload: { data: { txData: '0xabcdef' } }
+        }));
+        const service = new KyberZapService();
+
+        const build = await service.buildOutRoute({
+            networkConfig: { CHAIN: 'bsc' },
+            route: '0xout',
+            sender: '0xsender',
+            recipient: '0xrecipient',
+            deadline: 1777306663
+        });
+
+        expect(build.txData).toBe('0xabcdef');
+        expect(globalThis.fetch).toHaveBeenCalledWith(
+            'https://zap-api.kyberswap.com/bsc/api/v1/out/route/build',
+            expect.objectContaining({
+                method: 'POST',
+                body: JSON.stringify({
+                    sender: '0xsender',
+                    recipient: '0xrecipient',
+                    route: '0xout',
+                    deadline: 1777306663,
+                    source: 'liberdus-lp-staking'
+                })
+            })
+        );
+    });
+
     it('fetches and caches GeckoTerminal token market metadata', async () => {
         const KyberZapService = await loadKyberZapService();
         globalThis.fetch = vi.fn().mockResolvedValue(createJsonResponse({


### PR DESCRIPTION
## Base branch
`split/remove-lp-04-v2-execution`

## What to review
- Adds Kyber zap-out quote/build service APIs.
- Adds DEX candidate fallback behavior for zap-out.
- Adds version-check entries for the changed/new service assets.
- Adds isolated Kyber service tests for zap-out quote URL construction, fallback candidates, and route build.

## Flow added
This PR adds Kyber zap-out service plumbing only. The modal does not call it yet; the service can request a zap-out quote and build the executable Kyber route data.

```mermaid
flowchart LR
    A[LP token + amount + desired output token] --> B[Choose chain network config]
    B --> C[Resolve DEX candidates]
    C --> D[Request Kyber zap-out quote]
    D --> E{Quote succeeds?}
    E -- no --> F[Try fallback DEX candidate]
    F --> D
    E -- yes --> G[Return route data]
    G --> H[Build zap-out transaction payload]
```

## Intentionally deferred
- No Remove LP modal checkbox or output-token selector yet.
- No modal execution path for Kyber `zapOutLP` yet.

## Tests
- `npm test -- tests/kyber-zap-service.test.js tests/v2-remove-liquidity-service.test.js tests/staking-modal-new.test.js`