### PR TITLE
Highlight Create LP custom slippage selection

### DIFF
--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -30,6 +30,7 @@ class StakingModalNew {
         this.zapSlippageBps = window.CONFIG?.KYBER_ZAP?.DEFAULT_SLIPPAGE_BPS || 50;
         this.zapCustomSlippage = '';
         this.zapCustomSlippageError = '';
+        this.zapCustomSlippageSelected = false;
         this.zapDeadlineMinutes = window.CONFIG?.KYBER_ZAP?.DEFAULT_DEADLINE_MINUTES || 20;
         this.zapQuoteDebounceTimer = null;
         this.zapQuoteRequestId = 0;
@@ -348,6 +349,10 @@ class StakingModalNew {
         });
 
         document.addEventListener('focusin', (e) => {
+            if (e.target.id === 'zap-custom-slippage-input') {
+                this.selectZapCustomSlippage();
+            }
+
             if (e.target.id === 'remove-liquidity-custom-slippage-input') {
                 this.selectRemoveLiquidityCustomSlippage();
             }
@@ -1471,6 +1476,8 @@ class StakingModalNew {
 
     setZapSlippage(value) {
         if (value === 'custom') {
+            this.zapCustomSlippageSelected = true;
+            this.updateZapSlippageButtonState();
             const customInput = document.getElementById('zap-custom-slippage-input');
             if (customInput) customInput.focus();
         } else {
@@ -1479,6 +1486,7 @@ class StakingModalNew {
                 this.zapSlippageBps = parsed;
                 this.zapCustomSlippage = '';
                 this.zapCustomSlippageError = '';
+                this.zapCustomSlippageSelected = false;
                 this.resetZapQuoteState();
                 this.renderTabContent();
                 this.debounceZapQuote();
@@ -1504,13 +1512,36 @@ class StakingModalNew {
     }
 
     isZapCustomSlippageActive() {
-        return !!this.zapCustomSlippage && !this.hasInvalidZapCustomSlippage();
+        return (this.zapCustomSlippageSelected || !!this.zapCustomSlippage)
+            && !this.hasInvalidZapCustomSlippage();
+    }
+
+    updateZapSlippageButtonState() {
+        document.querySelectorAll('.zap-slippage-btn').forEach(button => {
+            if (button.classList.contains('remove-liquidity-slippage-btn')) {
+                return;
+            }
+
+            const isCustom = button.dataset?.slippage === 'custom';
+            const isPreset = Number(button.dataset?.slippage) === this.zapSlippageBps;
+            const isActive = isCustom
+                ? this.isZapCustomSlippageActive()
+                : isPreset && !this.zapCustomSlippageSelected && !this.zapCustomSlippage;
+            button.classList.toggle('active', isActive);
+        });
+    }
+
+    selectZapCustomSlippage() {
+        this.zapCustomSlippageSelected = true;
+        this.updateZapSlippageButtonState();
     }
 
     setZapCustomSlippageInput(value) {
         const sanitizedValue = this.applyDecimalLimit(String(value ?? ''), 2);
         this.zapCustomSlippage = sanitizedValue;
+        this.zapCustomSlippageSelected = true;
         this.zapCustomSlippageError = this.getZapCustomSlippageError(sanitizedValue);
+        this.updateZapSlippageButtonState();
         this.updateCustomSlippageFieldError(
             'zap-custom-slippage-input',
             'zap-custom-slippage-error',
@@ -2969,6 +3000,7 @@ class StakingModalNew {
         this.zapQuoteInFlightKey = '';
         this.zapCustomSlippage = '';
         this.zapCustomSlippageError = '';
+        this.zapCustomSlippageSelected = false;
         this.zapQuoteRequestId += 1;
         this.stopZapQuoteAutoRefresh();
         this.clearZapQuoteRateLimitTimer();
@@ -3896,7 +3928,7 @@ class StakingModalNew {
                 <label class="form-label">Slippage</label>
                 <div class="zap-slippage-row">
                     ${slippageOptions.map(option => `
-                        <button class="zap-slippage-btn ${this.zapSlippageBps === option && !this.zapCustomSlippage ? 'active' : ''}" data-slippage="${option}">
+                        <button class="zap-slippage-btn ${this.zapSlippageBps === option && !this.zapCustomSlippageSelected && !this.zapCustomSlippage ? 'active' : ''}" data-slippage="${option}">
                             ${(option / 100).toFixed(1)}%
                         </button>
                     `).join('')}

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -1476,8 +1476,7 @@ class StakingModalNew {
 
     setZapSlippage(value) {
         if (value === 'custom') {
-            this.zapCustomSlippageSelected = true;
-            this.updateZapSlippageButtonState();
+            this.selectZapCustomSlippage();
             const customInput = document.getElementById('zap-custom-slippage-input');
             if (customInput) customInput.focus();
         } else {

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -702,7 +702,46 @@ describe('StakingModalNew zap cleanup', () => {
 
         expect(modal.zapCustomSlippage).toBe('');
         expect(modal.zapCustomSlippageError).toBe('');
+        expect(modal.zapCustomSlippageSelected).toBe(false);
         expect(modal.hasInvalidZapCustomSlippage()).toBe(false);
+    });
+
+    it('highlights custom zap slippage when selected before typing a value', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyZapQuote(modal);
+
+        modal.setZapSlippage('custom');
+        const html = modal.renderZapTab();
+        const slippageButtons = [...html.matchAll(/<button[\s\S]*?class="([^"]*)"[\s\S]*?data-slippage="([^"]+)"[\s\S]*?>/g)]
+            .filter(([, className]) => className.includes('zap-slippage-btn'));
+        const defaultButton = slippageButtons.find(([, , value]) => value === '50');
+        const customButton = slippageButtons.find(([, , value]) => value === 'custom');
+
+        expect(modal.zapCustomSlippageSelected).toBe(true);
+        expect(defaultButton?.[1]).not.toContain('active');
+        expect(customButton?.[1]).toContain('active');
+    });
+
+    it('highlights custom zap slippage when the input is focused', async () => {
+        const modal = await createLoadedModal();
+        const defaultButton = document.registerElement(createElement({
+            classes: ['zap-slippage-btn', 'active']
+        }));
+        defaultButton.dataset.slippage = '50';
+        const customButton = document.registerElement(createElement({
+            classes: ['zap-slippage-btn']
+        }));
+        customButton.dataset.slippage = 'custom';
+        const customInput = document.registerElement(createElement({
+            id: 'zap-custom-slippage-input'
+        }));
+        const focusHandler = document.addEventListener.mock.calls.find(([eventName]) => eventName === 'focusin')?.[1];
+
+        focusHandler({ target: customInput });
+
+        expect(modal.zapCustomSlippageSelected).toBe(true);
+        expect(defaultButton.classList.contains('active')).toBe(false);
+        expect(customButton.classList.contains('active')).toBe(true);
     });
 
     it('valid custom zap slippage applies bps and refreshes quotes', async () => {


### PR DESCRIPTION
## Summary
- Add Create LP custom-slippage selection state so the Custom button can highlight before a value is typed.
- Select the Custom slippage option when the user clicks Custom or focuses the custom slippage input.
- Keep preset selection, custom validation, and quote-refresh behavior intact.

## Flow
1. Clicking the Create LP `Custom` slippage button calls `selectZapCustomSlippage()`, marks custom mode selected, and updates the slippage button classes without needing a typed value.
2. Focusing/clicking/tabbing into the Create LP custom slippage input uses the same selection path, matching the Remove LP tab behavior.
3. While custom mode is selected, preset buttons no longer render as active; typing a valid custom value continues to update bps and refresh the quote as before.
4. Selecting a preset clears the custom value, error, and selected state, then refreshes the quote with the preset slippage.

```mermaid
flowchart TD
    A["User is on Create LP tab"] --> B{"Interaction"}
    B -->|"Clicks Custom slippage"| C["selectZapCustomSlippage()"]
    B -->|"Focuses custom input"| C
    C --> D["Set custom slippage selected"]
    D --> E["Update slippage button states"]
    E --> F["Custom button highlighted"]
    E --> G["Preset buttons not highlighted"]
    F --> H{"Next action"}
    H -->|"Types valid custom value"| I["Apply bps and refresh quote"]
    H -->|"Types invalid custom value"| J["Show field error and keep quote blocked"]
    H -->|"Selects preset"| K["Clear custom value, error, and selected state"]
    K --> L["Refresh quote with preset slippage"]
```

Refs #259.

## Validation
- `git diff --check 3d38dadb6cb6cdf33e3f0bc4678a9b507754cb18`
- `npm test -- tests/staking-modal-new.test.js` -> 87 passed
- `npm test` -> 8 files passed, 154 tests passed