### PR TITLE
Auto-refresh Remove LP zap-out quotes

### DIFF
--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -793,10 +793,8 @@ class StakingModalNew {
     }
 
     stopRemoveLiquidityPreviewAutoRefresh() {
-        if (this.removeLiquidityPreviewRefreshTimer) {
-            clearInterval(this.removeLiquidityPreviewRefreshTimer);
-            this.removeLiquidityPreviewRefreshTimer = null;
-        }
+        clearInterval(this.removeLiquidityPreviewRefreshTimer);
+        this.removeLiquidityPreviewRefreshTimer = null;
     }
 
     resetRemoveLiquidityFormState() {
@@ -1058,11 +1056,15 @@ class StakingModalNew {
         }, delay);
     }
 
-    syncRemoveLiquidityPreviewAutoRefresh() {
-        if (this.isOpen
+    canAutoRefreshRemoveLiquidityPreview() {
+        return this.isOpen
             && this.currentTab === 'remove-liquidity'
             && this.removeLiquidityZapOutEnabled
-            && this.canFetchRemoveLiquidityPreview()) {
+            && this.canFetchRemoveLiquidityPreview();
+    }
+
+    syncRemoveLiquidityPreviewAutoRefresh() {
+        if (this.canAutoRefreshRemoveLiquidityPreview()) {
             this.startRemoveLiquidityPreviewAutoRefresh();
         } else {
             this.stopRemoveLiquidityPreviewAutoRefresh();
@@ -1076,11 +1078,7 @@ class StakingModalNew {
 
         const refreshMs = (this.zapQuoteRefreshSeconds || 10) * 1000;
         this.removeLiquidityPreviewRefreshTimer = setInterval(() => {
-            if (!this.isOpen
-                || this.currentTab !== 'remove-liquidity'
-                || this.isExecutingRemoveLiquidity
-                || !this.removeLiquidityZapOutEnabled
-                || !this.canFetchRemoveLiquidityPreview()) {
+            if (this.isExecutingRemoveLiquidity || !this.canAutoRefreshRemoveLiquidityPreview()) {
                 this.stopRemoveLiquidityPreviewAutoRefresh();
                 return;
             }

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -59,7 +59,7 @@ class StakingModalNew {
         this.removeLiquiditySettingsOpen = false;
         this.removeLiquidityPreviewDebounceTimer = null;
         this.removeLiquidityPreviewRefreshTimer = null;
-        this.removeLiquidityPreviewCountdown = 10;
+        this.removeLiquidityPreviewCountdown = this.zapQuoteRefreshSeconds;
         this.removeLiquidityPreviewRequestId = 0;
         this.removeLiquidityOutputTokenAddress = '';
         this.removeLiquidityOutputTokens = [];

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -58,6 +58,7 @@ class StakingModalNew {
         this.removeLiquidityDeadlineMinutes = window.CONFIG?.KYBER_ZAP?.DEFAULT_DEADLINE_MINUTES || 20;
         this.removeLiquiditySettingsOpen = false;
         this.removeLiquidityPreviewDebounceTimer = null;
+        this.removeLiquidityPreviewRefreshTimer = null;
         this.removeLiquidityPreviewRequestId = 0;
         this.removeLiquidityOutputTokenAddress = '';
         this.removeLiquidityOutputTokens = [];
@@ -791,6 +792,13 @@ class StakingModalNew {
         }
     }
 
+    stopRemoveLiquidityPreviewAutoRefresh() {
+        if (this.removeLiquidityPreviewRefreshTimer) {
+            clearInterval(this.removeLiquidityPreviewRefreshTimer);
+            this.removeLiquidityPreviewRefreshTimer = null;
+        }
+    }
+
     resetRemoveLiquidityFormState() {
         this.removeLiquidityZapOutEnabled = false;
         this.removeLiquidityAmount = '';
@@ -805,6 +813,7 @@ class StakingModalNew {
         this.removeLiquidityCustomOutputTokenError = '';
         this.removeLiquidityPreviewRequestId += 1;
         this.clearRemoveLiquidityPreviewDebounce();
+        this.stopRemoveLiquidityPreviewAutoRefresh();
     }
 
     resetRemoveLiquidityPreview({ status = 'idle', error = '' } = {}) {
@@ -813,6 +822,7 @@ class StakingModalNew {
         this.removeLiquidityPreviewError = error;
         this.removeLiquidityPreviewRequestId += 1;
         this.clearRemoveLiquidityPreviewDebounce();
+        this.syncRemoveLiquidityPreviewAutoRefresh();
         this.updateRemoveLiquidityPreviewPanel();
         this.updateRemoveLiquidityButton();
     }
@@ -1036,18 +1046,56 @@ class StakingModalNew {
         this.clearRemoveLiquidityPreviewDebounce();
 
         if (!this.canFetchRemoveLiquidityPreview()) {
+            this.stopRemoveLiquidityPreviewAutoRefresh();
             this.updateRemoveLiquidityPreviewPanel();
             this.updateRemoveLiquidityButton();
             return;
         }
 
+        this.syncRemoveLiquidityPreviewAutoRefresh();
         this.removeLiquidityPreviewDebounceTimer = setTimeout(() => {
             this.fetchRemoveLiquidityPreview();
         }, delay);
     }
 
+    syncRemoveLiquidityPreviewAutoRefresh() {
+        if (this.isOpen
+            && this.currentTab === 'remove-liquidity'
+            && this.removeLiquidityZapOutEnabled
+            && this.canFetchRemoveLiquidityPreview()) {
+            this.startRemoveLiquidityPreviewAutoRefresh();
+        } else {
+            this.stopRemoveLiquidityPreviewAutoRefresh();
+        }
+    }
+
+    startRemoveLiquidityPreviewAutoRefresh() {
+        if (this.removeLiquidityPreviewRefreshTimer) {
+            return;
+        }
+
+        const refreshMs = (this.zapQuoteRefreshSeconds || 10) * 1000;
+        this.removeLiquidityPreviewRefreshTimer = setInterval(() => {
+            if (!this.isOpen
+                || this.currentTab !== 'remove-liquidity'
+                || this.isExecutingRemoveLiquidity
+                || !this.removeLiquidityZapOutEnabled
+                || !this.canFetchRemoveLiquidityPreview()) {
+                this.stopRemoveLiquidityPreviewAutoRefresh();
+                return;
+            }
+
+            if (this.removeLiquidityPreviewStatus === 'loading') {
+                return;
+            }
+
+            this.fetchRemoveLiquidityPreview({ force: true });
+        }, refreshMs);
+    }
+
     async fetchRemoveLiquidityPreview({ force = false } = {}) {
         if (!this.canPrepareRemoveLiquidityPreview()) {
+            this.stopRemoveLiquidityPreviewAutoRefresh();
             this.updateRemoveLiquidityPreviewPanel();
             this.updateRemoveLiquidityButton();
             return;
@@ -1148,6 +1196,7 @@ class StakingModalNew {
             if (requestId === this.removeLiquidityPreviewRequestId) {
                 this.updateRemoveLiquidityPreviewPanel();
                 this.updateRemoveLiquidityButton();
+                this.syncRemoveLiquidityPreviewAutoRefresh();
             }
         }
     }
@@ -3027,6 +3076,7 @@ class StakingModalNew {
     switchTab(tab) {
         this.currentTab = tab;
         this.syncZapQuoteAutoRefresh();
+        this.syncRemoveLiquidityPreviewAutoRefresh();
 
         // Update tab buttons
         document.querySelectorAll('.tab-button').forEach(btn => {

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -59,6 +59,7 @@ class StakingModalNew {
         this.removeLiquiditySettingsOpen = false;
         this.removeLiquidityPreviewDebounceTimer = null;
         this.removeLiquidityPreviewRefreshTimer = null;
+        this.removeLiquidityPreviewCountdown = 10;
         this.removeLiquidityPreviewRequestId = 0;
         this.removeLiquidityOutputTokenAddress = '';
         this.removeLiquidityOutputTokens = [];
@@ -795,6 +796,7 @@ class StakingModalNew {
     stopRemoveLiquidityPreviewAutoRefresh() {
         clearInterval(this.removeLiquidityPreviewRefreshTimer);
         this.removeLiquidityPreviewRefreshTimer = null;
+        this.resetRemoveLiquidityPreviewCountdown();
     }
 
     resetRemoveLiquidityFormState() {
@@ -1073,10 +1075,11 @@ class StakingModalNew {
 
     startRemoveLiquidityPreviewAutoRefresh() {
         if (this.removeLiquidityPreviewRefreshTimer) {
+            this.updateRemoveLiquidityPreviewCountdownDisplay();
             return;
         }
 
-        const refreshMs = (this.zapQuoteRefreshSeconds || 10) * 1000;
+        this.resetRemoveLiquidityPreviewCountdown();
         this.removeLiquidityPreviewRefreshTimer = setInterval(() => {
             if (this.isExecutingRemoveLiquidity || !this.canAutoRefreshRemoveLiquidityPreview()) {
                 this.stopRemoveLiquidityPreviewAutoRefresh();
@@ -1084,11 +1087,32 @@ class StakingModalNew {
             }
 
             if (this.removeLiquidityPreviewStatus === 'loading') {
+                this.updateRemoveLiquidityPreviewCountdownDisplay();
                 return;
             }
 
-            this.fetchRemoveLiquidityPreview({ force: true });
-        }, refreshMs);
+            this.removeLiquidityPreviewCountdown = Math.max(0, this.removeLiquidityPreviewCountdown - 1);
+            this.updateRemoveLiquidityPreviewCountdownDisplay();
+
+            if (this.removeLiquidityPreviewCountdown === 0) {
+                this.resetRemoveLiquidityPreviewCountdown();
+                this.fetchRemoveLiquidityPreview({ force: true });
+            }
+        }, 1000);
+    }
+
+    resetRemoveLiquidityPreviewCountdown(seconds = this.zapQuoteRefreshSeconds) {
+        this.removeLiquidityPreviewCountdown = seconds;
+        this.updateRemoveLiquidityPreviewCountdownDisplay();
+    }
+
+    updateRemoveLiquidityPreviewCountdownDisplay() {
+        const countdown = document.getElementById('remove-liquidity-preview-countdown');
+        if (countdown) {
+            countdown.textContent = this.canAutoRefreshRemoveLiquidityPreview()
+                ? `${this.removeLiquidityPreviewCountdown}s`
+                : '--';
+        }
     }
 
     async fetchRemoveLiquidityPreview({ force = false } = {}) {
@@ -3753,11 +3777,18 @@ class StakingModalNew {
     }
 
     renderRemoveLiquidityPreviewCard(cardClass, summary, rows, isLoading, refreshLabel, warningMessages = []) {
+        const countdownDisplay = this.canAutoRefreshRemoveLiquidityPreview()
+            ? `${this.removeLiquidityPreviewCountdown}s`
+            : '--';
+
         return `
             <div class="${cardClass}">
                 <div class="zap-quote-header">
                     <div class="zap-route-summary">${this.escapeHtml(summary)}</div>
                     <div class="zap-refresh-controls">
+                        ${this.removeLiquidityZapOutEnabled ? `
+                            <span id="remove-liquidity-preview-countdown" class="zap-quote-countdown">${this.escapeHtml(countdownDisplay)}</span>
+                        ` : ''}
                         <button
                             type="button"
                             class="zap-refresh-btn"

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1251,6 +1251,68 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).not.toContain('Unsupported</dd>');
     });
 
+    it('auto-refreshes checked remove-liquidity zap-out previews', async () => {
+        vi.useFakeTimers();
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
+        modal.isOpen = true;
+        modal.currentTab = 'remove-liquidity';
+        modal.fetchRemoveLiquidityPreview = vi.fn();
+
+        modal.syncRemoveLiquidityPreviewAutoRefresh();
+        await vi.advanceTimersByTimeAsync(10000);
+
+        expect(modal.removeLiquidityPreviewRefreshTimer).not.toBeNull();
+        expect(modal.fetchRemoveLiquidityPreview).toHaveBeenCalledWith({ force: true });
+        modal.stopRemoveLiquidityPreviewAutoRefresh();
+    });
+
+    it('does not auto-refresh direct remove-liquidity previews', async () => {
+        vi.useFakeTimers();
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.isOpen = true;
+        modal.currentTab = 'remove-liquidity';
+        modal.fetchRemoveLiquidityPreview = vi.fn();
+
+        modal.syncRemoveLiquidityPreviewAutoRefresh();
+        await vi.advanceTimersByTimeAsync(10000);
+
+        expect(modal.removeLiquidityPreviewRefreshTimer).toBeNull();
+        expect(modal.fetchRemoveLiquidityPreview).not.toHaveBeenCalled();
+    });
+
+    it('stops remove-liquidity zap-out auto-refresh when leaving the flow', async () => {
+        vi.useFakeTimers();
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
+        modal.isOpen = true;
+        modal.currentTab = 'remove-liquidity';
+
+        modal.syncRemoveLiquidityPreviewAutoRefresh();
+        expect(modal.removeLiquidityPreviewRefreshTimer).not.toBeNull();
+
+        modal.currentTab = 'zap';
+        modal.syncRemoveLiquidityPreviewAutoRefresh();
+
+        expect(modal.removeLiquidityPreviewRefreshTimer).toBeNull();
+    });
+
+    it('stops remove-liquidity zap-out auto-refresh when the form resets', async () => {
+        vi.useFakeTimers();
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
+        modal.isOpen = true;
+        modal.currentTab = 'remove-liquidity';
+
+        modal.syncRemoveLiquidityPreviewAutoRefresh();
+        expect(modal.removeLiquidityPreviewRefreshTimer).not.toBeNull();
+
+        modal.resetRemoveLiquidityFormState();
+
+        expect(modal.removeLiquidityPreviewRefreshTimer).toBeNull();
+    });
+
     it('derives checked remove-liquidity output amount from Kyber zap-out actions', async () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal, { convert: true });

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1258,13 +1258,42 @@ describe('StakingModalNew zap cleanup', () => {
         modal.isOpen = true;
         modal.currentTab = 'remove-liquidity';
         modal.fetchRemoveLiquidityPreview = vi.fn();
+        const countdown = document.registerElement(createElement({ id: 'remove-liquidity-preview-countdown' }));
 
         modal.syncRemoveLiquidityPreviewAutoRefresh();
-        await vi.advanceTimersByTimeAsync(10000);
+        await vi.advanceTimersByTimeAsync(1000);
 
+        expect(countdown.textContent).toBe('9s');
+        expect(modal.fetchRemoveLiquidityPreview).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(9000);
+
+        expect(countdown.textContent).toBe('10s');
         expect(modal.removeLiquidityPreviewRefreshTimer).not.toBeNull();
         expect(modal.fetchRemoveLiquidityPreview).toHaveBeenCalledWith({ force: true });
         modal.stopRemoveLiquidityPreviewAutoRefresh();
+    });
+
+    it('renders a countdown for checked remove-liquidity zap-out previews', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
+        modal.isOpen = true;
+        modal.currentTab = 'remove-liquidity';
+
+        const html = modal.renderRemoveLiquidityPreviewPanel();
+
+        expect(html).toContain('id="remove-liquidity-preview-countdown"');
+        expect(html).toContain('10s');
+    });
+
+    it('does not render a countdown for direct remove-liquidity previews', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.isOpen = true;
+        modal.currentTab = 'remove-liquidity';
+
+        const html = modal.renderRemoveLiquidityPreviewPanel();
+
+        expect(html).not.toContain('remove-liquidity-preview-countdown');
     });
 
     it('does not auto-refresh direct remove-liquidity previews', async () => {


### PR DESCRIPTION
## Summary
- Add Remove LP zap-out preview auto-refresh so checked zap-out quotes update like the Create LP Zap tab.
- Start the refresh loop only when the modal is open, the Remove LP tab is active, zap-out is checked, and the form can fetch a preview.
- Stop the refresh loop when the user leaves the flow, resets the form, disables zap-out, enters an invalid state, or execution is in progress.

## Flow
1. Opening Remove LP with `Convert to one preferred token` checked calls `syncRemoveLiquidityPreviewAutoRefresh()` after preview state changes.
2. If the tab is active and the form can fetch a zap-out preview, `startRemoveLiquidityPreviewAutoRefresh()` starts a 10-second interval using the existing quote refresh cadence.
3. Each interval skips while a preview is already loading, stops during execution or invalid states, and otherwise refreshes the Kyber zap-out preview with `force: true`.
4. Switching tabs, resetting the Remove LP form, unchecking zap-out, or entering a non-fetchable state stops the interval so direct/basic remove liquidity does not auto-refresh.

```mermaid
flowchart TD
    A["User is on Remove LP tab"] --> B{"Convert to one preferred token checked?"}
    B -->|"No"| C["Stop zap-out auto-refresh"]
    B -->|"Yes"| D{"Can fetch Remove LP preview?"}
    D -->|"No"| C
    D -->|"Yes"| E["Start 10s refresh interval"]
    E --> F{"Interval tick"}
    F -->|"Executing or invalid state"| C
    F -->|"Preview already loading"| G["Skip this tick"]
    F -->|"Ready to refresh"| H["fetchRemoveLiquidityPreview({ force: true })"]
    H --> I["Update quote panel and button state"]
    I --> D
    G --> E
    C --> J["No background Remove LP quote polling"]
```

Refs #258.

## Validation
- `git diff --check guided-v2-remove-liquidity`
- `npm test -- tests/staking-modal-new.test.js` -> 89 passed
- `npm test` -> 8 files passed, 156 tests passed