### PR TITLE
Add Farm 1.0 migration banner

### DIFF
--- a/css/farm-migration-banner.css
+++ b/css/farm-migration-banner.css
@@ -1,0 +1,139 @@
+.farm-migration-banner {
+    max-width: 960px;
+    margin: 0 auto var(--spacing-3);
+    padding: 14px 16px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-2);
+    background: rgba(255, 152, 0, 0.1);
+    border: 1px solid rgba(255, 152, 0, 0.35);
+    border-left: 4px solid var(--warning-main);
+    border-radius: var(--border-radius-lg);
+}
+
+.farm-migration-banner--position-found {
+    background: rgba(76, 175, 80, 0.12);
+    border-color: rgba(76, 175, 80, 0.42);
+    border-left-color: var(--success-main);
+    box-shadow: 0 0 0 1px rgba(76, 175, 80, 0.08), var(--shadow-4);
+}
+
+.farm-migration-banner-content {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-width: 0;
+}
+
+.farm-migration-banner-icon {
+    flex: 0 0 auto;
+    color: var(--warning-main);
+    font-size: 26px;
+}
+
+.farm-migration-banner--position-found .farm-migration-banner-icon {
+    color: var(--success-main);
+}
+
+.farm-migration-banner-copy {
+    min-width: 0;
+}
+
+.farm-migration-banner-heading {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 0 0 2px;
+}
+
+.farm-migration-banner-copy h2 {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 1.3;
+}
+
+.farm-migration-banner-badge {
+    display: inline-flex;
+    align-items: center;
+    min-height: 22px;
+    padding: 3px 8px;
+    color: var(--success-main);
+    background: rgba(76, 175, 80, 0.14);
+    border: 1px solid rgba(76, 175, 80, 0.35);
+    border-radius: var(--border-radius);
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1.2;
+    white-space: nowrap;
+}
+
+.farm-migration-banner-copy p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.farm-migration-banner-link {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-height: 38px;
+    padding: 8px 12px;
+    color: var(--text-inverse);
+    background: var(--warning-main);
+    border-radius: var(--border-radius);
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 1.2;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: filter 0.2s, transform 0.2s;
+}
+
+.farm-migration-banner--position-found .farm-migration-banner-link {
+    background: var(--success-main);
+}
+
+.farm-migration-banner-link:hover,
+.farm-migration-banner-link:focus,
+.farm-migration-banner-link:visited {
+    color: var(--text-inverse);
+    text-decoration: none;
+}
+
+.farm-migration-banner-link:hover,
+.farm-migration-banner-link:focus {
+    filter: brightness(0.95);
+    transform: translateY(-1px);
+}
+
+.farm-migration-banner-link .material-icons {
+    font-size: 18px;
+}
+
+@media (max-width: 768px) {
+    .farm-migration-banner {
+        max-width: 100%;
+    }
+}
+
+@media (max-width: 480px) {
+    .farm-migration-banner {
+        align-items: stretch;
+        flex-direction: column;
+        padding: 14px;
+    }
+
+    .farm-migration-banner-link {
+        width: 100%;
+        white-space: normal;
+        text-align: center;
+    }
+}

--- a/js/components/farm-migration-banner.js
+++ b/js/components/farm-migration-banner.js
@@ -1,0 +1,307 @@
+/**
+ * Farm 1.0 migration banner and read-only position check.
+ * This keeps temporary migration UI isolated from the main staking page.
+ */
+class FarmMigrationBanner {
+    constructor({ isWalletConnected, requestRender } = {}) {
+        this.isWalletConnected = typeof isWalletConnected === 'function'
+            ? isWalletConnected
+            : () => false;
+        this.requestRender = typeof requestRender === 'function'
+            ? requestRender
+            : () => {};
+        this.checkNonce = 0;
+        this.status = this.createStatus();
+    }
+
+    getConfig() {
+        const config = window.CONFIG?.FARM_MIGRATION || {};
+
+        return {
+            enabled: config.ENABLED !== false,
+            positionCheckEnabled: config.POSITION_CHECK_ENABLED !== false,
+            hideWhenConnectedWalletHasNoPosition: config.HIDE_WHEN_CONNECTED_WALLET_HAS_NO_POSITION === true,
+            oldFarmLabel: config.OLD_FARM_LABEL || 'Farm 1.0',
+            oldFarmUrl: config.OLD_FARM_URL || '',
+            oldFarmContracts: config.OLD_FARM_CONTRACTS || {},
+            legacyLpTokens: config.LEGACY_LP_TOKENS || {}
+        };
+    }
+
+    createStatus(overrides = {}) {
+        return {
+            state: 'idle',
+            checked: false,
+            checking: false,
+            hasPosition: false,
+            walletAddress: null,
+            networkKey: null,
+            stakeAmountRaw: '0',
+            pendingRewardsRaw: '0',
+            error: null,
+            ...overrides
+        };
+    }
+
+    reset() {
+        this.checkNonce++;
+        this.status = this.createStatus();
+        this.requestRender();
+    }
+
+    render() {
+        const {
+            enabled,
+            hideWhenConnectedWalletHasNoPosition,
+            oldFarmLabel,
+            oldFarmUrl
+        } = this.getConfig();
+
+        if (!enabled || !oldFarmUrl) {
+            return '';
+        }
+
+        const status = this.status || this.createStatus();
+        const walletConnected = this.isWalletConnected();
+
+        if (
+            walletConnected &&
+            status.checked &&
+            !status.hasPosition &&
+            hideWhenConnectedWalletHasNoPosition
+        ) {
+            return '';
+        }
+
+        const hasMigrationPosition = walletConnected && status.checked && status.hasPosition;
+        const bannerClass = hasMigrationPosition
+            ? 'farm-migration-banner farm-migration-banner--position-found'
+            : 'farm-migration-banner';
+        const title = hasMigrationPosition
+            ? `${oldFarmLabel} position found`
+            : `${oldFarmLabel} migration is available`;
+        const message = hasMigrationPosition
+            ? `This wallet still has ${oldFarmLabel} LP or rewards to migrate.`
+            : 'Open the old farm to unstake LP and claim any remaining rewards.';
+        const statusBadge = hasMigrationPosition
+            ? '<span class="farm-migration-banner-badge">Position detected</span>'
+            : '';
+
+        return `
+            <section class="${bannerClass}" aria-labelledby="farm-migration-title">
+                <div class="farm-migration-banner-content">
+                    <span class="material-icons farm-migration-banner-icon" aria-hidden="true">moving</span>
+                    <div class="farm-migration-banner-copy">
+                        <div class="farm-migration-banner-heading">
+                            <h2 id="farm-migration-title">${title}</h2>
+                            ${statusBadge}
+                        </div>
+                        <p>${message}</p>
+                    </div>
+                </div>
+                <a class="farm-migration-banner-link" href="${oldFarmUrl}" target="_blank" rel="noopener noreferrer">
+                    <span>Open ${oldFarmLabel}</span>
+                    <span class="material-icons" aria-hidden="true">open_in_new</span>
+                </a>
+            </section>
+        `;
+    }
+
+    getCurrentNetworkKey() {
+        return window.networkSelector?.getSelectedNetworkKey?.() || null;
+    }
+
+    getConnectedWalletAddress() {
+        return window.walletManager?.currentAccount ||
+            window.walletManager?.getAddress?.() ||
+            window.walletManager?.address ||
+            null;
+    }
+
+    getOldFarmContractAddress(config, networkKey) {
+        if (!networkKey) {
+            return null;
+        }
+
+        return config.oldFarmContracts?.[networkKey] || null;
+    }
+
+    getLegacyLpTokens(config, networkKey) {
+        const configuredTokens = config.legacyLpTokens?.[networkKey];
+
+        if (!Array.isArray(configuredTokens)) {
+            return [];
+        }
+
+        return configuredTokens.filter(Boolean);
+    }
+
+    createProvider(networkKey) {
+        const ethers = window.ethers;
+        const networkConfig = window.CONFIG?.NETWORKS?.[networkKey];
+        const rpcUrl = networkConfig?.RPC_URL || networkConfig?.FALLBACK_RPCS?.[0];
+
+        if (!ethers?.providers?.JsonRpcProvider || !rpcUrl) {
+            return window.contractManager?.provider || window.walletManager?.provider || null;
+        }
+
+        const staticNetwork = networkConfig?.CHAIN_ID
+            ? { chainId: networkConfig.CHAIN_ID, name: networkKey.toLowerCase() }
+            : undefined;
+
+        return new ethers.providers.JsonRpcProvider({
+            url: rpcUrl,
+            timeout: window.CONFIG?.API?.RPC_TIMEOUT || 12000
+        }, staticNetwork);
+    }
+
+    getStakingAbi() {
+        return window.CONFIG?.ABIS?.STAKING_CONTRACT || [
+            'function getPairs() external view returns (tuple(address lpToken, string pairName, string platform, uint256 weight, bool isActive)[])',
+            'function getUserStakeInfo(address user, address lpToken) external view returns (uint256 amount, uint256 pendingRewards, uint256 lastRewardTime)'
+        ];
+    }
+
+    getPairAddress(pair) {
+        return pair?.lpToken || pair?.[0] || null;
+    }
+
+    getUniqueLpTokens(pairs, legacyTokens) {
+        const tokens = new Set();
+
+        if (Array.isArray(pairs)) {
+            pairs.forEach((pair) => {
+                const pairAddress = this.getPairAddress(pair);
+
+                if (pairAddress) {
+                    tokens.add(pairAddress);
+                }
+            });
+        }
+
+        legacyTokens.forEach((token) => tokens.add(token));
+
+        return [...tokens];
+    }
+
+    normalizeBigNumber(value) {
+        const ethers = window.ethers;
+
+        if (ethers?.BigNumber?.from) {
+            return ethers.BigNumber.from(value || 0);
+        }
+
+        const numericValue = BigInt(value?.toString?.() || value || 0);
+
+        return {
+            add: (other) => this.normalizeBigNumber(numericValue + BigInt(other?.toString?.() || other || 0)),
+            gt: (other) => numericValue > BigInt(other?.toString?.() || other || 0),
+            toString: () => numericValue.toString()
+        };
+    }
+
+    async fetchPosition(config, walletAddress, networkKey) {
+        const ethers = window.ethers;
+        const oldFarmAddress = this.getOldFarmContractAddress(config, networkKey);
+
+        if (!ethers?.Contract || !oldFarmAddress) {
+            return { hasPosition: false, stakeAmountRaw: '0', pendingRewardsRaw: '0' };
+        }
+
+        const provider = this.createProvider(networkKey);
+        if (!provider) {
+            return { hasPosition: false, stakeAmountRaw: '0', pendingRewardsRaw: '0' };
+        }
+
+        const oldFarmContract = new ethers.Contract(oldFarmAddress, this.getStakingAbi(), provider);
+        const pairs = await oldFarmContract.getPairs();
+        const lpTokens = this.getUniqueLpTokens(pairs, this.getLegacyLpTokens(config, networkKey));
+        let totalStake = this.normalizeBigNumber(0);
+        let totalRewards = this.normalizeBigNumber(0);
+
+        await Promise.all(lpTokens.map(async (lpToken) => {
+            try {
+                const stakeInfo = await oldFarmContract.getUserStakeInfo(walletAddress, lpToken);
+                const amount = this.normalizeBigNumber(stakeInfo?.amount || stakeInfo?.[0] || 0);
+                const pendingRewards = this.normalizeBigNumber(stakeInfo?.pendingRewards || stakeInfo?.[1] || 0);
+                totalStake = totalStake.add(amount);
+                totalRewards = totalRewards.add(pendingRewards);
+            } catch (error) {
+                console.warn('Failed to check Farm 1.0 position for LP token:', lpToken, error);
+            }
+        }));
+
+        return {
+            hasPosition: totalStake.gt(0) || totalRewards.gt(0),
+            stakeAmountRaw: totalStake.toString(),
+            pendingRewardsRaw: totalRewards.toString()
+        };
+    }
+
+    async checkPosition({ force = false } = {}) {
+        const config = this.getConfig();
+        const walletAddress = this.getConnectedWalletAddress();
+        const networkKey = this.getCurrentNetworkKey();
+
+        if (!config.enabled || !config.positionCheckEnabled || !walletAddress) {
+            this.status = this.createStatus();
+            this.requestRender();
+            return;
+        }
+
+        if (
+            !force &&
+            this.status?.checked &&
+            this.status.walletAddress?.toLowerCase?.() === walletAddress.toLowerCase() &&
+            this.status.networkKey === networkKey
+        ) {
+            return;
+        }
+
+        const nonce = ++this.checkNonce;
+        this.status = this.createStatus({
+            state: 'checking',
+            checking: true,
+            walletAddress,
+            networkKey
+        });
+        this.requestRender();
+
+        try {
+            const result = await this.fetchPosition(config, walletAddress, networkKey);
+            if (nonce !== this.checkNonce) {
+                return;
+            }
+
+            this.status = this.createStatus({
+                state: 'checked',
+                checked: true,
+                checking: false,
+                hasPosition: result.hasPosition,
+                walletAddress,
+                networkKey,
+                stakeAmountRaw: result.stakeAmountRaw,
+                pendingRewardsRaw: result.pendingRewardsRaw
+            });
+        } catch (error) {
+            if (nonce !== this.checkNonce) {
+                return;
+            }
+
+            console.warn('Failed to check Farm 1.0 migration position:', error);
+            this.status = this.createStatus({
+                state: 'error',
+                checked: false,
+                checking: false,
+                hasPosition: false,
+                walletAddress,
+                networkKey,
+                error
+            });
+        }
+
+        this.requestRender();
+    }
+}
+
+window.FarmMigrationBanner = FarmMigrationBanner;

--- a/js/components/farm-migration-banner.js
+++ b/js/components/farm-migration-banner.js
@@ -1,9 +1,10 @@
 /**
- * Farm 1.0 migration banner and read-only position check.
+ * Farm 1.0 migration banner.
  * This keeps temporary migration UI isolated from the main staking page.
  */
 class FarmMigrationBanner {
-    constructor({ isWalletConnected, requestRender } = {}) {
+    constructor({ checker, isWalletConnected, requestRender } = {}) {
+        this.checker = checker || (window.FarmMigrationChecker ? new window.FarmMigrationChecker() : null);
         this.isWalletConnected = typeof isWalletConnected === 'function'
             ? isWalletConnected
             : () => false;
@@ -107,143 +108,19 @@ class FarmMigrationBanner {
         `;
     }
 
-    getCurrentNetworkKey() {
-        return window.networkSelector?.getSelectedNetworkKey?.() || null;
-    }
-
-    getConnectedWalletAddress() {
-        return window.walletManager?.currentAccount ||
-            window.walletManager?.getAddress?.() ||
-            window.walletManager?.address ||
-            null;
-    }
-
-    getOldFarmContractAddress(config, networkKey) {
-        if (!networkKey) {
-            return null;
-        }
-
-        return config.oldFarmContracts?.[networkKey] || null;
-    }
-
-    getLegacyLpTokens(config, networkKey) {
-        const configuredTokens = config.legacyLpTokens?.[networkKey];
-
-        if (!Array.isArray(configuredTokens)) {
-            return [];
-        }
-
-        return configuredTokens.filter(Boolean);
-    }
-
-    createProvider(networkKey) {
-        const ethers = window.ethers;
-        const networkConfig = window.CONFIG?.NETWORKS?.[networkKey];
-        const rpcUrl = networkConfig?.RPC_URL || networkConfig?.FALLBACK_RPCS?.[0];
-
-        if (!ethers?.providers?.JsonRpcProvider || !rpcUrl) {
-            return window.contractManager?.provider || window.walletManager?.provider || null;
-        }
-
-        const staticNetwork = networkConfig?.CHAIN_ID
-            ? { chainId: networkConfig.CHAIN_ID, name: networkKey.toLowerCase() }
-            : undefined;
-
-        return new ethers.providers.JsonRpcProvider({
-            url: rpcUrl,
-            timeout: window.CONFIG?.API?.RPC_TIMEOUT || 12000
-        }, staticNetwork);
-    }
-
-    getStakingAbi() {
-        return window.CONFIG?.ABIS?.STAKING_CONTRACT || [
-            'function getPairs() external view returns (tuple(address lpToken, string pairName, string platform, uint256 weight, bool isActive)[])',
-            'function getUserStakeInfo(address user, address lpToken) external view returns (uint256 amount, uint256 pendingRewards, uint256 lastRewardTime)'
-        ];
-    }
-
-    getPairAddress(pair) {
-        return pair?.lpToken || pair?.[0] || null;
-    }
-
-    getUniqueLpTokens(pairs, legacyTokens) {
-        const tokens = new Set();
-
-        if (Array.isArray(pairs)) {
-            pairs.forEach((pair) => {
-                const pairAddress = this.getPairAddress(pair);
-
-                if (pairAddress) {
-                    tokens.add(pairAddress);
-                }
-            });
-        }
-
-        legacyTokens.forEach((token) => tokens.add(token));
-
-        return [...tokens];
-    }
-
-    normalizeBigNumber(value) {
-        const ethers = window.ethers;
-
-        if (ethers?.BigNumber?.from) {
-            return ethers.BigNumber.from(value || 0);
-        }
-
-        const numericValue = BigInt(value?.toString?.() || value || 0);
-
-        return {
-            add: (other) => this.normalizeBigNumber(numericValue + BigInt(other?.toString?.() || other || 0)),
-            gt: (other) => numericValue > BigInt(other?.toString?.() || other || 0),
-            toString: () => numericValue.toString()
-        };
-    }
-
-    async fetchPosition(config, walletAddress, networkKey) {
-        const ethers = window.ethers;
-        const oldFarmAddress = this.getOldFarmContractAddress(config, networkKey);
-
-        if (!ethers?.Contract || !oldFarmAddress) {
-            return { hasPosition: false, stakeAmountRaw: '0', pendingRewardsRaw: '0' };
-        }
-
-        const provider = this.createProvider(networkKey);
-        if (!provider) {
-            return { hasPosition: false, stakeAmountRaw: '0', pendingRewardsRaw: '0' };
-        }
-
-        const oldFarmContract = new ethers.Contract(oldFarmAddress, this.getStakingAbi(), provider);
-        const pairs = await oldFarmContract.getPairs();
-        const lpTokens = this.getUniqueLpTokens(pairs, this.getLegacyLpTokens(config, networkKey));
-        let totalStake = this.normalizeBigNumber(0);
-        let totalRewards = this.normalizeBigNumber(0);
-
-        await Promise.all(lpTokens.map(async (lpToken) => {
-            try {
-                const stakeInfo = await oldFarmContract.getUserStakeInfo(walletAddress, lpToken);
-                const amount = this.normalizeBigNumber(stakeInfo?.amount || stakeInfo?.[0] || 0);
-                const pendingRewards = this.normalizeBigNumber(stakeInfo?.pendingRewards || stakeInfo?.[1] || 0);
-                totalStake = totalStake.add(amount);
-                totalRewards = totalRewards.add(pendingRewards);
-            } catch (error) {
-                console.warn('Failed to check Farm 1.0 position for LP token:', lpToken, error);
-            }
-        }));
-
-        return {
-            hasPosition: totalStake.gt(0) || totalRewards.gt(0),
-            stakeAmountRaw: totalStake.toString(),
-            pendingRewardsRaw: totalRewards.toString()
-        };
-    }
-
     async checkPosition({ force = false } = {}) {
         const config = this.getConfig();
-        const walletAddress = this.getConnectedWalletAddress();
-        const networkKey = this.getCurrentNetworkKey();
+        const checker = this.checker;
 
-        if (!config.enabled || !config.positionCheckEnabled || !walletAddress) {
+        if (!config.enabled || !config.positionCheckEnabled || !checker) {
+            this.status = this.createStatus();
+            this.requestRender();
+            return;
+        }
+
+        const networkKey = checker.getCurrentNetworkKey();
+        const walletAddress = await checker.getConnectedWalletAddress();
+        if (!walletAddress) {
             this.status = this.createStatus();
             this.requestRender();
             return;
@@ -268,7 +145,7 @@ class FarmMigrationBanner {
         this.requestRender();
 
         try {
-            const result = await this.fetchPosition(config, walletAddress, networkKey);
+            const result = await checker.fetchPosition(config, walletAddress, networkKey);
             if (nonce !== this.checkNonce) {
                 return;
             }

--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -19,6 +19,12 @@ class HomePage {
         this.lastNetworkId = null;
         this.refreshDebounceTimer = null; // Prevent overlapping refreshes during rapid network changes
         this.isAdmin = false; // Track admin status
+        this.farmMigrationBanner = window.FarmMigrationBanner
+            ? new window.FarmMigrationBanner({
+                isWalletConnected: () => this.isWalletConnected(),
+                requestRender: () => this.render()
+            })
+            : null;
         // OPTIMIZATION: Simple caching for contract data that doesn't change frequently
         this.cache = {
             hourlyRewardRate: { value: null, timestamp: 0, ttl: 300000 }, // 5 minutes
@@ -55,6 +61,7 @@ class HomePage {
             console.log('🏠 HomePage: ContractManager is ready, loading data...');
             this.updateFooter();
             this.loadData().catch(() => {});
+            this.checkFarmMigrationPosition().catch(() => {});
             // Auto-refresh disabled - manual refresh only
         });
 
@@ -89,6 +96,7 @@ class HomePage {
             window.NetworkIndicator?.update('network-indicator-home', 'home-network-selector', 'home');
             this.updateFooter();
             this.refreshDataAfterWalletChange();
+            this.checkFarmMigrationPosition({ force: true }).catch(() => {});
             this.checkAdminAccess();
         });
 
@@ -96,6 +104,7 @@ class HomePage {
             console.log('🏠 HomePage: Wallet disconnected, refreshing data...');
             window.NetworkIndicator?.update('network-indicator-home', 'home-network-selector', 'home');
             this.updateFooter();
+            this.resetFarmMigrationStatus();
             this.refreshDataAfterWalletChange();
             this.hideAdminButton();
         });
@@ -106,6 +115,7 @@ class HomePage {
                 console.log('🏠 HomePage: Accounts changed:', accounts);
                 this.updateFooter();
                 this.refreshDataAfterWalletChange();
+                this.checkFarmMigrationPosition({ force: true }).catch(() => {});
                 this.checkAdminAccess();
             });
 
@@ -115,6 +125,7 @@ class HomePage {
                 // Only update the network indicator to re-check permissions
                 window.NetworkIndicator?.update('network-indicator-home', 'home-network-selector', 'home');
                 this.updateFooter();
+                this.checkFarmMigrationPosition({ force: true }).catch(() => {});
             });
 
             // Re-check permissions when page regains focus (in case permissions were removed in another tab)
@@ -157,6 +168,7 @@ class HomePage {
             console.log('🏠 HomePage: ContractManager already ready, loading data immediately...');
             this.updateFooter();
             await this.loadData().catch(() => {});
+            await this.checkFarmMigrationPosition().catch(() => {});
             this.checkAdminAccess();
             // Auto-refresh disabled - manual refresh only
         } else {
@@ -188,12 +200,14 @@ class HomePage {
         const container = document.getElementById('content-container');
         if (!container) return;
 
+        const migrationBanner = this.renderFarmMigrationBanner();
+
         if (this.loading) {
-            container.innerHTML = this.renderSkeleton();
+            container.innerHTML = migrationBanner + this.renderSkeleton();
         } else if (this.error) {
-            container.innerHTML = this.renderError();
+            container.innerHTML = migrationBanner + this.renderError();
         } else {
-            container.innerHTML = this.renderHomepage();
+            container.innerHTML = migrationBanner + this.renderHomepage();
         }
 
         this.attachRetryHandler();
@@ -201,6 +215,18 @@ class HomePage {
 
     renderHomepage() {
         return this.renderTable();
+    }
+
+    renderFarmMigrationBanner() {
+        return this.farmMigrationBanner?.render() || '';
+    }
+
+    resetFarmMigrationStatus() {
+        this.farmMigrationBanner?.reset();
+    }
+
+    async checkFarmMigrationPosition(options) {
+        await this.farmMigrationBanner?.checkPosition(options);
     }
 
     attachRetryHandler() {
@@ -1274,6 +1300,7 @@ class HomePage {
                 try {
                     await window.contractManager.initialize();
                     this.loadDataWhenReady();
+                    this.checkFarmMigrationPosition({ force: true }).catch(() => {});
                 } catch (error) {
                     console.error('❌ Error refreshing contract data:', error);
                     this.loading = false;

--- a/js/config/app-config.js
+++ b/js/config/app-config.js
@@ -58,7 +58,7 @@ window.CONFIG = {
             BLOCK_EXPLORER: 'https://bscscan.com',
             NATIVE_CURRENCY: { name: 'BNB', symbol: 'BNB', decimals: 18 },
             CONTRACTS: {
-                STAKING_CONTRACT: '0x89E662CB5d784582DB631e2Cbc81bB6643BB2EF4'
+                STAKING_CONTRACT: '0x67e7cAEc6A043E2E3bFCa27eC5BA12D1ed6EFe4C'
             }
         },
         BSC_TESTNET: {
@@ -97,6 +97,20 @@ window.CONFIG = {
         NOTIFICATION_DURATION: 5000, // 5 seconds
         ANIMATION_DURATION: 300, // 300ms
         DEBOUNCE_DELAY: 500 // 500ms
+    },
+
+    // Farm 1.0 migration notice shown on the Farm page
+    FARM_MIGRATION: {
+        ENABLED: true,
+        POSITION_CHECK_ENABLED: true,
+        HIDE_WHEN_CONNECTED_WALLET_HAS_NO_POSITION: true,
+        OLD_FARM_LABEL: 'Farm 1.0',
+        OLD_FARM_URL: 'https://liberdus.com/farm/migration',
+        OLD_FARM_CONTRACTS: {
+            BSC_MAINNET: '0x89E662CB5d784582DB631e2Cbc81bB6643BB2EF4',
+            BSC_TESTNET: '0x24F28129B65E9AeDdAfE3f1Fc67ab82DDCF30dF9'
+        },
+        LEGACY_LP_TOKENS: {}
     },
 
     // Support Links

--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -164,9 +164,11 @@ class MasterInitializer {
 
         // Homepage only: Load CSS for wallet popup
         await this.loadCSS('css/wallet-popup.css');
+        await this.loadCSS('css/farm-migration-banner.css');
 
         const uiScripts = [
             'js/components/wallet-popup.js',
+            'js/components/farm-migration-banner.js',
             'js/components/home-page.js',
             'js/services/kyber-zap-rate-limiter.js',
             'js/services/kyber-zap-service.js',

--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -168,6 +168,7 @@ class MasterInitializer {
 
         const uiScripts = [
             'js/components/wallet-popup.js',
+            'js/services/farm-migration-checker.js',
             'js/components/farm-migration-banner.js',
             'js/components/home-page.js',
             'js/services/kyber-zap-rate-limiter.js',

--- a/js/services/farm-migration-checker.js
+++ b/js/services/farm-migration-checker.js
@@ -1,0 +1,176 @@
+/**
+ * Read-only Farm 1.0 position checker.
+ * Reuses ContractManager providers, ABI storage, and fallback reads when available.
+ */
+class FarmMigrationChecker {
+    getCurrentNetworkKey() {
+        return window.networkSelector?.getSelectedNetworkKey?.() || null;
+    }
+
+    async getConnectedWalletAddress() {
+        const contractManager = window.contractManager;
+
+        if (typeof contractManager?.getCurrentSignerForPermissions === 'function') {
+            const address = await contractManager.getCurrentSignerForPermissions();
+            if (address) {
+                return address;
+            }
+        }
+
+        return window.walletManager?.currentAccount ||
+            window.walletManager?.getAddress?.() ||
+            window.walletManager?.address ||
+            null;
+    }
+
+    getOldFarmContractAddress(config, networkKey) {
+        if (!networkKey) {
+            return null;
+        }
+
+        return config.oldFarmContracts?.[networkKey] || null;
+    }
+
+    getLegacyLpTokens(config, networkKey) {
+        const configuredTokens = config.legacyLpTokens?.[networkKey];
+
+        if (!Array.isArray(configuredTokens)) {
+            return [];
+        }
+
+        return configuredTokens.filter(Boolean);
+    }
+
+    getProvider(networkKey) {
+        const contractManager = window.contractManager;
+        if (contractManager?.provider) {
+            return contractManager.provider;
+        }
+
+        if (window.walletManager?.provider) {
+            return window.walletManager.provider;
+        }
+
+        const networkConfig = window.CONFIG?.NETWORKS?.[networkKey];
+        const rpcUrl = networkConfig?.RPC_URL || networkConfig?.FALLBACK_RPCS?.[0];
+        if (rpcUrl && typeof contractManager?.getRpcProvider === 'function') {
+            return contractManager.getRpcProvider(rpcUrl);
+        }
+
+        return null;
+    }
+
+    async withProviderFallback(operation, networkKey) {
+        const contractManager = window.contractManager;
+
+        if (contractManager?.provider && typeof contractManager.executeWithProviderFallback === 'function') {
+            return contractManager.executeWithProviderFallback(
+                operation,
+                'FarmMigrationChecker.checkPosition',
+                2
+            );
+        }
+
+        const provider = this.getProvider(networkKey);
+        if (!provider) {
+            return null;
+        }
+
+        return operation(provider, null);
+    }
+
+    getStakingAbi() {
+        return window.contractManager?.contractABIs?.get?.('STAKING') ||
+            window.CONFIG?.ABIS?.STAKING_CONTRACT ||
+            null;
+    }
+
+    createOldFarmContract(oldFarmAddress, provider) {
+        const ethers = window.ethers;
+        const stakingAbi = this.getStakingAbi();
+
+        if (!ethers?.Contract || !stakingAbi || !oldFarmAddress || !provider) {
+            return null;
+        }
+
+        return new ethers.Contract(oldFarmAddress, stakingAbi, provider);
+    }
+
+    getPairAddress(pair) {
+        return pair?.lpToken || pair?.[0] || null;
+    }
+
+    getUniqueLpTokens(pairs, legacyTokens) {
+        const tokens = new Set();
+
+        if (Array.isArray(pairs)) {
+            pairs.forEach((pair) => {
+                const pairAddress = this.getPairAddress(pair);
+
+                if (pairAddress) {
+                    tokens.add(pairAddress);
+                }
+            });
+        }
+
+        legacyTokens.forEach((token) => tokens.add(token));
+
+        return [...tokens];
+    }
+
+    toBigNumber(value) {
+        return window.ethers.BigNumber.from(value || 0);
+    }
+
+    async callView(contractCall, blockTag) {
+        return blockTag
+            ? contractCall({ blockTag })
+            : contractCall();
+    }
+
+    async readPositionForProvider(config, walletAddress, networkKey, provider, blockTag) {
+        const oldFarmAddress = this.getOldFarmContractAddress(config, networkKey);
+        const oldFarmContract = this.createOldFarmContract(oldFarmAddress, provider);
+        if (!oldFarmContract) {
+            return { hasPosition: false, stakeAmountRaw: '0', pendingRewardsRaw: '0' };
+        }
+
+        const pairs = await this.callView((overrides) => oldFarmContract.getPairs(overrides), blockTag);
+        const lpTokens = this.getUniqueLpTokens(pairs, this.getLegacyLpTokens(config, networkKey));
+        let totalStake = this.toBigNumber(0);
+        let totalRewards = this.toBigNumber(0);
+
+        await Promise.all(lpTokens.map(async (lpToken) => {
+            try {
+                const stakeInfo = blockTag
+                    ? await oldFarmContract.getUserStakeInfo(walletAddress, lpToken, { blockTag })
+                    : await oldFarmContract.getUserStakeInfo(walletAddress, lpToken);
+                const amount = this.toBigNumber(stakeInfo?.amount ?? stakeInfo?.[0] ?? 0);
+                const pendingRewards = this.toBigNumber(stakeInfo?.pendingRewards ?? stakeInfo?.[1] ?? 0);
+                totalStake = totalStake.add(amount);
+                totalRewards = totalRewards.add(pendingRewards);
+            } catch (error) {
+                console.warn('Failed to check Farm 1.0 position for LP token:', lpToken, error);
+            }
+        }));
+
+        return {
+            hasPosition: totalStake.gt(0) || totalRewards.gt(0),
+            stakeAmountRaw: totalStake.toString(),
+            pendingRewardsRaw: totalRewards.toString()
+        };
+    }
+
+    async fetchPosition(config, walletAddress, networkKey) {
+        if (!this.getOldFarmContractAddress(config, networkKey) || !window.ethers?.BigNumber) {
+            return { hasPosition: false, stakeAmountRaw: '0', pendingRewardsRaw: '0' };
+        }
+
+        return await this.withProviderFallback(
+            (provider, blockTag) => this.readPositionForProvider(config, walletAddress, networkKey, provider, blockTag),
+            networkKey
+        ) || { hasPosition: false, stakeAmountRaw: '0', pendingRewardsRaw: '0' };
+    }
+}
+
+window.FarmMigrationChecker = FarmMigrationChecker;

--- a/js/utils/version-check.js
+++ b/js/utils/version-check.js
@@ -155,6 +155,7 @@
             
             // JavaScript - Components (only existing files)
             `${basePath}js/components/admin-page.js`,
+            `${basePath}js/components/farm-migration-banner.js`,
             `${basePath}js/components/home-page.js`,
             `${basePath}js/components/network-indicator-selector.js`,
             `${basePath}js/components/staking-modal-new.js`,
@@ -177,6 +178,7 @@
             `${basePath}js/master-initializer.js`,
 
             // JavaScript - Services
+            `${basePath}js/services/farm-migration-checker.js`,
             `${basePath}js/services/kyber-zap-rate-limiter.js`,
             `${basePath}js/services/kyber-zap-service.js`,
             `${basePath}js/services/v2-remove-liquidity-service.js`,
@@ -206,6 +208,7 @@
             `${basePath}css/admin.css`,
             `${basePath}css/base.css`,
             `${basePath}css/components.css`,
+            `${basePath}css/farm-migration-banner.css`,
             `${basePath}css/network-indicator-selector.css`,
             `${basePath}css/staking-modal.css`,
             `${basePath}css/theme-toggle.css`,

--- a/tests/farm-migration-banner.test.js
+++ b/tests/farm-migration-banner.test.js
@@ -9,22 +9,6 @@ async function loadFarmMigrationBanner() {
     return globalThis.FarmMigrationBanner;
 }
 
-function createMockBigNumber(value) {
-    const normalizedValue = BigInt(value?.toString?.() || value || 0);
-
-    return {
-        add(other) {
-            return createMockBigNumber(normalizedValue + BigInt(other.toString()));
-        },
-        gt(other) {
-            return normalizedValue > BigInt(other.toString());
-        },
-        toString() {
-            return normalizedValue.toString();
-        }
-    };
-}
-
 describe('FarmMigrationBanner.render', () => {
     beforeEach(() => {
         vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -149,69 +133,42 @@ describe('FarmMigrationBanner.checkPosition', () => {
     afterEach(() => {
         vi.restoreAllMocks();
         delete globalThis.CONFIG;
-        delete globalThis.ethers;
-        delete globalThis.networkSelector;
-        delete globalThis.walletManager;
         delete globalThis.FarmMigrationBanner;
         delete globalThis.window;
     });
 
     it('marks a connected wallet as having migration work when old stake or rewards exist', async () => {
         const FarmMigrationBanner = await loadFarmMigrationBanner();
-        const getUserStakeInfo = vi.fn()
-            .mockResolvedValueOnce({
-                amount: createMockBigNumber('0'),
-                pendingRewards: createMockBigNumber('5')
-            });
-        const getPairs = vi.fn().mockResolvedValue([
-            { lpToken: '0xlp1' }
-        ]);
-        const Contract = vi.fn(function MockContract() {
-            return { getPairs, getUserStakeInfo };
-        });
         const requestRender = vi.fn();
+        const checker = {
+            getCurrentNetworkKey: vi.fn().mockReturnValue('BSC_MAINNET'),
+            getConnectedWalletAddress: vi.fn().mockResolvedValue('0xwallet'),
+            fetchPosition: vi.fn().mockResolvedValue({
+                hasPosition: true,
+                stakeAmountRaw: '0',
+                pendingRewardsRaw: '5'
+            })
+        };
 
         globalThis.CONFIG = {
             FARM_MIGRATION: {
                 ENABLED: true,
-                POSITION_CHECK_ENABLED: true,
-                OLD_FARM_CONTRACTS: {
-                    BSC_MAINNET: '0xoldfarm'
-                },
-                LEGACY_LP_TOKENS: {}
-            },
-            NETWORKS: {
-                BSC_MAINNET: {
-                    RPC_URL: 'https://rpc.example',
-                    CHAIN_ID: 56
-                }
-            },
-            API: { RPC_TIMEOUT: 12000 }
-        };
-        globalThis.ethers = {
-            BigNumber: { from: createMockBigNumber },
-            Contract,
-            providers: {
-                JsonRpcProvider: vi.fn(function MockJsonRpcProvider() {
-                    return { provider: true };
-                })
+                POSITION_CHECK_ENABLED: true
             }
         };
-        globalThis.networkSelector = {
-            getSelectedNetworkKey: vi.fn().mockReturnValue('BSC_MAINNET')
-        };
-        globalThis.walletManager = {
-            currentAccount: '0xwallet'
-        };
         const banner = new FarmMigrationBanner({
+            checker,
             isWalletConnected: vi.fn().mockReturnValue(true),
             requestRender
         });
 
         await banner.checkPosition({ force: true });
 
-        expect(Contract).toHaveBeenCalledWith('0xoldfarm', expect.any(Array), expect.any(Object));
-        expect(getUserStakeInfo).toHaveBeenCalledWith('0xwallet', '0xlp1');
+        expect(checker.fetchPosition).toHaveBeenCalledWith(
+            expect.objectContaining({ enabled: true, positionCheckEnabled: true }),
+            '0xwallet',
+            'BSC_MAINNET'
+        );
         expect(banner.status.checked).toBe(true);
         expect(banner.status.hasPosition).toBe(true);
         expect(banner.status.pendingRewardsRaw).toBe('5');
@@ -220,17 +177,22 @@ describe('FarmMigrationBanner.checkPosition', () => {
 
     it('does not check old farm positions when no wallet is connected', async () => {
         const FarmMigrationBanner = await loadFarmMigrationBanner();
+        const checker = {
+            getCurrentNetworkKey: vi.fn().mockReturnValue('BSC_MAINNET'),
+            getConnectedWalletAddress: vi.fn().mockResolvedValue(null),
+            fetchPosition: vi.fn()
+        };
         globalThis.CONFIG = {
             FARM_MIGRATION: {
                 ENABLED: true,
                 POSITION_CHECK_ENABLED: true
             }
         };
-        globalThis.walletManager = {};
-        const banner = new FarmMigrationBanner();
+        const banner = new FarmMigrationBanner({ checker });
 
         await banner.checkPosition({ force: true });
 
+        expect(checker.fetchPosition).not.toHaveBeenCalled();
         expect(banner.status.checked).toBe(false);
         expect(banner.status.hasPosition).toBe(false);
     });

--- a/tests/farm-migration-banner.test.js
+++ b/tests/farm-migration-banner.test.js
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function loadFarmMigrationBanner() {
+    vi.resetModules();
+    globalThis.window = globalThis;
+    delete globalThis.FarmMigrationBanner;
+
+    await import('../js/components/farm-migration-banner.js');
+    return globalThis.FarmMigrationBanner;
+}
+
+function createMockBigNumber(value) {
+    const normalizedValue = BigInt(value?.toString?.() || value || 0);
+
+    return {
+        add(other) {
+            return createMockBigNumber(normalizedValue + BigInt(other.toString()));
+        },
+        gt(other) {
+            return normalizedValue > BigInt(other.toString());
+        },
+        toString() {
+            return normalizedValue.toString();
+        }
+    };
+}
+
+describe('FarmMigrationBanner.render', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete globalThis.CONFIG;
+        delete globalThis.FarmMigrationBanner;
+        delete globalThis.window;
+    });
+
+    it('links users to the configured Farm 1.0 migration page', async () => {
+        const FarmMigrationBanner = await loadFarmMigrationBanner();
+        globalThis.CONFIG = {
+            FARM_MIGRATION: {
+                ENABLED: true,
+                OLD_FARM_LABEL: 'Farm 1.0',
+                OLD_FARM_URL: 'https://liberdus.com/farm/'
+            }
+        };
+        const banner = new FarmMigrationBanner();
+
+        const output = banner.render();
+
+        expect(output).toContain('Farm 1.0 migration is available');
+        expect(output).toContain('Open the old farm to unstake LP and claim any remaining rewards.');
+        expect(output).toContain('href="https://liberdus.com/farm/"');
+        expect(output).toContain('Open Farm 1.0');
+    });
+
+    it('highlights the banner when the connected wallet has an old farm position', async () => {
+        const FarmMigrationBanner = await loadFarmMigrationBanner();
+        globalThis.CONFIG = {
+            FARM_MIGRATION: {
+                ENABLED: true,
+                OLD_FARM_LABEL: 'Farm 1.0',
+                OLD_FARM_URL: 'https://liberdus.com/farm/'
+            }
+        };
+        const banner = new FarmMigrationBanner({
+            isWalletConnected: vi.fn().mockReturnValue(true)
+        });
+        banner.status = banner.createStatus({
+            checked: true,
+            hasPosition: true
+        });
+
+        const output = banner.render();
+
+        expect(output).toContain('Farm 1.0 position found');
+        expect(output).toContain('This wallet still has Farm 1.0 LP or rewards to migrate.');
+        expect(output).toContain('farm-migration-banner--position-found');
+        expect(output).toContain('Position detected');
+    });
+
+    it('keeps the general banner visible for connected wallets without an old farm position by default', async () => {
+        const FarmMigrationBanner = await loadFarmMigrationBanner();
+        globalThis.CONFIG = {
+            FARM_MIGRATION: {
+                ENABLED: true,
+                OLD_FARM_LABEL: 'Farm 1.0',
+                OLD_FARM_URL: 'https://liberdus.com/farm/'
+            }
+        };
+        const banner = new FarmMigrationBanner({
+            isWalletConnected: vi.fn().mockReturnValue(true)
+        });
+        banner.status = banner.createStatus({
+            checked: true,
+            hasPosition: false
+        });
+
+        const output = banner.render();
+
+        expect(output).toContain('Farm 1.0 migration is available');
+        expect(output).not.toContain('farm-migration-banner--position-found');
+    });
+
+    it('can hide the banner when the connected wallet has no old farm position', async () => {
+        const FarmMigrationBanner = await loadFarmMigrationBanner();
+        globalThis.CONFIG = {
+            FARM_MIGRATION: {
+                ENABLED: true,
+                HIDE_WHEN_CONNECTED_WALLET_HAS_NO_POSITION: true,
+                OLD_FARM_LABEL: 'Farm 1.0',
+                OLD_FARM_URL: 'https://liberdus.com/farm/'
+            }
+        };
+        const banner = new FarmMigrationBanner({
+            isWalletConnected: vi.fn().mockReturnValue(true)
+        });
+        banner.status = banner.createStatus({
+            checked: true,
+            hasPosition: false
+        });
+
+        expect(banner.render()).toBe('');
+    });
+
+    it('does not render when the migration banner is disabled', async () => {
+        const FarmMigrationBanner = await loadFarmMigrationBanner();
+        globalThis.CONFIG = {
+            FARM_MIGRATION: {
+                ENABLED: false,
+                OLD_FARM_LABEL: 'Farm 1.0',
+                OLD_FARM_URL: 'https://liberdus.com/farm/'
+            }
+        };
+        const banner = new FarmMigrationBanner();
+
+        expect(banner.render()).toBe('');
+    });
+});
+
+describe('FarmMigrationBanner.checkPosition', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete globalThis.CONFIG;
+        delete globalThis.ethers;
+        delete globalThis.networkSelector;
+        delete globalThis.walletManager;
+        delete globalThis.FarmMigrationBanner;
+        delete globalThis.window;
+    });
+
+    it('marks a connected wallet as having migration work when old stake or rewards exist', async () => {
+        const FarmMigrationBanner = await loadFarmMigrationBanner();
+        const getUserStakeInfo = vi.fn()
+            .mockResolvedValueOnce({
+                amount: createMockBigNumber('0'),
+                pendingRewards: createMockBigNumber('5')
+            });
+        const getPairs = vi.fn().mockResolvedValue([
+            { lpToken: '0xlp1' }
+        ]);
+        const Contract = vi.fn(function MockContract() {
+            return { getPairs, getUserStakeInfo };
+        });
+        const requestRender = vi.fn();
+
+        globalThis.CONFIG = {
+            FARM_MIGRATION: {
+                ENABLED: true,
+                POSITION_CHECK_ENABLED: true,
+                OLD_FARM_CONTRACTS: {
+                    BSC_MAINNET: '0xoldfarm'
+                },
+                LEGACY_LP_TOKENS: {}
+            },
+            NETWORKS: {
+                BSC_MAINNET: {
+                    RPC_URL: 'https://rpc.example',
+                    CHAIN_ID: 56
+                }
+            },
+            API: { RPC_TIMEOUT: 12000 }
+        };
+        globalThis.ethers = {
+            BigNumber: { from: createMockBigNumber },
+            Contract,
+            providers: {
+                JsonRpcProvider: vi.fn(function MockJsonRpcProvider() {
+                    return { provider: true };
+                })
+            }
+        };
+        globalThis.networkSelector = {
+            getSelectedNetworkKey: vi.fn().mockReturnValue('BSC_MAINNET')
+        };
+        globalThis.walletManager = {
+            currentAccount: '0xwallet'
+        };
+        const banner = new FarmMigrationBanner({
+            isWalletConnected: vi.fn().mockReturnValue(true),
+            requestRender
+        });
+
+        await banner.checkPosition({ force: true });
+
+        expect(Contract).toHaveBeenCalledWith('0xoldfarm', expect.any(Array), expect.any(Object));
+        expect(getUserStakeInfo).toHaveBeenCalledWith('0xwallet', '0xlp1');
+        expect(banner.status.checked).toBe(true);
+        expect(banner.status.hasPosition).toBe(true);
+        expect(banner.status.pendingRewardsRaw).toBe('5');
+        expect(requestRender).toHaveBeenCalled();
+    });
+
+    it('does not check old farm positions when no wallet is connected', async () => {
+        const FarmMigrationBanner = await loadFarmMigrationBanner();
+        globalThis.CONFIG = {
+            FARM_MIGRATION: {
+                ENABLED: true,
+                POSITION_CHECK_ENABLED: true
+            }
+        };
+        globalThis.walletManager = {};
+        const banner = new FarmMigrationBanner();
+
+        await banner.checkPosition({ force: true });
+
+        expect(banner.status.checked).toBe(false);
+        expect(banner.status.hasPosition).toBe(false);
+    });
+});

--- a/tests/farm-migration-checker.test.js
+++ b/tests/farm-migration-checker.test.js
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function loadFarmMigrationChecker() {
+    vi.resetModules();
+    globalThis.window = globalThis;
+    delete globalThis.FarmMigrationChecker;
+
+    await import('../js/services/farm-migration-checker.js');
+    return globalThis.FarmMigrationChecker;
+}
+
+function createMockBigNumber(value) {
+    const normalizedValue = BigInt(value?.toString?.() || value || 0);
+
+    return {
+        add(other) {
+            return createMockBigNumber(normalizedValue + BigInt(other.toString()));
+        },
+        gt(other) {
+            return normalizedValue > BigInt(other.toString());
+        },
+        toString() {
+            return normalizedValue.toString();
+        }
+    };
+}
+
+describe('FarmMigrationChecker', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete globalThis.CONFIG;
+        delete globalThis.ethers;
+        delete globalThis.contractManager;
+        delete globalThis.networkSelector;
+        delete globalThis.walletManager;
+        delete globalThis.FarmMigrationChecker;
+        delete globalThis.window;
+    });
+
+    it('uses ContractManager signer permissions before wallet-manager fallbacks', async () => {
+        const FarmMigrationChecker = await loadFarmMigrationChecker();
+        globalThis.contractManager = {
+            getCurrentSignerForPermissions: vi.fn().mockResolvedValue('0xpermission')
+        };
+        globalThis.walletManager = {
+            currentAccount: '0xwallet'
+        };
+
+        const checker = new FarmMigrationChecker();
+
+        await expect(checker.getConnectedWalletAddress()).resolves.toBe('0xpermission');
+    });
+
+    it('marks a connected wallet as having migration work when old stake or rewards exist', async () => {
+        const FarmMigrationChecker = await loadFarmMigrationChecker();
+        const getUserStakeInfo = vi.fn()
+            .mockResolvedValueOnce({
+                amount: createMockBigNumber('0'),
+                pendingRewards: createMockBigNumber('5')
+            });
+        const getPairs = vi.fn().mockResolvedValue([
+            { lpToken: '0xlp1' }
+        ]);
+        const Contract = vi.fn(function MockContract() {
+            return { getPairs, getUserStakeInfo };
+        });
+        const provider = { provider: true };
+        const executeWithProviderFallback = vi.fn(async (operation) => operation(provider, null));
+
+        globalThis.CONFIG = {
+            FARM_MIGRATION: {
+                OLD_FARM_CONTRACTS: {
+                    BSC_MAINNET: '0xoldfarm'
+                },
+                LEGACY_LP_TOKENS: {}
+            },
+            ABIS: {
+                STAKING_CONTRACT: ['staking abi']
+            }
+        };
+        globalThis.ethers = {
+            BigNumber: { from: createMockBigNumber },
+            Contract
+        };
+        globalThis.contractManager = {
+            provider,
+            executeWithProviderFallback,
+            contractABIs: new Map([['STAKING', ['manager staking abi']]])
+        };
+        const checker = new FarmMigrationChecker();
+
+        const result = await checker.fetchPosition(
+            {
+                oldFarmContracts: { BSC_MAINNET: '0xoldfarm' },
+                legacyLpTokens: {}
+            },
+            '0xwallet',
+            'BSC_MAINNET'
+        );
+
+        expect(executeWithProviderFallback).toHaveBeenCalledWith(
+            expect.any(Function),
+            'FarmMigrationChecker.checkPosition',
+            2
+        );
+        expect(Contract).toHaveBeenCalledWith('0xoldfarm', ['manager staking abi'], provider);
+        expect(getPairs).toHaveBeenCalled();
+        expect(getUserStakeInfo).toHaveBeenCalledWith('0xwallet', '0xlp1');
+        expect(result).toEqual({
+            hasPosition: true,
+            stakeAmountRaw: '0',
+            pendingRewardsRaw: '5'
+        });
+    });
+
+    it('reuses ContractManager cached RPC providers when no active provider exists', async () => {
+        const FarmMigrationChecker = await loadFarmMigrationChecker();
+        const cachedProvider = { cached: true };
+        globalThis.CONFIG = {
+            NETWORKS: {
+                BSC_MAINNET: {
+                    RPC_URL: 'https://rpc.example'
+                }
+            }
+        };
+        globalThis.contractManager = {
+            getRpcProvider: vi.fn().mockReturnValue(cachedProvider)
+        };
+
+        const checker = new FarmMigrationChecker();
+
+        expect(checker.getProvider('BSC_MAINNET')).toBe(cachedProvider);
+        expect(globalThis.contractManager.getRpcProvider).toHaveBeenCalledWith('https://rpc.example');
+    });
+});

--- a/tests/home-page.test.js
+++ b/tests/home-page.test.js
@@ -63,6 +63,38 @@ describe('HomePage.formatTvlDisplay', () => {
     });
 });
 
+describe('HomePage.loadDataWhenReady', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete globalThis.contractManager;
+        delete globalThis.HomePage;
+        delete globalThis.window;
+    });
+
+    it('checks Farm 1.0 migration status when the contract manager is already ready on page load', async () => {
+        const homePagePrototype = await loadHomePage();
+        globalThis.contractManager = {
+            isReady: vi.fn().mockReturnValue(true)
+        };
+        const context = {
+            updateFooter: vi.fn(),
+            loadData: vi.fn().mockResolvedValue(undefined),
+            checkFarmMigrationPosition: vi.fn().mockResolvedValue(undefined),
+            checkAdminAccess: vi.fn()
+        };
+
+        await homePagePrototype.loadDataWhenReady.call(context);
+
+        expect(context.loadData).toHaveBeenCalled();
+        expect(context.checkFarmMigrationPosition).toHaveBeenCalled();
+        expect(context.checkAdminAccess).toHaveBeenCalled();
+    });
+});
+
 describe('HomePage.renderPairRow', () => {
     beforeEach(() => {
         vi.spyOn(console, 'log').mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- Add an isolated Farm 1.0 migration banner component and stylesheet for the farm page
- Split old-farm position detection into `FarmMigrationChecker`, reusing existing ContractManager provider, ABI, signer, and provider-fallback helpers without changing ContractManager
- Detect connected wallets with old Farm 1.0 stake or pending rewards and show the highlighted migration message
- Update BSC mainnet config to the new staking contract while keeping old farm contract addresses for migration checks

## Notes
- The migration feature is controlled by `CONFIG.FARM_MIGRATION`, including enable/disable and position-check switches.

<img width="999" height="304" alt="image" src="https://github.com/user-attachments/assets/a251f9e0-fdd8-437c-a87a-09b67d5089f9" />