### PR TITLE
Show admin pair TVL for old farm migration

### DIFF
--- a/css/admin-combined.css
+++ b/css/admin-combined.css
@@ -340,6 +340,19 @@ table tbody tr:last-child td {
   background: rgba(0, 0, 0, 0.05);
 }
 
+[data-theme="light"] .pair-tvl-item {
+  background: rgba(0, 0, 0, 0.03);
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .tvl-label {
+  color: rgba(0, 0, 0, 0.55);
+}
+
+[data-theme="light"] .tvl-value {
+  color: rgba(0, 0, 0, 0.82);
+}
+
 [data-theme="light"] .address-label {
   color: rgba(0, 0, 0, 0.6);
 }
@@ -1417,7 +1430,41 @@ table td:last-child {
 .pair-details-section {
   display: flex;
   flex-direction: column;
-  gap: 0;
+  gap: 12px;
+}
+
+.pair-tvl-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.pair-tvl-item {
+  min-width: 0;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+}
+
+.tvl-label {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.2;
+  color: rgba(255, 255, 255, 0.55);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.tvl-value {
+  display: block;
+  overflow-wrap: anywhere;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.25;
+  color: rgba(255, 255, 255, 0.92);
 }
 
 .pair-address-wrapper {

--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -2673,6 +2673,10 @@ class AdminPage {
             return '...';
         }
 
+        if (pair.tvl === null || pair.tvl === undefined) {
+            return 'N/A';
+        }
+
         const tvl = Number(pair.tvl);
         if (!Number.isFinite(tvl)) {
             return 'N/A';

--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -2639,24 +2639,193 @@ class AdminPage {
         }
     }
 
+    parseWeightValue(weight) {
+        if (!weight && weight !== 0) return null;
+
+        try {
+            if (typeof weight === 'object' && weight._isBigNumber) {
+                return Number(ethers.utils.formatEther(weight));
+            }
+
+            if (typeof weight === 'bigint') {
+                return Number(weight);
+            }
+
+            if (typeof weight === 'string') {
+                const weightStr = weight.trim();
+                const normalizedWeight = (/^\d+$/.test(weightStr) && weightStr.length >= 18)
+                    ? ethers.utils.formatUnits(weightStr, 18)
+                    : weightStr;
+                const num = Number(normalizedWeight);
+                return Number.isFinite(num) ? num : null;
+            }
+
+            const num = Number(weight);
+            return Number.isFinite(num) ? num : null;
+        } catch (error) {
+            console.warn('Failed to parse weight value:', error);
+            return null;
+        }
+    }
+
+    formatPairTvlTokens(pair) {
+        if (!pair?.tvlCalculated) {
+            return '...';
+        }
+
+        const tvl = Number(pair.tvl);
+        if (!Number.isFinite(tvl)) {
+            return 'N/A';
+        }
+
+        const formattedTvl = window.Formatter?.formatSmallNumberWithSubscript?.(tvl)
+            || this.formatNumber(tvl);
+        return `${formattedTvl} LP`;
+    }
+
+    formatPairTvlUsd(pair) {
+        if (!pair?.tvlCalculated) {
+            return '...';
+        }
+
+        if (pair.tvlUsd === null || pair.tvlUsd === undefined) {
+            return 'N/A';
+        }
+
+        const tvlUsd = Number(pair.tvlUsd);
+        if (!Number.isFinite(tvlUsd)) {
+            return 'N/A';
+        }
+
+        return window.Formatter?.formatCompactCurrency?.(tvlUsd)
+            || window.Formatter?.formatCurrency?.(tvlUsd)
+            || `$${this.formatNumber(tvlUsd)}`;
+    }
+
+    async ensureRewardsCalculator(contractManager) {
+        if (window.rewardsCalculator) {
+            return window.rewardsCalculator;
+        }
+
+        if (!window.RewardsCalculator) {
+            return null;
+        }
+
+        try {
+            window.rewardsCalculator = new window.RewardsCalculator();
+            await window.rewardsCalculator.initialize({ contractManager });
+            return window.rewardsCalculator;
+        } catch (error) {
+            console.warn('Unable to initialize rewards calculator for admin TVL:', error);
+            return null;
+        }
+    }
+
+    async enrichPairsWithTvl(pairs, totalWeight) {
+        if (!Array.isArray(pairs) || pairs.length === 0) {
+            return pairs || [];
+        }
+
+        const contractManager = window.contractManager;
+        const rewardsCalculator = await this.ensureRewardsCalculator(contractManager);
+
+        if (!contractManager?.getLPStakeBreakdowns || !rewardsCalculator?.buildPoolMetrics) {
+            console.warn('TVL prerequisites unavailable for admin pair list');
+            return pairs.map(pair => ({
+                ...pair,
+                tvl: null,
+                tvlUsd: null,
+                tvlCalculated: true
+            }));
+        }
+
+        try {
+            const breakdowns = await contractManager.getLPStakeBreakdowns(pairs);
+            const tokenAddresses = new Set();
+
+            breakdowns.forEach((breakdown) => {
+                const token0Address = breakdown?.token0?.address?.toLowerCase?.();
+                const token1Address = breakdown?.token1?.address?.toLowerCase?.();
+
+                if (token0Address) tokenAddresses.add(token0Address);
+                if (token1Address) tokenAddresses.add(token1Address);
+            });
+
+            const tokenPricesUsd = new Map();
+            await Promise.all(Array.from(tokenAddresses).map(async (address) => {
+                const priceUsd = await rewardsCalculator.fetchTokenPriceByAddress(address);
+                tokenPricesUsd.set(address, priceUsd);
+            }));
+
+            const rewardTokenAddress = (contractManager.contractAddresses instanceof Map)
+                ? contractManager.contractAddresses.get('REWARD_TOKEN')
+                : contractManager.rewardTokenContract?.address;
+            const totalWeightValue = this.parseWeightValue(totalWeight)
+                || pairs.reduce((sum, pair) => sum + (this.parseWeightValue(pair?.weight) || 0), 0)
+                || 1;
+
+            return pairs.map((pair) => {
+                try {
+                    const pairIdentifier = pair.address || pair.lpToken || pair.name;
+                    const resolvedAddress = contractManager.resolveLPTokenAddress(pairIdentifier);
+                    const breakdown = resolvedAddress ? breakdowns.get(resolvedAddress) : null;
+
+                    if (!breakdown) {
+                        return {
+                            ...pair,
+                            tvl: null,
+                            tvlUsd: null,
+                            tvlCalculated: true
+                        };
+                    }
+
+                    const token0Addr = breakdown?.token0?.address?.toLowerCase?.();
+                    const token1Addr = breakdown?.token1?.address?.toLowerCase?.();
+                    const poolWeight = this.parseWeightValue(pair?.weight) || 1;
+                    const metrics = rewardsCalculator.buildPoolMetrics({
+                        breakdown,
+                        rewardTokenAddress,
+                        hourlyRate: 0,
+                        poolWeight,
+                        totalWeight: totalWeightValue,
+                        token0PriceUsd: token0Addr ? (tokenPricesUsd.get(token0Addr) || 0) : 0,
+                        token1PriceUsd: token1Addr ? (tokenPricesUsd.get(token1Addr) || 0) : 0
+                    });
+
+                    return {
+                        ...pair,
+                        tvl: metrics.tvlLpTokens,
+                        tvlUsd: metrics.tvlUsd,
+                        tvlCalculated: true
+                    };
+                } catch (error) {
+                    console.warn(`Failed to calculate admin TVL for ${pair?.name || pair?.address || 'pair'}:`, error);
+                    return {
+                        ...pair,
+                        tvl: null,
+                        tvlUsd: null,
+                        tvlCalculated: true
+                    };
+                }
+            });
+        } catch (error) {
+            console.warn('Failed to calculate admin pair TVL:', error);
+            return pairs.map(pair => ({
+                ...pair,
+                tvl: null,
+                tvlUsd: null,
+                tvlCalculated: true
+            }));
+        }
+    }
+
     renderPairsList(pairs, totalWeight) {
         if (!pairs || pairs.length === 0) {
             return '<div class="no-data">No pairs configured</div>';
         }
 
-        // Calculate total weight and parse pair weights
-        const parseWeight = (weight) => {
-            if (!weight || (typeof weight === 'object' && weight === null)) return null;
-            try {
-                const num = typeof weight === 'string' ? parseFloat(weight) : Number(weight);
-                return !isNaN(num) ? num : null;
-            } catch {
-                return null;
-            }
-        };
-
         const pairData = pairs.map(pair => {
-            const weight = parseWeight(pair?.weight);
+            const weight = this.parseWeightValue(pair?.weight);
             let displayWeight;
             if (weight != null) {
                 displayWeight = window.Formatter?.formatSmallNumberWithSubscript(weight) || weight.toString();
@@ -2669,13 +2838,18 @@ class AdminPage {
                 address: pair?.address || 'Unknown',
                 platform: pair?.platform || '',
                 weight: weight,
-                displayWeight: displayWeight
+                displayWeight: displayWeight,
+                tvl: pair?.tvl,
+                tvlUsd: pair?.tvlUsd,
+                tvlCalculated: pair?.tvlCalculated === true
             };
         });
         
         // if totalWeight not provided, calculate it
         if (totalWeight === undefined || totalWeight === null) {
             totalWeight = pairData.reduce((sum, p) => sum + (p.weight || 0), 0);
+        } else {
+            totalWeight = this.parseWeightValue(totalWeight) || 0;
         }
 
         return pairData.map(pair => {
@@ -2702,6 +2876,16 @@ class AdminPage {
                         </div>
                     </div>
                     <div class="pair-details-section">
+                        <div class="pair-tvl-grid">
+                            <div class="pair-tvl-item">
+                                <span class="tvl-label">TVL Tokens</span>
+                                <span class="tvl-value">${this.formatPairTvlTokens(pair)}</span>
+                            </div>
+                            <div class="pair-tvl-item">
+                                <span class="tvl-label">TVL USD</span>
+                                <span class="tvl-value">${this.formatPairTvlUsd(pair)}</span>
+                            </div>
+                        </div>
                         <div class="weight-bar-container">
                             <div class="weight-bar" style="width: ${percentageValue}%"></div>
                         </div>
@@ -4413,6 +4597,7 @@ class AdminPage {
             contractInfo.totalWeight = await this.safeContractCall(
                 async () => {
                     const totalWeight = await contractManager.getTotalWeight();
+                    contractInfo.totalWeightRaw = totalWeight;
                     // consistent formatting without rounding
                     return this.formatWeightForDisplay(totalWeight);
                 },
@@ -4423,7 +4608,7 @@ class AdminPage {
             contractInfo.pairs = await this.safeContractCall(
                 async () => {
                     const pairsInfo = await contractManager.getAllPairsInfo();
-                    return pairsInfo || [];
+                    return await this.enrichPairsWithTvl(pairsInfo || [], contractInfo.totalWeightRaw);
                 },
                 []
             );
@@ -4533,7 +4718,7 @@ class AdminPage {
                     const weightB = parseFloat(b.weight || '0');
                     return weightB - weightA; // Descending order (highest first)
                 });
-                pairsContainer.innerHTML = this.renderPairsList(sortedPairs, info.totalWeight);
+                pairsContainer.innerHTML = this.renderPairsList(sortedPairs, info.totalWeightRaw ?? info.totalWeight);
             } else {
                 pairsContainer.innerHTML = '<div class="no-data">No LP pairs configured</div>';
             }

--- a/js/master-initializer.js
+++ b/js/master-initializer.js
@@ -117,14 +117,9 @@ class MasterInitializer {
             'js/contracts/contract-manager.js'
         ];
 
-        // Only load rewards calculator on homepage
-        if (!this.isAdminPage) {
-            walletScripts.push('js/utils/pricing/gecko-terminal-price-provider.js');
-            walletScripts.push('js/utils/pricing/dex-screener-price-provider.js');
-            walletScripts.push('js/utils/rewards-calculator.js');
-        } else {
-            console.log('⏭️ Skipping homepage utilities (admin mode)');
-        }
+        walletScripts.push('js/utils/pricing/gecko-terminal-price-provider.js');
+        walletScripts.push('js/utils/pricing/dex-screener-price-provider.js');
+        walletScripts.push('js/utils/rewards-calculator.js');
 
         for (const script of walletScripts) {
             await this.loadScript(script);
@@ -302,28 +297,24 @@ class MasterInitializer {
             }
         }
 
-        // Initialize rewards calculator (homepage only)
-        if (!this.isAdminPage) {
-            if (window.RewardsCalculator && !window.rewardsCalculator && window.contractManager) {
-                try {
-                    window.rewardsCalculator = new window.RewardsCalculator();
+        // Initialize rewards calculator for pages that display pool TVL/APR.
+        if (window.RewardsCalculator && !window.rewardsCalculator && window.contractManager) {
+            try {
+                window.rewardsCalculator = new window.RewardsCalculator();
 
-                    await window.rewardsCalculator.initialize({
-                        contractManager: window.contractManager
-                    });
+                await window.rewardsCalculator.initialize({
+                    contractManager: window.contractManager
+                });
 
-                    this.components.set('rewardsCalculator', window.rewardsCalculator);
-                } catch (error) {
-                    console.error('❌ Failed to initialize RewardsCalculator:', error);
-                    console.error('   Error stack:', error.stack);
-                }
-            } else if (window.rewardsCalculator) {
-                console.warn('⚠️ RewardsCalculator instance already exists');
-            } else if (!window.RewardsCalculator || !window.contractManager) {
-                console.error('❌ RewardsCalculator prerequisites not met!');
+                this.components.set('rewardsCalculator', window.rewardsCalculator);
+            } catch (error) {
+                console.error('❌ Failed to initialize RewardsCalculator:', error);
+                console.error('   Error stack:', error.stack);
             }
-        } else {
-            console.log('⏭️ Skipping RewardsCalculator initialization (admin mode)');
+        } else if (window.rewardsCalculator) {
+            console.warn('⚠️ RewardsCalculator instance already exists');
+        } else if (!window.RewardsCalculator || !window.contractManager) {
+            console.error('❌ RewardsCalculator prerequisites not met!');
         }
 
         // Initialize homepage UI components (homepage only)


### PR DESCRIPTION
## Summary

- Load the existing pricing and rewards utilities on the admin page so pair TVL can use the same calculation path as staking.
- Enrich eligible pairs with LP-token TVL and USD TVL before rendering the admin contract info card.
- Add compact admin card styling for token and USD TVL values in light and dark themes.
