### PR TITLE
Add ownership controls to admin panel

### DIFF
--- a/css/admin-combined.css
+++ b/css/admin-combined.css
@@ -318,12 +318,14 @@ table tbody tr:last-child td {
 
 [data-theme="light"] .info-card,
 [data-theme="light"] .pair-item-card,
+[data-theme="light"] .ownership-item,
 [data-theme="light"] .signer-address {
   background: rgba(0, 0, 0, 0.02);
   border-color: rgba(0, 0, 0, 0.1);
 }
 
 [data-theme="light"] .pair-item-card:hover,
+[data-theme="light"] .ownership-address:hover,
 [data-theme="light"] .signer-address:hover {
   background: rgba(0, 0, 0, 0.04);
   border-color: rgba(0, 212, 255, 0.3);
@@ -332,6 +334,7 @@ table tbody tr:last-child td {
 [data-theme="light"] .pair-name-section .pair-name,
 [data-theme="light"] .section-header h6,
 [data-theme="light"] .pair-address,
+[data-theme="light"] .ownership-address,
 [data-theme="light"] .signer-address {
   color: rgba(0, 0, 0, 0.8);
 }
@@ -1492,8 +1495,53 @@ table td:last-child {
   transition: width 0.3s ease;
 }
 
+.ownership-section,
 .signers-section {
   margin-top: 20px;
+}
+
+.ownership-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.ownership-entry {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.ownership-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+}
+
+.ownership-item {
+  margin: 0;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  font-family: 'Courier New', 'Monaco', 'Menlo', monospace;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.8);
+  word-break: break-all;
+  transition: all 0.2s ease;
+}
+
+.ownership-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.ownership-action-btn {
+  min-height: 40px;
 }
 
 .signers-list {
@@ -1513,6 +1561,13 @@ table td:last-child {
   color: rgba(255, 255, 255, 0.8);
   word-break: break-all;
   transition: all 0.2s ease;
+}
+
+@media (max-width: 720px) {
+  .ownership-grid,
+  .signers-list {
+    grid-template-columns: 1fr;
+  }
 }
 
 .contract-info-separator {

--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -7,6 +7,9 @@ class AdminPage {
     constructor() {
         this.isInitialized = false;
         this.isAuthorized = false;
+        this.isOwner = false;
+        this.isPendingOwner = false;
+        this.canManageProposals = false;
         this.userAddress = null;
         this.adminRole = null;
         this.contractStats = {};
@@ -39,7 +42,9 @@ class AdminPage {
             '.pair-address',
             '.signer-address',
             '[data-info="staking-address"]',
-            '[data-info="reward-token-address"]'
+            '[data-info="reward-token-address"]',
+            '[data-info="owner-address"]',
+            '[data-info="pending-owner-address"]'
         ].join(', ');
 
         // Initialize asynchronously (don't await in constructor)
@@ -203,6 +208,11 @@ class AdminPage {
                 throw new Error('Wallet not connected');
             }
 
+            this.isAuthorized = false;
+            this.isOwner = false;
+            this.isPendingOwner = false;
+            this.canManageProposals = false;
+
             // Check against authorized admin list first (development/fallback)
             if (window.DEV_CONFIG?.AUTHORIZED_ADMINS) {
                 const isAuthorizedAdmin = window.DEV_CONFIG.AUTHORIZED_ADMINS.some(
@@ -211,45 +221,37 @@ class AdminPage {
 
                 if (isAuthorizedAdmin) {
                     this.isAuthorized = true;
+                    this.canManageProposals = true;
                     return;
                 }
             }
 
-            // Check if user has admin role via contract
+            // Check if user has admin or standard ownership access via contract
             if (window.contractManager?.stakingContract) {
+                let hasAdminRole = false;
+
                 try {
-                    // Try to call hasRole function
-                    const hasAdminRole = await window.contractManager.hasAdminRole(this.userAddress);
+                    hasAdminRole = await window.contractManager.hasAdminRole(this.userAddress);
+                } catch (adminRoleError) {
+                    console.warn('Admin role check failed:', adminRoleError.message);
+                }
 
-                    if (hasAdminRole) {
-                        this.isAuthorized = true;
-                        return;
+                try {
+                    if (typeof window.contractManager.isOwner === 'function') {
+                        this.isOwner = await window.contractManager.isOwner(this.userAddress);
                     }
 
-                    if (typeof window.contractManager.hasOwnerApproverRole === 'function') {
-                        const hasOwnerRole = await window.contractManager.hasOwnerApproverRole(this.userAddress);
-                        this.isAuthorized = hasOwnerRole;
-
-                        if (this.isAuthorized) return;
-                    } else {
-                        this.isAuthorized = false;
+                    if (typeof window.contractManager.isPendingOwner === 'function') {
+                        this.isPendingOwner = await window.contractManager.isPendingOwner(this.userAddress);
                     }
+                } catch (ownerError) {
+                    console.warn('Ownership access check failed:', ownerError.message);
+                }
 
-                } catch (roleError) {
-                    console.error('⚠️ Role check failed, checking owner approver role as fallback:', roleError.message);
-
-                    if (typeof window.contractManager?.hasOwnerApproverRole === 'function') {
-                        try {
-                            const hasOwnerRole = await window.contractManager.hasOwnerApproverRole(this.userAddress);
-                            this.isAuthorized = hasOwnerRole;
-                            console.warn(`🔐 Owner approver role fallback: ${hasOwnerRole ? 'AUTHORIZED' : 'DENIED'}`);
-
-                            if (this.isAuthorized) return;
-
-                        } catch (ownerRoleError) {
-                            console.error('⚠️ Owner approver fallback failed:', ownerRoleError.message);
-                        }
-                    }
+                if (hasAdminRole || this.isOwner || this.isPendingOwner) {
+                    this.isAuthorized = true;
+                    this.canManageProposals = hasAdminRole || this.isOwner;
+                    return;
                 }
             } else {
                 console.warn('⚠️ Staking contract not available for role verification');
@@ -335,7 +337,7 @@ class AdminPage {
                     
                     <div class="access-details">
                         <p><strong>Your Address:</strong> ${this.userAddress}</p>
-                        <p><strong>Required Role:</strong> ADMIN_ROLE or OWNER_APPROVER_ROLE</p>
+                        <p><strong>Required Access:</strong> ADMIN_ROLE, contract owner, or pending owner</p>
                     </div>
                 </div>
             </div>
@@ -789,6 +791,9 @@ class AdminPage {
                                 break;
                             case 'withdrawal-form':
                                 await this.submitWithdrawalProposal(e);
+                                break;
+                            case 'transfer-ownership-form':
+                                await this.submitTransferOwnership(e);
                                 break;
                             default:
                                 console.error('📝 Unhandled form submission:', form.id);
@@ -1274,12 +1279,15 @@ class AdminPage {
      */
     setProposalButtonsEnabled(enabled) {
         const proposalButtons = document.querySelectorAll('.proposal-btn');
+        const canEnable = enabled && this.canManageProposals;
 
         proposalButtons.forEach(button => {
-            button.disabled = !enabled;
-            button.setAttribute('aria-disabled', (!enabled).toString());
-            if (enabled) {
+            button.disabled = !canEnable;
+            button.setAttribute('aria-disabled', (!canEnable).toString());
+            if (canEnable) {
                 button.removeAttribute('title');
+            } else if (enabled && !this.canManageProposals) {
+                button.title = 'Accept ownership before managing proposals';
             } else if (!button.hasAttribute('title')) {
                 button.title = 'Unavailable while proposals load';
             }
@@ -1514,8 +1522,6 @@ class AdminPage {
                         </div>
                     </div>
 
-                    <hr class="contract-info-separator">
-
                     <div class="pairs-section">
                         <div class="section-header">
                             <h6>Eligible Pairs</h6>
@@ -1533,6 +1539,17 @@ class AdminPage {
                         </div>
                         <div class="signers-list" data-info="signers">
                             <div class="info-value">Loading signers...</div>
+                        </div>
+                    </div>
+
+                    <hr class="contract-info-separator">
+
+                    <div class="ownership-section">
+                        <div class="section-header">
+                            <h6>Contract Ownership</h6>
+                        </div>
+                        <div class="ownership-list" data-info="ownership">
+                            <div class="info-value">Loading ownership...</div>
                         </div>
                     </div>
                 </div>
@@ -2721,6 +2738,46 @@ class AdminPage {
         `).join('');
     }
 
+    renderOwnershipInfo(owner, pendingOwner) {
+        const ownerDisplay = owner || 'Unavailable';
+        const pendingOwnerDisplay = this.hasPendingOwner(pendingOwner) ? pendingOwner : 'None';
+        const canTransfer = this.isCurrentOwner(owner);
+        const canCancel = canTransfer && this.hasPendingOwner(pendingOwner);
+        const canAccept = this.isCurrentPendingOwner(pendingOwner);
+
+        return `
+            <div class="ownership-grid">
+                <div class="ownership-entry">
+                    <span class="ownership-label">Owner</span>
+                    <p class="ownership-item ownership-address address-display" data-info="owner-address" ${owner ? `data-address="${owner}" title="Click to copy address"` : ''}>${ownerDisplay}</p>
+                </div>
+                <div class="ownership-entry">
+                    <span class="ownership-label">Pending Owner</span>
+                    <p class="ownership-item ownership-address address-display" data-info="pending-owner-address" ${this.hasPendingOwner(pendingOwner) ? `data-address="${pendingOwner}" title="Click to copy address"` : ''}>${pendingOwnerDisplay}</p>
+                </div>
+            </div>
+            ${canTransfer || canAccept ? `
+                <div class="ownership-actions">
+                    ${canTransfer ? `
+                        <button type="button" class="btn btn-primary ownership-action-btn" onclick="adminPage.showTransferOwnershipModal()">
+                            Transfer Ownership
+                        </button>
+                    ` : ''}
+                    ${canCancel ? `
+                        <button type="button" class="btn btn-secondary ownership-action-btn" onclick="adminPage.cancelOwnershipTransfer()">
+                            Cancel Transfer
+                        </button>
+                    ` : ''}
+                    ${canAccept ? `
+                        <button type="button" class="btn btn-primary ownership-action-btn" onclick="adminPage.acceptOwnership()">
+                            Accept Ownership
+                        </button>
+                    ` : ''}
+                </div>
+            ` : ''}
+        `;
+    }
+
     async showDashboard() {
         const contentDiv = document.getElementById('admin-section-content');
         
@@ -2967,6 +3024,30 @@ class AdminPage {
     formatAddress(address) {
         if (!address) return 'Unknown';
         return `${address.slice(0, 6)}...${address.slice(-4)}`;
+    }
+
+    getZeroAddress() {
+        return window.ethers?.constants?.AddressZero || '0x0000000000000000000000000000000000000000';
+    }
+
+    addressesMatch(a, b) {
+        return !!a && !!b && a.toLowerCase() === b.toLowerCase();
+    }
+
+    hasPendingOwner(pendingOwner) {
+        return !!pendingOwner &&
+            !this.addressesMatch(pendingOwner, this.getZeroAddress()) &&
+            pendingOwner !== 'Error' &&
+            pendingOwner !== 'Unavailable';
+    }
+
+    isCurrentOwner(owner = this.contractStats?.owner) {
+        return this.addressesMatch(owner, this.userAddress);
+    }
+
+    isCurrentPendingOwner(pendingOwner = this.contractStats?.pendingOwner) {
+        return this.hasPendingOwner(pendingOwner) &&
+            this.addressesMatch(pendingOwner, this.userAddress);
     }
 
     startAutoRefresh() {
@@ -4018,6 +4099,65 @@ class AdminPage {
         this.applyModalVisibilityFixes(modalContainer);
     }
 
+    showTransferOwnershipModal() {
+        const modalContainer = document.getElementById('modal-container');
+        if (!modalContainer) return;
+
+        if (!this.isCurrentOwner()) {
+            this.showError('Only the current contract owner can transfer ownership.');
+            return;
+        }
+
+        const currentOwner = this.contractStats?.owner || this.userAddress || 'Unknown';
+
+        modalContainer.innerHTML = `
+            <div class="modal-overlay" onclick="adminPage.closeModal()">
+                <div class="modal-content" onclick="event.stopPropagation()">
+                    <div class="modal-header">
+                        <h3>Transfer Ownership</h3>
+                        <button class="modal-close" type="button" onclick="adminPage.closeModal()">
+                            <span class="material-icons">close</span>
+                        </button>
+                    </div>
+
+                    <div class="modal-body">
+                        <form id="transfer-ownership-form">
+                            <div class="form-group">
+                                <label>Current Owner</label>
+                                <code class="ownership-address address-display" data-address="${currentOwner}" title="Click to copy address">${currentOwner}</code>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="new-owner">New Owner Address</label>
+                                <input type="text" id="new-owner" required
+                                       placeholder="0x..." pattern="^0x[a-fA-F0-9]{40}$">
+                                <small class="form-help">The new owner must call accept ownership before the transfer is complete.</small>
+                            </div>
+
+                            <div class="warning-box">
+                                <div class="warning-text">
+                                    <strong>Important:</strong> Ownership controls contract-level owner actions.
+                                    Confirm this wallet is controlled by the intended owner.
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary modal-cancel">
+                            Cancel
+                        </button>
+                        <button type="submit" form="transfer-ownership-form" class="btn btn-primary">
+                            Start Ownership Transfer
+                        </button>
+                    </div>
+                </div>
+            </div>
+        `;
+
+        this.applyModalVisibilityFixes(modalContainer);
+    }
+
     showWithdrawalModal() {
         const modalContainer = document.getElementById('modal-container');
         if (!modalContainer) return;
@@ -4348,6 +4488,28 @@ class AdminPage {
             contractInfo.rewardTokenAddress = rewardTokenAddress;
             this.contractStats.rewardTokenAddress = rewardTokenAddress;
 
+            contractInfo.owner = await this.safeContractCall(
+                async () => {
+                    if (typeof contractManager.getOwner === 'function') {
+                        return await contractManager.getOwner();
+                    }
+                    return await contractManager.stakingContract.owner();
+                },
+                null
+            );
+            this.contractStats.owner = contractInfo.owner;
+
+            contractInfo.pendingOwner = await this.safeContractCall(
+                async () => {
+                    if (typeof contractManager.getPendingOwner === 'function') {
+                        return await contractManager.getPendingOwner();
+                    }
+                    return await contractManager.stakingContract.pendingOwner();
+                },
+                this.getZeroAddress()
+            );
+            this.contractStats.pendingOwner = contractInfo.pendingOwner;
+
             let balanceBig = null;
             let rateBig = null;
             let obligationBig = null;
@@ -4453,6 +4615,8 @@ class AdminPage {
                 totalWeight: 'Error',
                 stakingAddress: 'Error',
                 rewardTokenAddress: 'Error',
+                owner: 'Error',
+                pendingOwner: 'Error',
                 pairs: [],
                 signers: []
             };
@@ -4462,6 +4626,8 @@ class AdminPage {
             this.contractStats.rewardObligation = errorInfo.rewardObligation;
             this.contractStats.stakingContractAddress = this.contractStats.stakingContractAddress || null;
             this.contractStats.rewardTokenAddress = this.contractStats.rewardTokenAddress || null;
+            this.contractStats.owner = this.contractStats.owner || null;
+            this.contractStats.pendingOwner = this.contractStats.pendingOwner || this.getZeroAddress();
             this.displayContractInfo(errorInfo);
             return { success: false, error };
         }
@@ -4521,6 +4687,17 @@ class AdminPage {
                 rewardTokenAddressEl.title = 'Click to copy address';
                 rewardTokenAddressEl.setAttribute('data-address', rewardTokenAddress);
             }
+        }
+
+        const ownershipContainer = document.querySelector('[data-info="ownership"]');
+        if (ownershipContainer) {
+            this.contractStats = this.contractStats || {};
+            this.contractStats.owner = info.owner || this.contractStats.owner || null;
+            this.contractStats.pendingOwner = info.pendingOwner || this.contractStats.pendingOwner || this.getZeroAddress();
+            ownershipContainer.innerHTML = this.renderOwnershipInfo(
+                this.contractStats.owner,
+                this.contractStats.pendingOwner
+            );
         }
 
         // Update LP pairs with real contract data
@@ -4988,6 +5165,161 @@ class AdminPage {
         } catch (error) {
             console.error('Failed to create weight update proposal:', error);
             this.showError(error.userMessage?.title || 'Failed to create proposal', error.userMessage?.message);
+        }
+    }
+
+    async submitTransferOwnership(event) {
+        event.preventDefault();
+
+        if (this.isSubmittingOwnershipTransfer) {
+            console.warn('Already submitting ownership transfer, ignoring duplicate request');
+            return;
+        }
+
+        const newOwner = document.getElementById('new-owner')?.value?.trim();
+        const submitBtn = document.querySelector('#transfer-ownership-form button[type="submit"], button[form="transfer-ownership-form"]');
+
+        this.isSubmittingOwnershipTransfer = true;
+        if (submitBtn) {
+            submitBtn.disabled = true;
+            submitBtn.textContent = 'Starting Transfer...';
+        }
+
+        try {
+            if (!this.isCurrentOwner()) {
+                this.showError('Only the current contract owner can transfer ownership.');
+                return;
+            }
+
+            if (!newOwner) {
+                this.showError('Please enter the new owner address');
+                return;
+            }
+
+            if (!ethers.utils.isAddress(newOwner)) {
+                this.showError('Invalid new owner address format');
+                return;
+            }
+
+            if (this.addressesMatch(newOwner, this.contractStats?.owner)) {
+                this.showError('New owner address must be different from the current owner');
+                return;
+            }
+
+            if (window.notificationManager) {
+                window.notificationManager.info('Starting ownership transfer');
+            }
+
+            const contractManager = await this.ensureContractReady();
+            const result = await contractManager.transferOwnership(newOwner);
+
+            if (result.success) {
+                this.closeModal();
+
+                let successMessage = 'Ownership transfer started successfully.';
+                if (result.transactionHash) {
+                    successMessage += ` Transaction: ${result.transactionHash.substring(0, 10)}...`;
+                }
+                this.showSuccess(successMessage);
+                await this.verifyAdminAccess();
+                this.refreshAdminDataOnce();
+            } else {
+                this.showError(result.error?.userMessage?.title || 'Failed to start ownership transfer', result.error?.userMessage?.message || result.error?.message);
+            }
+        } catch (error) {
+            console.error('Failed to start ownership transfer:', error);
+            this.showError(error.userMessage?.title || 'Failed to start ownership transfer', error.userMessage?.message || error.message);
+        } finally {
+            this.isSubmittingOwnershipTransfer = false;
+            if (submitBtn) {
+                submitBtn.disabled = false;
+                submitBtn.textContent = 'Start Ownership Transfer';
+            }
+        }
+    }
+
+    async cancelOwnershipTransfer() {
+        if (this.isCancelingOwnershipTransfer) {
+            console.warn('Already canceling ownership transfer, ignoring duplicate request');
+            return;
+        }
+
+        this.isCancelingOwnershipTransfer = true;
+
+        try {
+            if (!this.isCurrentOwner()) {
+                this.showError('Only the current contract owner can cancel an ownership transfer.');
+                return;
+            }
+
+            if (!this.hasPendingOwner(this.contractStats?.pendingOwner)) {
+                this.showError('There is no pending ownership transfer to cancel.');
+                return;
+            }
+
+            if (window.notificationManager) {
+                window.notificationManager.info('Canceling ownership transfer');
+            }
+
+            const contractManager = await this.ensureContractReady();
+            const result = await contractManager.transferOwnership(this.getZeroAddress());
+
+            if (result.success) {
+                let successMessage = 'Ownership transfer canceled successfully.';
+                if (result.transactionHash) {
+                    successMessage += ` Transaction: ${result.transactionHash.substring(0, 10)}...`;
+                }
+                this.showSuccess(successMessage);
+                await this.verifyAdminAccess();
+                this.refreshAdminDataOnce();
+            } else {
+                this.showError(result.error?.userMessage?.title || 'Failed to cancel ownership transfer', result.error?.userMessage?.message || result.error?.message);
+            }
+        } catch (error) {
+            console.error('Failed to cancel ownership transfer:', error);
+            this.showError(error.userMessage?.title || 'Failed to cancel ownership transfer', error.userMessage?.message || error.message);
+        } finally {
+            this.isCancelingOwnershipTransfer = false;
+        }
+    }
+
+    async acceptOwnership() {
+        if (this.isAcceptingOwnership) {
+            console.warn('Already accepting ownership, ignoring duplicate request');
+            return;
+        }
+
+        this.isAcceptingOwnership = true;
+
+        try {
+            if (!this.isCurrentPendingOwner()) {
+                this.showError('Only the pending owner can accept ownership.');
+                return;
+            }
+
+            if (window.notificationManager) {
+                window.notificationManager.info('Accepting ownership');
+            }
+
+            const contractManager = await this.ensureContractReady();
+            const result = await contractManager.acceptOwnership();
+
+            if (result.success) {
+                let successMessage = 'Ownership accepted successfully.';
+                if (result.transactionHash) {
+                    successMessage += ` Transaction: ${result.transactionHash.substring(0, 10)}...`;
+                }
+                this.showSuccess(successMessage);
+                await this.verifyAdminAccess();
+                this.refreshAdminDataOnce();
+            } else {
+                this.showError(result.error?.userMessage?.title || 'Failed to accept ownership', result.error?.userMessage?.message || result.error?.message);
+            }
+        } catch (error) {
+            console.error('Failed to accept ownership:', error);
+            this.showError(error.userMessage?.title || 'Failed to accept ownership', error.userMessage?.message || error.message);
+        } finally {
+            this.isAcceptingOwnership = false;
         }
     }
 

--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -1361,27 +1361,32 @@ class HomePage {
                 }
             }
 
-            // Check if user has the owner approver role (with timeout and error handling)
-            if (typeof window.contractManager?.hasOwnerApproverRole === 'function') {
+            // Check if user is the contract owner or pending owner (with timeout and error handling)
+            if (typeof window.contractManager?.isOwner === 'function') {
                 try {
                     let timeoutId;
                     const timeoutPromise = new Promise((_, reject) => {
-                        timeoutId = setTimeout(() => reject(new Error('Owner approver role check timeout')), 5000);
+                        timeoutId = setTimeout(() => reject(new Error('Ownership check timeout')), 5000);
                     });
 
-                    const hasOwnerRole = await Promise.race([
-                        window.contractManager.hasOwnerApproverRole(userAddress),
+                    const hasOwnershipAccess = await Promise.race([
+                        Promise.all([
+                            window.contractManager.isOwner(userAddress),
+                            typeof window.contractManager.isPendingOwner === 'function'
+                                ? window.contractManager.isPendingOwner(userAddress)
+                                : Promise.resolve(false)
+                        ]).then(([isOwner, isPendingOwner]) => isOwner || isPendingOwner),
                         timeoutPromise
                     ]);
 
                     clearTimeout(timeoutId);
 
-                    if (hasOwnerRole) {
+                    if (hasOwnershipAccess) {
                         this.showAdminButton();
                         return;
                     }
-                } catch (ownerRoleError) {
-                    console.warn('⚠️ Owner approver role check failed:', ownerRoleError.message);
+                } catch (ownerError) {
+                    console.warn('Ownership check failed:', ownerError.message);
                 }
             }
 

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -73,7 +73,7 @@ window.CONFIG = {
             BLOCK_EXPLORER: 'https://testnet.bscscan.com',
             NATIVE_CURRENCY: { name: 'Test BNB', symbol: 'tBNB', decimals: 18 },
             CONTRACTS: {
-                STAKING_CONTRACT: '0x24F28129B65E9AeDdAfE3f1Fc67ab82DDCF30dF9'
+                STAKING_CONTRACT: '0x87104FB0A772280697F87eE5Af99E18DBbBbbE24'
             }
         }
     },
@@ -283,56 +283,88 @@ window.CONFIG = {
     }
 };
 
-// Contract ABIs (Essential functions for local deployment)
+// Contract ABIs
 window.CONFIG.ABIS = {
     STAKING_CONTRACT: [
-        // Core staking functions
-        'function stake(address lpToken, uint256 amount) external',
-        'function unstake(address lpToken, uint256 amount, bool claimRewards) external',
+        'event ActionApproved(uint256 actionId, address approver)',
+        'event ActionExecuted(uint256 actionId)',
+        'event ActionExpired(uint256 actionId)',
+        'event ActionProposed(uint256 actionId, address proposer, uint8 actionType)',
+        'event ActionRejected(uint256 actionId, address rejecter)',
+        'event HourlyRateUpdated(uint256 newRate)',
+        'event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)',
+        'event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)',
+        'event PairAdded(address lpToken, string platform, uint256 weight)',
+        'event PairRemoved(address lpToken, string pairName)',
+        'event RewardsClaimed(address user, address lpToken, uint256 amount)',
+        'event RewardsClaimedTo(address indexed user, address indexed receiver, address indexed lpToken, uint256 amount)',
+        'event RewardsWithdrawn(address recipient, uint256 amount)',
+        'event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)',
+        'event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)',
+        'event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)',
+        'event SignerChanged(address oldSigner, address newSigner)',
+        'event StakeAdded(address user, address lpToken, uint256 amount)',
+        'event StakeRemoved(address user, address lpToken, uint256 amount)',
+        'event StakeRemovedTo(address indexed user, address indexed receiver, address indexed lpToken, uint256 amount)',
+        'event WeightsUpdated(address[] pairs, uint256[] weights)',
+        'function ADMIN_ROLE() external view returns (bytes32)',
+        'function DEFAULT_ADMIN_ROLE() external view returns (bytes32)',
+        'function MAX_PAIRS() external view returns (uint256)',
+        'function MAX_WEIGHT() external view returns (uint256)',
+        'function MIN_STAKE() external view returns (uint256)',
+        'function PRECISION() external view returns (uint256)',
+        'function REQUIRED_APPROVALS() external view returns (uint256)',
+        'function acceptOwnership() external',
+        'function actionCounter() external view returns (uint256)',
+        'function actions(uint256) external view returns (uint8 actionType, uint256 newHourlyRewardRate, address pairToAdd, string pairNameToAdd, string platformToAdd, uint256 weightToAdd, address pairToRemove, address recipient, uint256 withdrawAmount, bool executed, bool expired, uint8 approvals, uint256 proposedTime, bool rejected)',
+        'function activePairs(uint256) external view returns (address)',
+        'function approveAction(uint256 actionId) external',
         'function claimRewards(address lpToken) external',
-
-        // View functions - User info
-        'function getUserStakeInfo(address user, address lpToken) external view returns (uint256 amount, uint256 pendingRewards, uint256 lastRewardTime)',
+        'function claimRewardsTo(address lpToken, address receiver) external',
+        'function cleanupExpiredActions() external',
         'function earned(address user, address lpToken) external view returns (uint256)',
-
-        // View functions - Pair info
-        'function getPairs() external view returns (tuple(address lpToken, string pairName, string platform, uint256 weight, bool isActive)[])',
+        'function executeAction(uint256 actionId) external',
+        'function getActionApproval(uint256 actionId) external view returns (address[])',
+        'function getActionPairs(uint256 actionId) external view returns (address[])',
+        'function getActionWeights(uint256 actionId) external view returns (uint256[])',
         'function getActivePairs() external view returns (address[])',
-
-        // View functions - Contract state
-        'function rewardToken() external view returns (address)',
-        'function hourlyRewardRate() external view returns (uint256)',
-        'function totalWeight() external view returns (uint256)',
+        'function getPairInfo(address lpToken) external view returns (address token, string platform, uint256 weight, bool isActive)',
+        'function getPairs() external view returns (tuple(address lpToken, string pairName, string platform, uint256 weight, bool isActive)[])',
+        'function getRoleAdmin(bytes32 role) external view returns (bytes32)',
         'function getSigners() external view returns (address[])',
         'function getTotalRewardObligation() external view returns (uint256)',
-
-        // Access control
+        'function getUserStakeInfo(address user, address lpToken) external view returns (uint256 amount, uint256 pendingRewards, uint256 lastRewardTime)',
+        'function getUserStakes(address user) external view returns (tuple(uint256 amount, uint256 lastRewardTime, uint256 pendingRewards, uint256 rewardPerTokenPaid)[])',
+        'function grantRole(bytes32 role, address account) external',
+        'function handleExpiredAction(uint256 actionId) external',
         'function hasRole(bytes32 role, address account) external view returns (bool)',
-        'function ADMIN_ROLE() external view returns (bytes32)',
-        'function OWNER_APPROVER_ROLE() external view returns (bytes32)',
-
-        // ============ GOVERNANCE FUNCTIONS ============
-        // Multi-signature proposal functions
-        'function proposeSetHourlyRewardRate(uint256 newRate) external returns (uint256)',
-        'function proposeUpdatePairWeights(address[] calldata lpTokens, uint256[] calldata weights) external returns (uint256)',
-        'function proposeAddPair(address lpToken, string calldata pairName, string calldata platform, uint256 weight) external returns (uint256)',
-        'function proposeRemovePair(address lpToken) external returns (uint256)',
+        'function hourlyRewardRate() external view returns (uint256)',
+        'function isActionExpired(uint256 actionId) external view returns (bool)',
+        'function lastUpdateTime(address) external view returns (uint256)',
+        'function owner() external view returns (address)',
+        'function pairs(address) external view returns (address lpToken, string pairName, string platform, uint256 weight, bool isActive)',
+        'function pendingOwner() external view returns (address)',
+        'function proposeAddPair(address lpToken, string pairName, string platform, uint256 weight) external returns (uint256)',
         'function proposeChangeSigner(address oldSigner, address newSigner) external returns (uint256)',
+        'function proposeRemovePair(address lpToken) external returns (uint256)',
+        'function proposeSetHourlyRewardRate(uint256 newRate) external returns (uint256)',
+        'function proposeUpdatePairWeights(address[] lpTokens, uint256[] weights) external returns (uint256)',
         'function proposeWithdrawRewards(address recipient, uint256 amount) external returns (uint256)',
-
-        // Multi-signature approval functions
-        'function approveAction(uint256 actionId) external',
         'function rejectAction(uint256 actionId) external',
-        'function executeAction(uint256 actionId) external',
-
-        // Multi-signature query functions
-        'function actionCounter() external view returns (uint256)',
-        'function REQUIRED_APPROVALS() external view returns (uint256)',
-        'function actions(uint256 actionId) external view returns (uint8 actionType, uint256 newHourlyRewardRate, address pairToAdd, string memory pairNameToAdd, string memory platformToAdd, uint256 weightToAdd, address pairToRemove, address recipient, uint256 withdrawAmount, bool executed, bool expired, uint8 approvals, uint256 proposedTime, bool rejected)',
-        'function getActionPairs(uint256 actionId) external view returns (address[] memory)',
-        'function getActionWeights(uint256 actionId) external view returns (uint256[] memory)',
-        'function getActionApproval(uint256 actionId) external view returns (address[] memory)',
-        'function isActionExpired(uint256 actionId) external view returns (bool)'
+        'function renounceOwnership() external',
+        'function renounceRole(bytes32 role, address callerConfirmation) external',
+        'function revokeRole(bytes32 role, address account) external',
+        'function rewardPerTokenStored(address) external view returns (uint256)',
+        'function rewardToken() external view returns (address)',
+        'function signers(uint256) external view returns (address)',
+        'function stake(address lpToken, uint256 amount) external',
+        'function supportsInterface(bytes4 interfaceId) external view returns (bool)',
+        'function totalRewardsObligated() external view returns (uint256)',
+        'function totalWeight() external view returns (uint256)',
+        'function transferOwnership(address newOwner) external',
+        'function unstake(address lpToken, uint256 amount, bool shouldClaimRewards) external',
+        'function unstakeTo(address lpToken, uint256 amount, bool shouldClaimRewards, address receiver) external',
+        'function userStakes(address, address) external view returns (uint256 amount, uint256 lastRewardTime, uint256 pendingRewards, uint256 rewardPerTokenPaid)'
     ],
 
     ERC20: [

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -760,12 +760,21 @@ class ContractManager {
                     "function actions(uint256 actionId) external view returns (uint8 actionType, uint256 newHourlyRewardRate, address pairToAdd, string memory pairNameToAdd, string memory platformToAdd, uint256 weightToAdd, address pairToRemove, address recipient, uint256 withdrawAmount, bool executed, bool expired, uint8 approvals, uint256 proposedTime, bool rejected)",
                     "function stake(address lpToken, uint256 amount) external",
                     "function unstake(address lpToken, uint256 amount, bool claimRewards) external",
+                    "function unstakeTo(address lpToken, uint256 amount, bool shouldClaimRewards, address receiver) external",
                     "function claimRewards(address lpToken) external",
+                    "function claimRewardsTo(address lpToken, address receiver) external",
 
                     // Admin role functions
                     "function hasRole(bytes32 role, address account) external view returns (bool)",
+                    "function ADMIN_ROLE() external view returns (bytes32)",
                     "function grantRole(bytes32 role, address account) external",
                     "function revokeRole(bytes32 role, address account) external",
+
+                    // Standard Ownable2Step functions
+                    "function owner() external view returns (address)",
+                    "function pendingOwner() external view returns (address)",
+                    "function transferOwnership(address newOwner) external",
+                    "function acceptOwnership() external",
 
                     // Multi-signature proposal functions
                     "function proposeSetHourlyRewardRate(uint256 newRate) external returns (uint256)",
@@ -781,8 +790,6 @@ class ContractManager {
                     "function rejectAction(uint256 actionId) external",
                     "function isActionExpired(uint256 actionId) external view returns (bool)",
                     "function getSigners() external view returns (address[])",
-                    "function hasApproved(uint256 actionId, address signer) external view returns (bool)",
-                    "function hasRejected(uint256 actionId, address signer) external view returns (bool)",
 
                     // Utility functions
                     "function cleanupExpiredActions() external"
@@ -2507,9 +2514,41 @@ class ContractManager {
         return false;
     }
 
-    async hasOwnerApproverRole(address = null) {
+    async getOwner() {
         if (!this.stakingContract) {
-            console.warn('⚠️ Staking contract not initialized - owner role check skipped');
+            console.warn('Staking contract not initialized - owner lookup skipped');
+            return null;
+        }
+
+        try {
+            return await this.executeWithRetry(async () => {
+                return await this.stakingContract.owner();
+            }, 'getOwner');
+        } catch (error) {
+            console.warn(`Owner lookup failed gracefully: ${error.message}`);
+            return null;
+        }
+    }
+
+    async getPendingOwner() {
+        if (!this.stakingContract) {
+            console.warn('Staking contract not initialized - pending owner lookup skipped');
+            return ethers.constants.AddressZero;
+        }
+
+        try {
+            return await this.executeWithRetry(async () => {
+                return await this.stakingContract.pendingOwner();
+            }, 'getPendingOwner');
+        } catch (error) {
+            console.warn(`Pending owner lookup failed gracefully: ${error.message}`);
+            return ethers.constants.AddressZero;
+        }
+    }
+
+    async isOwner(address = null) {
+        if (!this.stakingContract) {
+            console.warn('Staking contract not initialized - owner check skipped');
             return false;
         }
 
@@ -2519,12 +2558,109 @@ class ContractManager {
                 if (!userAddress) {
                     throw new Error('No address provided and no signer available');
                 }
-                const OWNER_ROLE = await this.stakingContract.OWNER_APPROVER_ROLE();
-                return await this.stakingContract.hasRole(OWNER_ROLE, userAddress);
-            }, 'hasOwnerApproverRole');
+
+                const ownerAddress = await this.stakingContract.owner();
+                return ownerAddress.toLowerCase() === userAddress.toLowerCase();
+            }, 'isOwner');
         } catch (error) {
-            console.warn(`⚠️ Owner approver role check failed gracefully: ${error.message}`);
+            console.warn(`Owner check failed gracefully: ${error.message}`);
             return false;
+        }
+    }
+
+    async isPendingOwner(address = null) {
+        if (!this.stakingContract) {
+            console.warn('Staking contract not initialized - pending owner check skipped');
+            return false;
+        }
+
+        try {
+            return await this.executeWithRetry(async () => {
+                const userAddress = address || (this.signer ? await this.signer.getAddress() : null);
+                if (!userAddress) {
+                    throw new Error('No address provided and no signer available');
+                }
+
+                const pendingOwnerAddress = await this.stakingContract.pendingOwner();
+                const zeroAddress = ethers.constants.AddressZero.toLowerCase();
+                return pendingOwnerAddress.toLowerCase() !== zeroAddress &&
+                    pendingOwnerAddress.toLowerCase() === userAddress.toLowerCase();
+            }, 'isPendingOwner');
+        } catch (error) {
+            console.warn(`Pending owner check failed gracefully: ${error.message}`);
+            return false;
+        }
+    }
+
+    async transferOwnership(newOwner) {
+        try {
+            newOwner = this.validateAndChecksumAddress(newOwner, 'New Owner Address');
+
+            await this.ensureSigner();
+
+            if (!this.stakingContract || typeof this.stakingContract.transferOwnership !== 'function') {
+                return {
+                    success: false,
+                    error: new Error('transferOwnership function is not available on the deployed contract.')
+                };
+            }
+
+            const result = await this.executeTransactionOnce(async () => {
+                const contractWithSigner = this.stakingContract.connect(this.signer);
+                const tx = await contractWithSigner.transferOwnership(newOwner);
+
+                console.log('Ownership transfer transaction sent:', tx.hash);
+                return tx;
+            }, 'transferOwnership');
+
+            return {
+                success: true,
+                transactionHash: result.transactionHash,
+                blockNumber: result.blockNumber,
+                gasUsed: result.gasUsed?.toString?.() || result.gasUsed,
+                message: 'Ownership transfer started'
+            };
+        } catch (error) {
+            console.error('Failed to transfer ownership:', error);
+            return {
+                success: false,
+                error
+            };
+        }
+    }
+
+    async acceptOwnership() {
+        try {
+            await this.ensureSigner();
+
+            if (!this.stakingContract || typeof this.stakingContract.acceptOwnership !== 'function') {
+                return {
+                    success: false,
+                    error: new Error('acceptOwnership function is not available on the deployed contract.')
+                };
+            }
+
+            const result = await this.executeTransactionOnce(async () => {
+                const contractWithSigner = this.stakingContract.connect(this.signer);
+                const tx = await contractWithSigner.acceptOwnership();
+
+                console.log('Accept ownership transaction sent:', tx.hash);
+                return tx;
+            }, 'acceptOwnership');
+
+            return {
+                success: true,
+                transactionHash: result.transactionHash,
+                blockNumber: result.blockNumber,
+                gasUsed: result.gasUsed?.toString?.() || result.gasUsed,
+                message: 'Ownership accepted'
+            };
+        } catch (error) {
+            console.error('Failed to accept ownership:', error);
+            return {
+                success: false,
+                error
+            };
         }
     }
 


### PR DESCRIPTION
## Summary
- updates the BSC testnet staking contract address and frontend staking ABI for the merged ownership/recipient-aware contract
- replaces owner-approver role checks with standard `owner()` / `pendingOwner()` access checks
- adds admin ownership UI for transfer, cancel pending transfer, and accept ownership

## Notes
- Pending owners can open the admin page to accept ownership, but proposal actions stay disabled until ownership is accepted.
- `unstakeTo` / `claimRewardsTo` are included in the ABI but no recipient-aware UI flows are added.

<img width="1120" height="245" alt="image" src="https://github.com/user-attachments/assets/d431830f-5f2f-4a84-a10e-0ca8c3378bc1" />
<img width="815" height="670" alt="image" src="https://github.com/user-attachments/assets/292832ec-141d-48ec-98c1-08f58213ff77" />
