### PR TITLE
Dynamic staking modal title per tab (#281)

### DIFF
--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -4,6 +4,14 @@
  */
 
 class StakingModalNew {
+    static TAB_TITLES = {
+        zap: 'Create LP',
+        stake: 'Stake',
+        unstake: 'Unstake',
+        claim: 'Claim',
+        'remove-liquidity': 'Remove LP'
+    };
+
     constructor() {
         this.isOpen = false;
         this.currentPair = null;
@@ -248,7 +256,7 @@ class StakingModalNew {
                 <div class="modal-content">
                     <div class="modal-header">
                         <div class="modal-title-section">
-                            <h2 class="modal-title">Staking</h2>
+                            <h2 class="modal-title" id="modal-title">Stake</h2>
                             <div class="pair-info" id="modal-pair-info">
                                 <!-- Pair info will be populated -->
                             </div>
@@ -3125,6 +3133,24 @@ class StakingModalNew {
         `;
     }
 
+    getTabTitle(tab) {
+        const title = StakingModalNew.TAB_TITLES[tab];
+        if (!title) {
+            throw new Error(`Unknown staking modal tab: ${tab}`);
+        }
+
+        return title;
+    }
+
+    updateModalTitle(tab) {
+        const titleElement = document.getElementById('modal-title');
+        if (!titleElement) {
+            return;
+        }
+
+        titleElement.textContent = this.getTabTitle(tab);
+    }
+
     switchTab(tab) {
         this.currentTab = tab;
         this.syncZapQuoteAutoRefresh();
@@ -3134,6 +3160,8 @@ class StakingModalNew {
         document.querySelectorAll('.tab-button').forEach(btn => {
             btn.classList.toggle('active', btn.dataset.tab === tab);
         });
+
+        this.updateModalTitle(tab);
 
         // Render tab content
         this.renderTabContent();

--- a/js/components/staking-modal-new.js
+++ b/js/components/staking-modal-new.js
@@ -3133,37 +3133,26 @@ class StakingModalNew {
         `;
     }
 
-    getTabTitle(tab) {
+    switchTab(tab) {
         const title = StakingModalNew.TAB_TITLES[tab];
         if (!title) {
             throw new Error(`Unknown staking modal tab: ${tab}`);
         }
 
-        return title;
-    }
-
-    updateModalTitle(tab) {
-        const titleElement = document.getElementById('modal-title');
-        if (!titleElement) {
-            return;
-        }
-
-        titleElement.textContent = this.getTabTitle(tab);
-    }
-
-    switchTab(tab) {
         this.currentTab = tab;
         this.syncZapQuoteAutoRefresh();
         this.syncRemoveLiquidityPreviewAutoRefresh();
 
-        // Update tab buttons
         document.querySelectorAll('.tab-button').forEach(btn => {
             btn.classList.toggle('active', btn.dataset.tab === tab);
         });
 
-        this.updateModalTitle(tab);
+        const titleElement = document.getElementById('modal-title');
+        if (!titleElement) {
+            throw new Error('modal-title element is missing');
+        }
+        titleElement.textContent = title;
 
-        // Render tab content
         this.renderTabContent();
     }
 

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -2160,3 +2160,46 @@ describe('StakingModalNew zap cleanup', () => {
         }));
     });
 });
+
+describe('StakingModalNew modal title', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete globalThis.StakingModalNew;
+    });
+
+    it('maps each tab id to the matching title', async () => {
+        const StakingModalNew = await loadStakingModalClass();
+        const modal = new StakingModalNew();
+
+        expect(modal.getTabTitle('zap')).toBe('Create LP');
+        expect(modal.getTabTitle('stake')).toBe('Stake');
+        expect(modal.getTabTitle('unstake')).toBe('Unstake');
+        expect(modal.getTabTitle('claim')).toBe('Claim');
+        expect(modal.getTabTitle('remove-liquidity')).toBe('Remove LP');
+        expect(() => modal.getTabTitle('invalid-tab')).toThrow('Unknown staking modal tab: invalid-tab');
+    });
+
+    it('updates the header title when switching tabs', async () => {
+        const StakingModalNew = await loadStakingModalClass();
+        const titleElement = document.registerElement(createElement({ id: 'modal-title' }));
+        const modal = new StakingModalNew();
+        modal.renderTabContent = vi.fn();
+        modal.syncZapQuoteAutoRefresh = vi.fn();
+        modal.syncRemoveLiquidityPreviewAutoRefresh = vi.fn();
+
+        modal.switchTab('claim');
+        expect(titleElement.textContent).toBe('Claim');
+
+        modal.switchTab('remove-liquidity');
+        expect(titleElement.textContent).toBe('Remove LP');
+    });
+
+    it('renders the modal title element for updates', async () => {
+        const StakingModalNew = await loadStakingModalClass();
+        const modalContainer = document.registerElement(createElement({ id: 'modal-container' }));
+
+        new StakingModalNew();
+
+        expect(modalContainer.innerHTML).toContain('<h2 class="modal-title" id="modal-title">Stake</h2>');
+    });
+});

--- a/tests/staking-modal-new.test.js
+++ b/tests/staking-modal-new.test.js
@@ -376,6 +376,7 @@ describe('StakingModalNew zap cleanup', () => {
         expect(modalContainer.innerHTML).toContain('<span class="tab-label">Create LP</span>');
         expect(modalContainer.innerHTML).toContain('<span class="tab-label">Unstake</span>');
         expect(modalContainer.innerHTML).toContain('<span class="tab-label">Remove LP</span>');
+        expect(modalContainer.innerHTML).toContain('<h2 class="modal-title" id="modal-title">Stake</h2>');
     });
 
     it('derives LP USD estimates from pair TVL data', async () => {
@@ -2162,24 +2163,7 @@ describe('StakingModalNew zap cleanup', () => {
 });
 
 describe('StakingModalNew modal title', () => {
-    afterEach(() => {
-        vi.restoreAllMocks();
-        delete globalThis.StakingModalNew;
-    });
-
-    it('maps each tab id to the matching title', async () => {
-        const StakingModalNew = await loadStakingModalClass();
-        const modal = new StakingModalNew();
-
-        expect(modal.getTabTitle('zap')).toBe('Create LP');
-        expect(modal.getTabTitle('stake')).toBe('Stake');
-        expect(modal.getTabTitle('unstake')).toBe('Unstake');
-        expect(modal.getTabTitle('claim')).toBe('Claim');
-        expect(modal.getTabTitle('remove-liquidity')).toBe('Remove LP');
-        expect(() => modal.getTabTitle('invalid-tab')).toThrow('Unknown staking modal tab: invalid-tab');
-    });
-
-    it('updates the header title when switching tabs', async () => {
+    it('syncs the header title to the active tab', async () => {
         const StakingModalNew = await loadStakingModalClass();
         const titleElement = document.registerElement(createElement({ id: 'modal-title' }));
         const modal = new StakingModalNew();
@@ -2190,16 +2174,9 @@ describe('StakingModalNew modal title', () => {
         modal.switchTab('claim');
         expect(titleElement.textContent).toBe('Claim');
 
-        modal.switchTab('remove-liquidity');
-        expect(titleElement.textContent).toBe('Remove LP');
-    });
+        modal.switchTab('zap');
+        expect(titleElement.textContent).toBe('Create LP');
 
-    it('renders the modal title element for updates', async () => {
-        const StakingModalNew = await loadStakingModalClass();
-        const modalContainer = document.registerElement(createElement({ id: 'modal-container' }));
-
-        new StakingModalNew();
-
-        expect(modalContainer.innerHTML).toContain('<h2 class="modal-title" id="modal-title">Stake</h2>');
+        expect(() => modal.switchTab('invalid-tab')).toThrow('Unknown staking modal tab: invalid-tab');
     });
 });


### PR DESCRIPTION
## What Changed

The staking modal header title now reflects the active tab instead of always showing "Staking".

- Adds a single tab-id → title mapping for: Create LP, Stake, Unstake, Claim, Remove LP.
- `switchTab(tab)` updates `#modal-title` whenever tabs change.
- Unknown tab ids fail loudly.
<img width="807" height="233" alt="image" src="https://github.com/user-attachments/assets/be1d3777-92da-467f-b1cd-f130eb3930dc" />
<img width="807" height="233" alt="image" src="https://github.com/user-attachments/assets/f9721c5d-f9a4-4c6e-9220-b2f28ff10ec8" />

## Why

With multiple tabs (and table shortcuts opening the modal on specific tabs), a static title is misleading. Matching the title to the active tab improves clarity and orientation.

## Validation

- `npm test`

Closes #281