### PR TITLE
Use up/down arrow icons for Create LP and Remove LP tabs

### DIFF
--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -260,7 +260,7 @@ class StakingModalNew {
                     
                     <div class="modal-tabs">
                         <button class="tab-button active" aria-label="Create LP" data-tab="zap">
-                            <span class="material-icons" aria-hidden="true">bolt</span>
+                            <span class="material-icons" aria-hidden="true">arrow_upward</span>
                             <span class="tab-label">Create LP</span>
                         </button>
                         <button class="tab-button" aria-label="Stake" data-tab="stake">
@@ -276,7 +276,7 @@ class StakingModalNew {
                             <span class="tab-label">Claim</span>
                         </button>
                         <button class="tab-button" aria-label="Remove LP" data-tab="remove-liquidity">
-                            <span class="material-icons" aria-hidden="true">swap_horiz</span>
+                            <span class="material-icons" aria-hidden="true">arrow_downward</span>
                             <span class="tab-label">Remove LP</span>
                         </button>
                     </div>

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -372,7 +372,8 @@ describe('StakingModalNew zap cleanup', () => {
 
         expect(modalContainer.innerHTML).toContain('class="modal-tabs"');
         expect(modalContainer.innerHTML).toContain('aria-label="Create LP"');
-        expect(modalContainer.innerHTML).toContain('<span class="material-icons" aria-hidden="true">bolt</span>');
+        expect(modalContainer.innerHTML).toContain('<span class="material-icons" aria-hidden="true">arrow_upward</span>');
+        expect(modalContainer.innerHTML).toContain('<span class="material-icons" aria-hidden="true">arrow_downward</span>');
         expect(modalContainer.innerHTML).toContain('<span class="tab-label">Create LP</span>');
         expect(modalContainer.innerHTML).toContain('<span class="tab-label">Unstake</span>');
         expect(modalContainer.innerHTML).toContain('<span class="tab-label">Remove LP</span>');


### PR DESCRIPTION
## Summary
- Replace Create LP tab icon `bolt` → `arrow_upward`
- Replace Remove LP tab icon `swap_horiz` → `arrow_downward`
- Update modal tab icon tests

Closes #276

## Test plan
- [x] `npm test -- tests/staking-modal-new.test.js`
- [x] Visual check: Create LP and Remove LP tabs show up/down arrows in the modal tab bar