### PR TITLE
Add info panel to Remove LP tab (#275)

### DIFF
--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -3374,8 +3374,14 @@ class StakingModalNew {
             Math.abs(removeLiquidityPercentage - percentage) < 0.001
         );
         const balanceErrorClass = balanceError ? '' : ' zap-balance-error-empty';
+        const pairName = this.escapeHtml(this.currentPair?.name || 'this pair');
 
         return `
+            <div class="zap-info-panel">
+                <span class="material-icons">info</span>
+                <span>Remove LP burns your ${pairName} LP tokens and returns the underlying pool tokens. Enable Convert to one preferred token to receive a single token via zap-out in one transaction.</span>
+            </div>
+
             <div class="balance-info">
                 <span class="balance-label">Available LP Tokens:</span>
                 <span class="balance-value">${this.userBalance} LP${this.renderInlineLpUsdEstimate(this.userBalance)}</span>

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -1079,6 +1079,31 @@ describe('StakingModalNew zap cleanup', () => {
         expect(html).toContain('<dd>None</dd>');
     });
 
+    it('renders an info panel explaining remove LP and optional zap-out', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.currentPair = { name: 'LIB/USDT' };
+
+        const html = modal.renderRemoveLiquidityTab();
+
+        expect(html).toContain('class="zap-info-panel"');
+        expect(html).toContain('<span class="material-icons">info</span>');
+        expect(html).toContain('Remove LP burns your LIB/USDT LP tokens and returns the underlying pool tokens.');
+        expect(html).toContain('Convert to one preferred token');
+        expect(html).toContain('zap-out in one transaction');
+        expect(html.indexOf('zap-info-panel')).toBeLessThan(html.indexOf('balance-info'));
+    });
+
+    it('uses a fallback pair name in the remove LP info panel', async () => {
+        const modal = await createLoadedModal();
+        arrangeReadyRemoveLiquidityPreview(modal);
+        modal.currentPair = null;
+
+        const html = modal.renderRemoveLiquidityTab();
+
+        expect(html).toContain('Remove LP burns your this pair LP tokens');
+    });
+
     it('renders guided remove-liquidity controls and preview on the Remove LP tab', async () => {
         const modal = await createLoadedModal();
         arrangeReadyRemoveLiquidityPreview(modal, { convert: true });
@@ -1087,6 +1112,7 @@ describe('StakingModalNew zap cleanup', () => {
 
         const html = modal.renderRemoveLiquidityTab();
 
+        expect(html).toContain('class="zap-info-panel"');
         expect(html).toContain('10 LP <span class="lp-usd-estimate">($100.00)</span>');
         expect(html).toContain('id="remove-liquidity-amount-input"');
         expect(html).toContain('remove-liquidity-meta-row');


### PR DESCRIPTION
## What Changed

This PR adds an informational callout at the top of the Remove LP tab, matching the Create LP tab pattern.

- `renderRemoveLiquidityTab()` renders a `zap-info-panel` before balance and amount controls.
- Copy explains direct remove (burn LP → underlying pool tokens) vs optional zap-out via **Convert to one preferred token**.
- Pair name is interpolated from `currentPair.name` with a `this pair` fallback, same as Create LP.
- Reuses existing `.zap-info-panel` styles; no CSS changes.

## Fixed Flow

1. User opens the staking modal and switches to **Remove LP**.
2. An info panel with the `info` icon appears at the top of the tab.
3. User reads how direct remove differs from enabling zap-out before entering an amount.

## Why

Remove LP had no inline guidance, unlike Create LP. Users may not understand direct remove vs zap-out without brief context at the top of the tab.
<img width="783" height="1091" alt="image" src="https://github.com/user-attachments/assets/73b7ab2b-ba75-4338-aeea-ecf699bf899f" />

## Validation

- `npm test` (176 tests passed)

Closes #275