### PR TITLE
Inline Stake, Unstake, and Claim row actions (#274)

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -168,30 +168,64 @@ body {
     justify-content: center;
 }
 
-.staking-metric-stack {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 8px;
-    min-width: 0;
-}
-
-.staking-metric-value {
+.staking-metric-value,
+.staking-apr-value {
     font-weight: 600;
     line-height: 1.35;
     white-space: nowrap;
+}
+
+.staking-apr-value {
+    color: var(--success-main);
+    font-weight: 700;
 }
 
 .staking-row-actions {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
+    justify-content: center;
     gap: 6px;
+    width: 100%;
 }
 
 .staking-pairs-table .staking-cell--share,
 .staking-pairs-table .staking-cell--reward {
     min-width: 132px;
+    text-align: center;
+}
+
+@media (min-width: 769px) {
+    .staking-pairs-table .staking-cell-body {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        width: 100%;
+        min-height: 52px;
+    }
+
+    .staking-pairs-table .staking-cell-value {
+        flex: 1 1 auto;
+        display: flex;
+        align-items: center;
+        justify-content: flex-start;
+        min-height: 24px;
+    }
+
+    .staking-pairs-table .staking-cell--share .staking-cell-value,
+    .staking-pairs-table .staking-cell--reward .staking-cell-value {
+        justify-content: center;
+    }
+
+    .staking-pairs-table .staking-cell-footer {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: flex-start;
+        justify-content: center;
+        min-height: 34px;
+        padding-top: 8px;
+        width: 100%;
+    }
 }
 
 .staking-pairs-table .staking-cell--actions {
@@ -712,6 +746,10 @@ body {
     .staking-pairs-table .staking-cell--share,
     .staking-pairs-table .staking-cell--reward {
         min-height: 0;
+    }
+
+    .staking-pairs-table .staking-cell-footer {
+        display: none;
     }
 }
 

--- a/css/home.css
+++ b/css/home.css
@@ -143,12 +143,18 @@ body {
     vertical-align: middle;
 }
 
+.staking-pairs-table th,
+.staking-pairs-table .staking-cell {
+    text-align: center;
+}
+
 .staking-pairs-table .pair-link-stack {
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
     gap: 2px;
     min-width: 0;
+    margin: 0 auto;
 }
 
 /* Button styles matching MUI */
@@ -192,14 +198,13 @@ body {
 .staking-pairs-table .staking-cell--share,
 .staking-pairs-table .staking-cell--reward {
     min-width: 132px;
-    text-align: center;
 }
 
 @media (min-width: 769px) {
     .staking-pairs-table .staking-cell-body {
         display: flex;
         flex-direction: column;
-        align-items: stretch;
+        align-items: center;
         width: 100%;
         min-height: 52px;
     }
@@ -208,13 +213,9 @@ body {
         flex: 1 1 auto;
         display: flex;
         align-items: center;
-        justify-content: flex-start;
-        min-height: 24px;
-    }
-
-    .staking-pairs-table .staking-cell--share .staking-cell-value,
-    .staking-pairs-table .staking-cell--reward .staking-cell-value {
         justify-content: center;
+        min-height: 24px;
+        width: 100%;
     }
 
     .staking-pairs-table .staking-cell-footer {

--- a/css/home.css
+++ b/css/home.css
@@ -168,19 +168,38 @@ body {
     justify-content: center;
 }
 
-/* Share and Earnings buttons in table */
-.btn-share,
-.btn-earnings {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
+.staking-metric-stack {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    min-width: 0;
+}
+
+.staking-metric-value {
     font-weight: 600;
+    line-height: 1.35;
     white-space: nowrap;
 }
 
-.btn-share .material-icons,
-.btn-earnings .material-icons {
-    font-size: 16px;
+.staking-row-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+}
+
+.staking-pairs-table .staking-cell--share,
+.staking-pairs-table .staking-cell--reward {
+    min-width: 132px;
+}
+
+.staking-pairs-table .staking-cell--actions {
+    display: none;
+}
+
+.staking-pairs-table .staking-row-actions .btn-small {
+    min-width: 72px;
 }
 
 /* Chip styles matching MUI */
@@ -419,8 +438,8 @@ body {
         grid-template-areas:
             "pair tvl"
             "apr weight"
-            "share share"
-            "reward reward";
+            "share reward"
+            "actions actions";
         gap: 10px;
         align-items: stretch;
         padding: 12px;
@@ -493,18 +512,37 @@ body {
         grid-area: reward;
     }
 
-    .staking-pairs-table .staking-cell--share,
-    .staking-pairs-table .staking-cell--reward {
-        min-height: 88px;
+    .staking-pairs-table .staking-cell--actions {
+        display: flex;
+        grid-area: actions;
+        min-height: 0;
     }
 
-    .staking-pairs-table .btn-share,
-    .staking-pairs-table .btn-earnings {
+    .staking-pairs-table .staking-cell--actions::before {
+        content: none;
+    }
+
+    .staking-pairs-table .staking-row-actions--desktop {
+        display: none !important;
+    }
+
+    .staking-pairs-table .staking-row-actions--mobile {
         width: 100%;
+        justify-content: stretch;
+        gap: 8px;
+    }
+
+    .staking-pairs-table .staking-row-actions--mobile .btn-small {
+        flex: 1 1 0;
         min-width: 0 !important;
         min-height: 44px;
         padding: 10px 12px;
-        white-space: normal;
+        white-space: nowrap;
+    }
+
+    .staking-pairs-table .staking-cell--share,
+    .staking-pairs-table .staking-cell--reward {
+        min-height: 0;
     }
 
     .staking-pairs-table .pair-link-stack,
@@ -687,9 +725,18 @@ body {
             "apr"
             "weight"
             "share"
-            "reward";
+            "reward"
+            "actions";
         gap: 8px;
         padding: 10px;
+    }
+
+    .staking-pairs-table .staking-row-actions--mobile {
+        flex-wrap: wrap;
+    }
+
+    .staking-pairs-table .staking-row-actions--mobile .btn-claim {
+        flex: 1 1 100%;
     }
 
     .page-title h1 {

--- a/css/home.css
+++ b/css/home.css
@@ -203,8 +203,12 @@ body {
 @media (min-width: 769px) {
     .staking-pairs-table {
         --staking-metric-row-height: 24px;
-        --staking-actions-row-height: 34px;
-        --staking-actions-row-gap: 8px;
+        --staking-actions-row-height: 28px;
+        --staking-actions-row-gap: 6px;
+    }
+
+    .staking-pairs-table tbody .staking-cell {
+        padding-bottom: 10px;
     }
 
     .staking-pairs-table .staking-cell-body {
@@ -246,7 +250,7 @@ body {
     .staking-pairs-table .staking-cell-footer {
         flex: 0 0 auto;
         display: flex;
-        align-items: flex-start;
+        align-items: center;
         justify-content: center;
         width: 100%;
         min-height: var(--staking-actions-row-height);

--- a/css/home.css
+++ b/css/home.css
@@ -139,8 +139,8 @@ body {
     border-bottom: none;
 }
 
-.staking-cell {
-    vertical-align: middle;
+.staking-pairs-table .staking-cell {
+    vertical-align: top;
 }
 
 .staking-pairs-table th,
@@ -201,21 +201,46 @@ body {
 }
 
 @media (min-width: 769px) {
+    .staking-pairs-table {
+        --staking-metric-row-height: 24px;
+        --staking-actions-row-height: 34px;
+        --staking-actions-row-gap: 8px;
+    }
+
     .staking-pairs-table .staking-cell-body {
         display: flex;
         flex-direction: column;
         align-items: center;
+        justify-content: flex-start;
         width: 100%;
-        min-height: 52px;
+        min-height: calc(
+            var(--staking-metric-row-height) +
+            var(--staking-actions-row-gap) +
+            var(--staking-actions-row-height)
+        );
     }
 
     .staking-pairs-table .staking-cell-value {
-        flex: 1 1 auto;
+        flex: 0 0 auto;
         display: flex;
         align-items: center;
         justify-content: center;
-        min-height: 24px;
         width: 100%;
+        min-height: var(--staking-metric-row-height);
+    }
+
+    .staking-pairs-table .staking-cell--apr .staking-cell-value,
+    .staking-pairs-table .staking-cell--weight .staking-cell-value,
+    .staking-pairs-table .staking-cell--tvl .staking-cell-value,
+    .staking-pairs-table .staking-cell--share .staking-cell-value,
+    .staking-pairs-table .staking-cell--reward .staking-cell-value {
+        height: var(--staking-metric-row-height);
+    }
+
+    .staking-pairs-table .staking-cell--pair .staking-cell-value {
+        align-items: flex-start;
+        height: auto;
+        min-height: var(--staking-metric-row-height);
     }
 
     .staking-pairs-table .staking-cell-footer {
@@ -223,9 +248,9 @@ body {
         display: flex;
         align-items: flex-start;
         justify-content: center;
-        min-height: 34px;
-        padding-top: 8px;
         width: 100%;
+        min-height: var(--staking-actions-row-height);
+        margin-top: var(--staking-actions-row-gap);
     }
 }
 

--- a/css/home.css
+++ b/css/home.css
@@ -174,14 +174,13 @@ body {
     justify-content: center;
 }
 
-.staking-metric-value,
-.staking-apr-value {
+.staking-metric-value {
     font-weight: 600;
     line-height: 1.35;
     white-space: nowrap;
 }
 
-.staking-apr-value {
+.staking-metric-value--apr {
     color: var(--success-main);
     font-weight: 700;
 }
@@ -231,20 +230,12 @@ body {
         justify-content: center;
         width: 100%;
         min-height: var(--staking-metric-row-height);
-    }
-
-    .staking-pairs-table .staking-cell--apr .staking-cell-value,
-    .staking-pairs-table .staking-cell--weight .staking-cell-value,
-    .staking-pairs-table .staking-cell--tvl .staking-cell-value,
-    .staking-pairs-table .staking-cell--share .staking-cell-value,
-    .staking-pairs-table .staking-cell--reward .staking-cell-value {
         height: var(--staking-metric-row-height);
     }
 
     .staking-pairs-table .staking-cell--pair .staking-cell-value {
         align-items: flex-start;
         height: auto;
-        min-height: var(--staking-metric-row-height);
     }
 
     .staking-pairs-table .staking-cell-footer {

--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -496,28 +496,52 @@ class HomePage {
                     <span style="font-weight: 600;">${this.formatTvlDisplay(pair)}</span>
                 </td>
                 <td class="staking-cell staking-cell--share" data-label="My Share">
-                    <button class="btn btn-primary btn-small btn-share"
-                            data-pair-id="${pair.id}"
-                            data-pair-address="${pair.address}"
-                            data-tab="0"
-                            title="Stake or Unstake"
-                            style="min-width: 100px;">
-                        <span class="material-icons" style="font-size: 16px;">share</span>
-                        ${userShares}%
-                    </button>
+                    <div class="staking-metric-stack">
+                        <span class="staking-metric-value">${userShares}%</span>
+                        <div class="staking-row-actions staking-row-actions--desktop">
+                            ${this.renderPairActionButton(pair, 'stake')}
+                            ${this.renderPairActionButton(pair, 'unstake')}
+                        </div>
+                    </div>
                 </td>
                 <td class="staking-cell staking-cell--reward" data-label="My Reward">
-                    <button class="btn btn-secondary btn-small btn-earnings"
-                            data-pair-id="${pair.id}"
-                            data-pair-address="${pair.address}"
-                            data-tab="2"
-                            title="Claim reward"
-                            style="min-width: 120px;">
-                        <span class="material-icons" style="font-size: 16px;">redeem</span>
-                        ${userEarnings} LIB
-                    </button>
+                    <div class="staking-metric-stack">
+                        <span class="staking-metric-value">${userEarnings} LIB</span>
+                        <div class="staking-row-actions staking-row-actions--desktop">
+                            ${this.renderPairActionButton(pair, 'claim')}
+                        </div>
+                    </div>
+                </td>
+                <td class="staking-cell staking-cell--actions" data-label="">
+                    <div class="staking-row-actions staking-row-actions--mobile">
+                        ${this.renderPairActionButton(pair, 'stake')}
+                        ${this.renderPairActionButton(pair, 'unstake')}
+                        ${this.renderPairActionButton(pair, 'claim')}
+                    </div>
                 </td>
             </tr>
+        `;
+    }
+
+    renderPairActionButton(pair, action) {
+        const buttonConfig = {
+            stake: { className: 'btn-primary btn-stake', label: 'Stake' },
+            unstake: { className: 'btn-secondary btn-unstake', label: 'Unstake' },
+            claim: { className: 'btn-secondary btn-claim', label: 'Claim' }
+        };
+        const config = buttonConfig[action];
+        if (!config) {
+            return '';
+        }
+
+        return `
+            <button
+                type="button"
+                class="btn ${config.className} btn-small"
+                data-pair-id="${pair.id}"
+                data-pair-address="${pair.address}"
+                data-action="${action}"
+            >${config.label}</button>
         `;
     }
 
@@ -559,31 +583,19 @@ class HomePage {
                 }
             }
 
-            // Handle Share button click (open modal on Stake tab)
-            if (e.target.closest('.btn-share')) {
+            const actionButton = e.target.closest('.btn-stake, .btn-unstake, .btn-claim');
+            if (actionButton) {
                 e.stopPropagation();
                 if (!this.isWalletConnected()) {
                     this.showWalletRequiredToast();
                     return;
                 }
 
-                const button = e.target.closest('.btn-share');
-                const pairId = button.dataset.pairId;
-                const tab = parseInt(button.dataset.tab) || 0;
-                this.openStakingModal(pairId, tab === 0 ? 'stake' : 'unstake');
-            }
-
-            // Handle Earnings button click (open modal on Claim tab)
-            if (e.target.closest('.btn-earnings')) {
-                e.stopPropagation();
-                if (!this.isWalletConnected()) {
-                    this.showWalletRequiredToast();
-                    return;
+                const pairId = actionButton.dataset.pairId;
+                const action = actionButton.dataset.action;
+                if (pairId && action) {
+                    this.openStakingModal(pairId, action);
                 }
-
-                const button = e.target.closest('.btn-earnings');
-                const pairId = button.dataset.pairId;
-                this.openStakingModal(pairId, 'claim');
             }
 
         });

--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -476,41 +476,42 @@ class HomePage {
             ? `<a href="${platformUrl}" target="_blank" rel="noopener noreferrer" class="platform-link" title="View pool on ${platform}" style="font-size: 12px; color: var(--text-secondary); display: inline-block;">${platform}</a>`
             : `<span style="font-size: 12px; color: var(--text-secondary);">${platform}</span>`;
         
+        const shareActionsHtml = `
+            <div class="staking-row-actions staking-row-actions--desktop">
+                ${this.renderPairActionButton(pair, 'stake')}
+                ${this.renderPairActionButton(pair, 'unstake')}
+            </div>
+        `;
+        const claimActionHtml = `
+            <div class="staking-row-actions staking-row-actions--desktop">
+                ${this.renderPairActionButton(pair, 'claim')}
+            </div>
+        `;
+
         return `
             <tr class="pair-row" data-pair-id="${pair.id}" style="cursor: pointer;">
                 <td class="staking-cell staking-cell--pair" data-label="Pair">
-                    <div class="pair-link-stack">
-                        ${pairNameHtml}
-                        ${platformHtml}
-                    </div>
+                    ${this.renderStakingCellBody(`
+                        <div class="pair-link-stack">
+                            ${pairNameHtml}
+                            ${platformHtml}
+                        </div>
+                    `)}
                 </td>
                 <td class="staking-cell staking-cell--apr" data-label="APR">
-                    <span style="color: var(--success-main); font-weight: bold;">${pair.apr || '0.00'}%</span>
+                    ${this.renderStakingCellBody(`<span class="staking-apr-value">${pair.apr || '0.00'}%</span>`)}
                 </td>
                 <td class="staking-cell staking-cell--weight" data-label="Weight">
-                    <span style="font-weight: 600;">
-                        ${pair.weightPercentage || '0.00'}%
-                    </span>
+                    ${this.renderStakingCellBody(`<span class="staking-metric-value">${pair.weightPercentage || '0.00'}%</span>`)}
                 </td>
                 <td class="staking-cell staking-cell--tvl" data-label="TVL">
-                    <span style="font-weight: 600;">${this.formatTvlDisplay(pair)}</span>
+                    ${this.renderStakingCellBody(`<span class="staking-metric-value">${this.formatTvlDisplay(pair)}</span>`)}
                 </td>
                 <td class="staking-cell staking-cell--share" data-label="My Share">
-                    <div class="staking-metric-stack">
-                        <span class="staking-metric-value">${userShares}%</span>
-                        <div class="staking-row-actions staking-row-actions--desktop">
-                            ${this.renderPairActionButton(pair, 'stake')}
-                            ${this.renderPairActionButton(pair, 'unstake')}
-                        </div>
-                    </div>
+                    ${this.renderStakingCellBody(`<span class="staking-metric-value">${userShares}%</span>`, shareActionsHtml)}
                 </td>
                 <td class="staking-cell staking-cell--reward" data-label="My Reward">
-                    <div class="staking-metric-stack">
-                        <span class="staking-metric-value">${userEarnings} LIB</span>
-                        <div class="staking-row-actions staking-row-actions--desktop">
-                            ${this.renderPairActionButton(pair, 'claim')}
-                        </div>
-                    </div>
+                    ${this.renderStakingCellBody(`<span class="staking-metric-value">${userEarnings} LIB</span>`, claimActionHtml)}
                 </td>
                 <td class="staking-cell staking-cell--actions" data-label="">
                     <div class="staking-row-actions staking-row-actions--mobile">
@@ -523,11 +524,20 @@ class HomePage {
         `;
     }
 
+    renderStakingCellBody(valueHtml, footerHtml = '') {
+        return `
+            <div class="staking-cell-body">
+                <div class="staking-cell-value">${valueHtml}</div>
+                <div class="staking-cell-footer">${footerHtml}</div>
+            </div>
+        `;
+    }
+
     renderPairActionButton(pair, action) {
         const buttonConfig = {
             stake: { className: 'btn-primary btn-stake', label: 'Stake' },
-            unstake: { className: 'btn-secondary btn-unstake', label: 'Unstake' },
-            claim: { className: 'btn-secondary btn-claim', label: 'Claim' }
+            unstake: { className: 'btn-danger btn-unstake', label: 'Unstake' },
+            claim: { className: 'btn-success btn-claim', label: 'Claim' }
         };
         const config = buttonConfig[action];
         if (!config) {

--- a/js/components/home-page.js
+++ b/js/components/home-page.js
@@ -476,15 +476,9 @@ class HomePage {
             ? `<a href="${platformUrl}" target="_blank" rel="noopener noreferrer" class="platform-link" title="View pool on ${platform}" style="font-size: 12px; color: var(--text-secondary); display: inline-block;">${platform}</a>`
             : `<span style="font-size: 12px; color: var(--text-secondary);">${platform}</span>`;
         
-        const shareActionsHtml = `
+        const desktopActions = (actions) => `
             <div class="staking-row-actions staking-row-actions--desktop">
-                ${this.renderPairActionButton(pair, 'stake')}
-                ${this.renderPairActionButton(pair, 'unstake')}
-            </div>
-        `;
-        const claimActionHtml = `
-            <div class="staking-row-actions staking-row-actions--desktop">
-                ${this.renderPairActionButton(pair, 'claim')}
+                ${actions.map((action) => this.renderPairActionButton(pair, action)).join('')}
             </div>
         `;
 
@@ -499,7 +493,7 @@ class HomePage {
                     `)}
                 </td>
                 <td class="staking-cell staking-cell--apr" data-label="APR">
-                    ${this.renderStakingCellBody(`<span class="staking-apr-value">${pair.apr || '0.00'}%</span>`)}
+                    ${this.renderStakingCellBody(`<span class="staking-metric-value staking-metric-value--apr">${pair.apr || '0.00'}%</span>`)}
                 </td>
                 <td class="staking-cell staking-cell--weight" data-label="Weight">
                     ${this.renderStakingCellBody(`<span class="staking-metric-value">${pair.weightPercentage || '0.00'}%</span>`)}
@@ -508,10 +502,10 @@ class HomePage {
                     ${this.renderStakingCellBody(`<span class="staking-metric-value">${this.formatTvlDisplay(pair)}</span>`)}
                 </td>
                 <td class="staking-cell staking-cell--share" data-label="My Share">
-                    ${this.renderStakingCellBody(`<span class="staking-metric-value">${userShares}%</span>`, shareActionsHtml)}
+                    ${this.renderStakingCellBody(`<span class="staking-metric-value">${userShares}%</span>`, desktopActions(['stake', 'unstake']))}
                 </td>
                 <td class="staking-cell staking-cell--reward" data-label="My Reward">
-                    ${this.renderStakingCellBody(`<span class="staking-metric-value">${userEarnings} LIB</span>`, claimActionHtml)}
+                    ${this.renderStakingCellBody(`<span class="staking-metric-value">${userEarnings} LIB</span>`, desktopActions(['claim']))}
                 </td>
                 <td class="staking-cell staking-cell--actions" data-label="">
                     <div class="staking-row-actions staking-row-actions--mobile">
@@ -524,35 +518,22 @@ class HomePage {
         `;
     }
 
-    renderStakingCellBody(valueHtml, footerHtml = '') {
-        return `
-            <div class="staking-cell-body">
-                <div class="staking-cell-value">${valueHtml}</div>
-                <div class="staking-cell-footer">${footerHtml}</div>
-            </div>
-        `;
+    renderStakingCellBody(valueHtml, footerHtml) {
+        return `<div class="staking-cell-body"><div class="staking-cell-value">${valueHtml}</div><div class="staking-cell-footer">${footerHtml || ''}</div></div>`;
     }
 
     renderPairActionButton(pair, action) {
-        const buttonConfig = {
-            stake: { className: 'btn-primary btn-stake', label: 'Stake' },
-            unstake: { className: 'btn-danger btn-unstake', label: 'Unstake' },
-            claim: { className: 'btn-success btn-claim', label: 'Claim' }
+        const classes = {
+            stake: 'btn-primary btn-stake',
+            unstake: 'btn-danger btn-unstake',
+            claim: 'btn-success btn-claim'
         };
-        const config = buttonConfig[action];
-        if (!config) {
-            return '';
+        const labels = { stake: 'Stake', unstake: 'Unstake', claim: 'Claim' };
+        if (!classes[action]) {
+            throw new Error(`Unknown staking row action: ${action}`);
         }
 
-        return `
-            <button
-                type="button"
-                class="btn ${config.className} btn-small"
-                data-pair-id="${pair.id}"
-                data-pair-address="${pair.address}"
-                data-action="${action}"
-            >${config.label}</button>
-        `;
+        return `<button type="button" class="btn ${classes[action]} btn-small" data-pair-id="${pair.id}" data-pair-address="${pair.address}" data-action="${action}">${labels[action]}</button>`;
     }
 
     attachEventListeners() {
@@ -601,11 +582,7 @@ class HomePage {
                     return;
                 }
 
-                const pairId = actionButton.dataset.pairId;
-                const action = actionButton.dataset.action;
-                if (pairId && action) {
-                    this.openStakingModal(pairId, action);
-                }
+                this.openStakingModal(actionButton.dataset.pairId, actionButton.dataset.action);
             }
 
         });

--- a/tests/home-page.test.js
+++ b/tests/home-page.test.js
@@ -116,20 +116,16 @@ describe('HomePage.renderPairRow', () => {
         delete globalThis.window;
     });
 
-    function createRenderPairRowContext(homePagePrototype, overrides = {}) {
+    function renderPairRowOutput(homePagePrototype, pair, overrides = {}) {
         const context = Object.create(homePagePrototype);
-        Object.assign(context, overrides);
-        return context;
+        context.isWalletConnected = overrides.isWalletConnected || (() => true);
+        context.formatTvlDisplay = overrides.formatTvlDisplay || (() => '$1.2K');
+        return homePagePrototype.renderPairRow.call(context, pair);
     }
 
-    it('adds mobile card labels and cell classes to each staking row cell', async () => {
+    it('renders inline row metrics and action buttons', async () => {
         const homePagePrototype = await loadHomePage();
-        const output = homePagePrototype.renderPairRow.call(
-            createRenderPairRowContext(homePagePrototype, {
-                isWalletConnected: () => true,
-                formatTvlDisplay: () => '$1.2K'
-            }),
-            {
+        const output = renderPairRowOutput(homePagePrototype, {
                 id: '1',
                 address: '0x123',
                 name: 'LIB/BNB',
@@ -155,72 +151,13 @@ describe('HomePage.renderPairRow', () => {
         expect(output).toContain('class="staking-cell staking-cell--actions"');
         expect(output).toContain('staking-metric-value">3.50%</span>');
         expect(output).toContain('staking-metric-value">1.2345 LIB</span>');
-        expect(output).toContain('btn-stake');
-        expect(output).toContain('btn-unstake');
         expect(output).toContain('btn-danger btn-unstake');
-        expect(output).toContain('btn-claim');
         expect(output).toContain('btn-success btn-claim');
-        expect(output).toContain('staking-cell-body');
-        expect(output).toContain('staking-cell-value');
-        expect(output).toContain('staking-cell-footer');
         expect(output).toContain('>Stake</button>');
         expect(output).toContain('>Unstake</button>');
         expect(output).toContain('>Claim</button>');
         expect(output).not.toContain('btn-share');
         expect(output).not.toContain('btn-earnings');
-    });
-
-    it('keeps table action buttons clickable when the wallet is disconnected', async () => {
-        const homePagePrototype = await loadHomePage();
-        const output = homePagePrototype.renderPairRow.call(
-            createRenderPairRowContext(homePagePrototype, {
-                isWalletConnected: () => false,
-                formatTvlDisplay: () => '$1.2K'
-            }),
-            {
-                id: '1',
-                address: '0x123',
-                name: 'LIB/BNB',
-                platform: 'PancakeSwap'
-            }
-        );
-
-        expect(output).toContain('btn-stake');
-        expect(output).toContain('btn-unstake');
-        expect(output).toContain('btn-danger btn-unstake');
-        expect(output).toContain('btn-claim');
-        expect(output).toContain('btn-success btn-claim');
-        expect(output).toContain('staking-cell-body');
-        expect(output).toContain('staking-cell-value');
-        expect(output).toContain('staking-cell-footer');
-        expect(output).not.toContain('disabled');
-    });
-
-    it('keeps table action buttons clickable when connected on the wrong network', async () => {
-        const homePagePrototype = await loadHomePage();
-        globalThis.networkManager.isOnRequiredNetwork.mockReturnValue(false);
-
-        const output = homePagePrototype.renderPairRow.call(
-            createRenderPairRowContext(homePagePrototype, {
-                isWalletConnected: () => true,
-                formatTvlDisplay: () => '$1.2K'
-            }),
-            {
-                id: '1',
-                address: '0x123',
-                name: 'LIB/BNB',
-                platform: 'PancakeSwap'
-            }
-        );
-
-        expect(output).toContain('btn-stake');
-        expect(output).toContain('btn-unstake');
-        expect(output).toContain('btn-danger btn-unstake');
-        expect(output).toContain('btn-claim');
-        expect(output).toContain('btn-success btn-claim');
-        expect(output).toContain('staking-cell-body');
-        expect(output).toContain('staking-cell-value');
-        expect(output).toContain('staking-cell-footer');
         expect(output).not.toContain('disabled');
     });
 });
@@ -254,20 +191,9 @@ describe('HomePage table action clicks', () => {
 
     function createActionButtonTarget(action) {
         const button = {
-            classList: {
-                contains(className) {
-                    return className === `btn-${action}`;
-                }
-            },
-            dataset: {
-                pairId: '1',
-                action
-            },
+            dataset: { pairId: '1', action },
             closest(selector) {
-                if (selector === '.pair-row') return { dataset: { pairId: '1' } };
-                if (selector === 'button') return button;
                 if (selector === '.btn-stake, .btn-unstake, .btn-claim') return button;
-                if (selector === `.btn-${action}`) return button;
                 return null;
             }
         };
@@ -325,31 +251,22 @@ describe('HomePage table action clicks', () => {
         }
     );
 
-    it.each([
-        ['stake', 'stake'],
-        ['unstake', 'unstake'],
-        ['claim', 'claim']
-    ])(
-        'opens the modal on the %s tab when the %s button is clicked',
-        async (action, expectedTab) => {
-            const homePagePrototype = await loadHomePage();
-            const openStakingModal = vi.fn();
-            const event = {
-                target: createActionButtonTarget(action),
-                stopPropagation: vi.fn()
-            };
+    it.each(['stake', 'unstake', 'claim'])('opens the modal on the %s tab', async (action) => {
+        const homePagePrototype = await loadHomePage();
+        const openStakingModal = vi.fn();
 
-            homePagePrototype.attachEventListeners.call({
-                isWalletConnected: () => true,
-                showWalletRequiredToast: homePagePrototype.showWalletRequiredToast,
-                openStakingModal
-            });
-            clickHandler(event);
+        homePagePrototype.attachEventListeners.call({
+            isWalletConnected: () => true,
+            showWalletRequiredToast: homePagePrototype.showWalletRequiredToast,
+            openStakingModal
+        });
+        clickHandler({
+            target: createActionButtonTarget(action),
+            stopPropagation: vi.fn()
+        });
 
-            expect(event.stopPropagation).toHaveBeenCalled();
-            expect(openStakingModal).toHaveBeenCalledWith('1', expectedTab);
-        }
-    );
+        expect(openStakingModal).toHaveBeenCalledWith('1', action);
+    });
 
     it('opens the modal for connected row clicks even when the wallet is on another network', async () => {
         const homePagePrototype = await loadHomePage();

--- a/tests/home-page.test.js
+++ b/tests/home-page.test.js
@@ -157,7 +157,12 @@ describe('HomePage.renderPairRow', () => {
         expect(output).toContain('staking-metric-value">1.2345 LIB</span>');
         expect(output).toContain('btn-stake');
         expect(output).toContain('btn-unstake');
+        expect(output).toContain('btn-danger btn-unstake');
         expect(output).toContain('btn-claim');
+        expect(output).toContain('btn-success btn-claim');
+        expect(output).toContain('staking-cell-body');
+        expect(output).toContain('staking-cell-value');
+        expect(output).toContain('staking-cell-footer');
         expect(output).toContain('>Stake</button>');
         expect(output).toContain('>Unstake</button>');
         expect(output).toContain('>Claim</button>');
@@ -182,7 +187,12 @@ describe('HomePage.renderPairRow', () => {
 
         expect(output).toContain('btn-stake');
         expect(output).toContain('btn-unstake');
+        expect(output).toContain('btn-danger btn-unstake');
         expect(output).toContain('btn-claim');
+        expect(output).toContain('btn-success btn-claim');
+        expect(output).toContain('staking-cell-body');
+        expect(output).toContain('staking-cell-value');
+        expect(output).toContain('staking-cell-footer');
         expect(output).not.toContain('disabled');
     });
 
@@ -205,7 +215,12 @@ describe('HomePage.renderPairRow', () => {
 
         expect(output).toContain('btn-stake');
         expect(output).toContain('btn-unstake');
+        expect(output).toContain('btn-danger btn-unstake');
         expect(output).toContain('btn-claim');
+        expect(output).toContain('btn-success btn-claim');
+        expect(output).toContain('staking-cell-body');
+        expect(output).toContain('staking-cell-value');
+        expect(output).toContain('staking-cell-footer');
         expect(output).not.toContain('disabled');
     });
 });

--- a/tests/home-page.test.js
+++ b/tests/home-page.test.js
@@ -116,13 +116,19 @@ describe('HomePage.renderPairRow', () => {
         delete globalThis.window;
     });
 
+    function createRenderPairRowContext(homePagePrototype, overrides = {}) {
+        const context = Object.create(homePagePrototype);
+        Object.assign(context, overrides);
+        return context;
+    }
+
     it('adds mobile card labels and cell classes to each staking row cell', async () => {
         const homePagePrototype = await loadHomePage();
         const output = homePagePrototype.renderPairRow.call(
-            {
+            createRenderPairRowContext(homePagePrototype, {
                 isWalletConnected: () => true,
                 formatTvlDisplay: () => '$1.2K'
-            },
+            }),
             {
                 id: '1',
                 address: '0x123',
@@ -145,15 +151,27 @@ describe('HomePage.renderPairRow', () => {
         ].forEach(([cell, label]) => {
             expect(output).toContain(`class="staking-cell staking-cell--${cell}" data-label="${label}"`);
         });
+
+        expect(output).toContain('class="staking-cell staking-cell--actions"');
+        expect(output).toContain('staking-metric-value">3.50%</span>');
+        expect(output).toContain('staking-metric-value">1.2345 LIB</span>');
+        expect(output).toContain('btn-stake');
+        expect(output).toContain('btn-unstake');
+        expect(output).toContain('btn-claim');
+        expect(output).toContain('>Stake</button>');
+        expect(output).toContain('>Unstake</button>');
+        expect(output).toContain('>Claim</button>');
+        expect(output).not.toContain('btn-share');
+        expect(output).not.toContain('btn-earnings');
     });
 
     it('keeps table action buttons clickable when the wallet is disconnected', async () => {
         const homePagePrototype = await loadHomePage();
         const output = homePagePrototype.renderPairRow.call(
-            {
+            createRenderPairRowContext(homePagePrototype, {
                 isWalletConnected: () => false,
                 formatTvlDisplay: () => '$1.2K'
-            },
+            }),
             {
                 id: '1',
                 address: '0x123',
@@ -162,8 +180,9 @@ describe('HomePage.renderPairRow', () => {
             }
         );
 
-        expect(output).toContain('btn-share');
-        expect(output).toContain('btn-earnings');
+        expect(output).toContain('btn-stake');
+        expect(output).toContain('btn-unstake');
+        expect(output).toContain('btn-claim');
         expect(output).not.toContain('disabled');
     });
 
@@ -172,10 +191,10 @@ describe('HomePage.renderPairRow', () => {
         globalThis.networkManager.isOnRequiredNetwork.mockReturnValue(false);
 
         const output = homePagePrototype.renderPairRow.call(
-            {
+            createRenderPairRowContext(homePagePrototype, {
                 isWalletConnected: () => true,
                 formatTvlDisplay: () => '$1.2K'
-            },
+            }),
             {
                 id: '1',
                 address: '0x123',
@@ -184,8 +203,9 @@ describe('HomePage.renderPairRow', () => {
             }
         );
 
-        expect(output).toContain('btn-share');
-        expect(output).toContain('btn-earnings');
+        expect(output).toContain('btn-stake');
+        expect(output).toContain('btn-unstake');
+        expect(output).toContain('btn-claim');
         expect(output).not.toContain('disabled');
     });
 });
@@ -217,17 +237,22 @@ describe('HomePage table action clicks', () => {
         clickHandler = undefined;
     });
 
-    function createActionButtonTarget(actionClass) {
+    function createActionButtonTarget(action) {
         const button = {
+            classList: {
+                contains(className) {
+                    return className === `btn-${action}`;
+                }
+            },
             dataset: {
                 pairId: '1',
-                tab: actionClass === 'btn-share' ? '0' : '2'
+                action
             },
             closest(selector) {
                 if (selector === '.pair-row') return { dataset: { pairId: '1' } };
                 if (selector === 'button') return button;
-                if (selector === '.btn-share') return actionClass === 'btn-share' ? button : null;
-                if (selector === '.btn-earnings') return actionClass === 'btn-earnings' ? button : null;
+                if (selector === '.btn-stake, .btn-unstake, .btn-claim') return button;
+                if (selector === `.btn-${action}`) return button;
                 return null;
             }
         };
@@ -262,13 +287,13 @@ describe('HomePage table action clicks', () => {
         expect(openStakingModal).not.toHaveBeenCalled();
     });
 
-    it.each(['btn-share', 'btn-earnings'])(
+    it.each(['stake', 'unstake', 'claim'])(
         'shows the wallet-required warning toast for disconnected %s clicks',
-        async (actionClass) => {
+        async (action) => {
             const homePagePrototype = await loadHomePage();
             const openStakingModal = vi.fn();
             const event = {
-                target: createActionButtonTarget(actionClass),
+                target: createActionButtonTarget(action),
                 stopPropagation: vi.fn()
             };
 
@@ -282,6 +307,32 @@ describe('HomePage table action clicks', () => {
             expect(event.stopPropagation).toHaveBeenCalled();
             expect(globalThis.notificationManager.warning).toHaveBeenCalledWith('Please connect your wallet to stake token.');
             expect(openStakingModal).not.toHaveBeenCalled();
+        }
+    );
+
+    it.each([
+        ['stake', 'stake'],
+        ['unstake', 'unstake'],
+        ['claim', 'claim']
+    ])(
+        'opens the modal on the %s tab when the %s button is clicked',
+        async (action, expectedTab) => {
+            const homePagePrototype = await loadHomePage();
+            const openStakingModal = vi.fn();
+            const event = {
+                target: createActionButtonTarget(action),
+                stopPropagation: vi.fn()
+            };
+
+            homePagePrototype.attachEventListeners.call({
+                isWalletConnected: () => true,
+                showWalletRequiredToast: homePagePrototype.showWalletRequiredToast,
+                openStakingModal
+            });
+            clickHandler(event);
+
+            expect(event.stopPropagation).toHaveBeenCalled();
+            expect(openStakingModal).toHaveBeenCalledWith('1', expectedTab);
         }
     );
 


### PR DESCRIPTION
## What Changed

This PR implements Option B from the staking table UX proposal: metrics as plain text with explicit action buttons underneath.

- `renderPairRow()` shows share % and reward amount as `staking-metric-value` text, with Stake/Unstake under My Share and Claim under My Reward on desktop.
- A mobile-only `staking-cell--actions` row groups all three buttons full width below the metrics row.
- `renderPairActionButton()` centralizes button markup; row click still opens the modal on the Stake tab for Create LP / Remove LP entry paths.
- Click handlers route `.btn-stake`, `.btn-unstake`, and `.btn-claim` to `openStakingModal(pairId, action)` with `stopPropagation()` and the existing wallet gate.

## Fixed Flow

1. User sees plain-text **My Share** and **My Reward** values in each row.
2. **Stake**, **Unstake**, or **Claim** opens the staking modal on the matching tab for that pair.
3. Row click (outside links/buttons) still opens the modal on **Stake** when the wallet is connected.
<img width="1317" height="262" alt="image" src="https://github.com/user-attachments/assets/9e0e3f32-ba2f-44cf-ac77-3eadba11f298" />
<img width="465" height="979" alt="image" src="https://github.com/user-attachments/assets/dc1d02d7-6a1e-40a0-8ed3-6a05a27708d3" />

## Why

Share and reward columns previously looked like buttons while displaying metrics, and Unstake had no direct shortcut from the table. Separating read (values) from act (buttons) matches Create LP guidance patterns and reduces tab hunting.

## Validation

- `npm test` (178 tests passed)

Closes #274