### PR TITLE
Auto-refresh direct Remove LP previews

### DIFF
--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -1066,7 +1066,6 @@ class StakingModalNew {
     canAutoRefreshRemoveLiquidityPreview() {
         return this.isOpen
             && this.currentTab === 'remove-liquidity'
-            && this.removeLiquidityZapOutEnabled
             && this.canFetchRemoveLiquidityPreview();
     }
 
@@ -3817,9 +3816,7 @@ class StakingModalNew {
                 <div class="zap-quote-header">
                     <div class="zap-route-summary">${this.escapeHtml(summary)}</div>
                     <div class="zap-refresh-controls">
-                        ${this.removeLiquidityZapOutEnabled ? `
-                            <span id="remove-liquidity-preview-countdown" class="zap-quote-countdown">${this.escapeHtml(countdownDisplay)}</span>
-                        ` : ''}
+                        <span id="remove-liquidity-preview-countdown" class="zap-quote-countdown">${this.escapeHtml(countdownDisplay)}</span>
                         <button
                             type="button"
                             class="zap-refresh-btn"

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1324,7 +1324,7 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('10s');
     });
 
-    it('does not render a countdown for direct remove-liquidity previews', async () => {
+    it('renders a countdown for direct remove-liquidity previews', async () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal);
         modal.isOpen = true;
@@ -1332,22 +1332,30 @@ describe('StakingModalNew zap cleanup', () => {
 
         const html = modal.renderRemoveLiquidityPreviewPanel();
 
-        expect(html).not.toContain('remove-liquidity-preview-countdown');
+        expect(html).toContain('id="remove-liquidity-preview-countdown"');
+        expect(html).toContain('10s');
     });
 
-    it('does not auto-refresh direct remove-liquidity previews', async () => {
+    it('auto-refreshes direct remove-liquidity previews', async () => {
         vi.useFakeTimers();
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal);
         modal.isOpen = true;
         modal.currentTab = 'remove-liquidity';
         modal.fetchRemoveLiquidityPreview = vi.fn();
+        const countdown = document.registerElement(createElement({ id: 'remove-liquidity-preview-countdown' }));
 
         modal.syncRemoveLiquidityPreviewAutoRefresh();
-        await vi.advanceTimersByTimeAsync(10000);
+        await vi.advanceTimersByTimeAsync(1000);
 
-        expect(modal.removeLiquidityPreviewRefreshTimer).toBeNull();
+        expect(countdown.textContent).toBe('9s');
         expect(modal.fetchRemoveLiquidityPreview).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(9000);
+
+        expect(countdown.textContent).toBe('10s');
+        expect(modal.removeLiquidityPreviewRefreshTimer).not.toBeNull();
+        expect(modal.fetchRemoveLiquidityPreview).toHaveBeenCalledWith({ force: true });
+        modal.stopRemoveLiquidityPreviewAutoRefresh();
     });
 
     it('stops remove-liquidity zap-out auto-refresh when leaving the flow', async () => {


### PR DESCRIPTION
## Summary
- Add the same 10-second preview refresh loop to unchecked/direct Remove LP that zap-out already uses.
- Render the countdown next to the preview refresh button for both Remove LP modes.
- Keep the existing preview branch split intact: direct mode still uses V2 reserve math, while zap-out continues to use Kyber.

## Testing
- Added coverage for the direct Remove LP countdown render and timer-driven refresh path.
- Existing Remove LP auto-refresh coverage continues to pass for zap-out behavior.
- `npm test`