### PR TITLE
Validate V2-compatible LP tokens (issue #271 PR 1)

### DIFF
--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -1104,6 +1104,85 @@ class ContractManager {
     }
 
     /**
+     * Validate that an address is a deployed V2-compatible LP token contract.
+     * @returns {Promise<{ valid: true, address: string, token0: string, token1: string, reserve0: ethers.BigNumber, reserve1: ethers.BigNumber } | { valid: false, error: string }>}
+     */
+    async validateV2CompatibleLpToken(address) {
+        if (!address || typeof address !== 'string' || !address.trim()) {
+            return { valid: false, error: 'LP token address is required' };
+        }
+
+        let lpTokenAddress;
+        try {
+            lpTokenAddress = ethers.utils.getAddress(address.trim());
+        } catch (error) {
+            return { valid: false, error: 'Invalid Ethereum address format' };
+        }
+
+        const provider = this.provider || this.signer?.provider;
+        if (!provider) {
+            return { valid: false, error: 'Network provider is not available' };
+        }
+
+        let contractCode;
+        try {
+            contractCode = await provider.getCode(lpTokenAddress);
+        } catch (error) {
+            return {
+                valid: false,
+                error: 'Unable to verify contract code. Check your network connection and try again.'
+            };
+        }
+
+        if (contractCode === '0x') {
+            return { valid: false, error: 'No contract code found at this address' };
+        }
+
+        const pairContract = new ethers.Contract(lpTokenAddress, [
+            'function token0() view returns (address)',
+            'function token1() view returns (address)',
+            'function getReserves() view returns (uint112,uint112,uint32)'
+        ], provider);
+
+        let token0;
+        let token1;
+        let reserve0;
+        let reserve1;
+        try {
+            const [token0Address, token1Address, reserves] = await Promise.all([
+                pairContract.token0(),
+                pairContract.token1(),
+                pairContract.getReserves()
+            ]);
+
+            if (!ethers.utils.isAddress(token0Address) || !ethers.utils.isAddress(token1Address)) {
+                throw new Error('invalid pair tokens');
+            }
+
+            token0 = ethers.utils.getAddress(token0Address);
+            token1 = ethers.utils.getAddress(token1Address);
+            const zeroAddress = ethers.constants.AddressZero;
+            if (token0 === zeroAddress || token1 === zeroAddress || token0.toLowerCase() === token1.toLowerCase()) {
+                throw new Error('invalid pair tokens');
+            }
+
+            if (!Array.isArray(reserves) || reserves.length < 2) {
+                throw new Error('invalid reserves');
+            }
+
+            reserve0 = ethers.BigNumber.from(reserves[0]);
+            reserve1 = ethers.BigNumber.from(reserves[1]);
+        } catch (error) {
+            return {
+                valid: false,
+                error: 'This address does not appear to be a V2-compatible LP token contract'
+            };
+        }
+
+        return { valid: true, address: lpTokenAddress, token0, token1, reserve0, reserve1 };
+    }
+
+    /**
     * Normalize LP pair names so keys remain consistent regardless of contract formatting
     * @param {string} rawName - Original pair name from the contract
     * @returns {string|null} Normalized pair identifier with an LP prefix, or null when input cannot be normalized

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -1144,32 +1144,55 @@ class ContractManager {
             'function getReserves() view returns (uint112,uint112,uint32)'
         ], provider);
 
-        let token0;
-        let token1;
-        let reserve0;
-        let reserve1;
+        let token0Address;
+        let token1Address;
+        let reserves;
         try {
-            const [token0Address, token1Address, reserves] = await Promise.all([
+            [token0Address, token1Address, reserves] = await Promise.all([
                 pairContract.token0(),
                 pairContract.token1(),
                 pairContract.getReserves()
             ]);
-
-            if (!ethers.utils.isAddress(token0Address) || !ethers.utils.isAddress(token1Address)) {
-                throw new Error('invalid pair tokens');
+        } catch (error) {
+            if (error?.code === 'NETWORK_ERROR' || error?.code === 'TIMEOUT' || error?.code === 'SERVER_ERROR') {
+                return {
+                    valid: false,
+                    error: 'Unable to verify LP token contract. Check your network connection and try again.'
+                };
             }
+            return {
+                valid: false,
+                error: 'This address does not appear to be a V2-compatible LP token contract'
+            };
+        }
 
-            token0 = ethers.utils.getAddress(token0Address);
-            token1 = ethers.utils.getAddress(token1Address);
-            const zeroAddress = ethers.constants.AddressZero;
-            if (token0 === zeroAddress || token1 === zeroAddress || token0.toLowerCase() === token1.toLowerCase()) {
-                throw new Error('invalid pair tokens');
-            }
+        if (!ethers.utils.isAddress(token0Address) || !ethers.utils.isAddress(token1Address)) {
+            return {
+                valid: false,
+                error: 'This address does not appear to be a V2-compatible LP token contract'
+            };
+        }
 
-            if (!Array.isArray(reserves) || reserves.length < 2) {
-                throw new Error('invalid reserves');
-            }
+        const token0 = ethers.utils.getAddress(token0Address);
+        const token1 = ethers.utils.getAddress(token1Address);
+        const zeroAddress = ethers.constants.AddressZero;
+        if (token0 === zeroAddress || token1 === zeroAddress || token0.toLowerCase() === token1.toLowerCase()) {
+            return {
+                valid: false,
+                error: 'This address does not appear to be a V2-compatible LP token contract'
+            };
+        }
 
+        if (!Array.isArray(reserves) || reserves.length < 2) {
+            return {
+                valid: false,
+                error: 'This address does not appear to be a V2-compatible LP token contract'
+            };
+        }
+
+        let reserve0;
+        let reserve1;
+        try {
             reserve0 = ethers.BigNumber.from(reserves[0]);
             reserve1 = ethers.BigNumber.from(reserves[1]);
         } catch (error) {

--- a/tests/v2-lp-token-validation.test.js
+++ b/tests/v2-lp-token-validation.test.js
@@ -137,5 +137,18 @@ describe('ContractManager.validateV2CompatibleLpToken', () => {
             valid: false,
             error: 'Unable to verify contract code. Check your network connection and try again.'
         });
+
+        const pairReadFailure = await loadContractManager(
+            { getCode: vi.fn().mockResolvedValue('0x6000') },
+            {
+                token0: vi.fn().mockRejectedValue(Object.assign(new Error('timeout'), { code: 'TIMEOUT' })),
+                token1: vi.fn(),
+                getReserves: vi.fn()
+            }
+        );
+        await expect(pairReadFailure.validateV2CompatibleLpToken(LP)).resolves.toEqual({
+            valid: false,
+            error: 'Unable to verify LP token contract. Check your network connection and try again.'
+        });
     });
 });

--- a/tests/v2-lp-token-validation.test.js
+++ b/tests/v2-lp-token-validation.test.js
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const scriptSrc = 'https://example.test/repo/js/contracts/contract-manager.js';
+const LP = '0x1111111111111111111111111111111111111111';
+const TOKEN0 = '0x2222222222222222222222222222222222222222';
+const TOKEN1 = '0x3333333333333333333333333333333333333333';
+
+async function loadContractManager(provider, pairContract) {
+    vi.resetModules();
+    globalThis.window = globalThis;
+    globalThis.location = { pathname: '/' };
+    globalThis.document = { currentScript: { src: scriptSrc } };
+    delete globalThis.ContractManager;
+    globalThis.ethers = {
+        constants: { AddressZero: '0x0000000000000000000000000000000000000000' },
+        utils: {
+            isAddress(value) {
+                return typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value);
+            },
+            getAddress(value) {
+                if (!globalThis.ethers.utils.isAddress(value)) {
+                    throw new Error('invalid address');
+                }
+                return value;
+            }
+        },
+        BigNumber: {
+            from(value) {
+                return { toString: () => String(value) };
+            }
+        },
+        Contract: vi.fn(function Contract() {
+            return pairContract;
+        })
+    };
+
+    await import('../js/contracts/contract-manager.js');
+    const manager = new globalThis.ContractManager();
+    manager.provider = provider;
+    return manager;
+}
+
+function validPairContract(token0 = TOKEN0, token1 = TOKEN1, reserve0 = '0', reserve1 = '0') {
+    return {
+        token0: vi.fn().mockResolvedValue(token0),
+        token1: vi.fn().mockResolvedValue(token1),
+        getReserves: vi.fn().mockResolvedValue([reserve0, reserve1, 0])
+    };
+}
+
+describe('ContractManager.validateV2CompatibleLpToken', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete globalThis.ContractManager;
+        delete globalThis.document;
+        delete globalThis.ethers;
+        delete globalThis.location;
+        delete globalThis.window;
+    });
+
+    it('rejects bad addresses before RPC calls', async () => {
+        const getCode = vi.fn();
+        const manager = await loadContractManager({ getCode }, validPairContract());
+
+        await expect(manager.validateV2CompatibleLpToken('')).resolves.toEqual({
+            valid: false,
+            error: 'LP token address is required'
+        });
+        await expect(manager.validateV2CompatibleLpToken('bad')).resolves.toEqual({
+            valid: false,
+            error: 'Invalid Ethereum address format'
+        });
+        expect(getCode).not.toHaveBeenCalled();
+    });
+
+    it('rejects EOAs and non-pair contracts', async () => {
+        const manager = await loadContractManager(
+            { getCode: vi.fn().mockResolvedValue('0x') },
+            validPairContract()
+        );
+        await expect(manager.validateV2CompatibleLpToken(LP)).resolves.toEqual({
+            valid: false,
+            error: 'No contract code found at this address'
+        });
+
+        const brokenPair = {
+            token0: vi.fn().mockRejectedValue(new Error('missing')),
+            token1: vi.fn(),
+            getReserves: vi.fn()
+        };
+        const brokenManager = await loadContractManager(
+            { getCode: vi.fn().mockResolvedValue('0x6000') },
+            brokenPair
+        );
+        await expect(brokenManager.validateV2CompatibleLpToken(LP)).resolves.toEqual({
+            valid: false,
+            error: 'This address does not appear to be a V2-compatible LP token contract'
+        });
+    });
+
+    it('accepts V2-compatible pair contracts', async () => {
+        const pairContract = validPairContract();
+        const manager = await loadContractManager(
+            { getCode: vi.fn().mockResolvedValue('0x6000') },
+            pairContract
+        );
+
+        const result = await manager.validateV2CompatibleLpToken(LP);
+
+        expect(result.valid).toBe(true);
+        expect(result.address).toBe(LP);
+        expect(result.token0).toBe(TOKEN0);
+        expect(result.token1).toBe(TOKEN1);
+        expect(result.reserve0.toString()).toBe('0');
+        expect(result.reserve1.toString()).toBe('0');
+    });
+
+    it('rejects invalid underlying tokens and RPC failures', async () => {
+        const invalidTokens = await loadContractManager(
+            { getCode: vi.fn().mockResolvedValue('0x6000') },
+            validPairContract(TOKEN0, TOKEN0)
+        );
+        await expect(invalidTokens.validateV2CompatibleLpToken(LP)).resolves.toEqual({
+            valid: false,
+            error: 'This address does not appear to be a V2-compatible LP token contract'
+        });
+
+        const rpcFailure = await loadContractManager(
+            { getCode: vi.fn().mockRejectedValue(new Error('timeout')) },
+            validPairContract()
+        );
+        await expect(rpcFailure.validateV2CompatibleLpToken(LP)).resolves.toEqual({
+            valid: false,
+            error: 'Unable to verify contract code. Check your network connection and try again.'
+        });
+    });
+});


### PR DESCRIPTION
## What Changed

This PR adds the core on-chain validator for issue #271, without admin UI wiring yet.

- `validateV2CompatibleLpToken` checks address format, deployed contract code, and V2 pair reads (`token0`, `token1`, `getReserves`).
- Returns a discriminated result: `{ valid: true, ... }` or `{ valid: false, error }`.
- Covers Uniswap V2, PancakeSwap V2, SushiSwap, and other V2-compatible forks.
- Unit tests cover malformed addresses, EOAs, non-pair contracts, valid pairs, invalid underlying tokens, and RPC failures.

## Fixed Flow

1. Admin enters an LP token address for a new-pair proposal.
2. App calls `validateV2CompatibleLpToken(address)` (wired in PR 2).
3. Validator confirms the address is a deployed V2-compatible pair contract.
4. Invalid addresses are rejected before proposal submission.

## Why

Add-pair proposals currently accept any valid hex address. This adds a reusable contract-layer check so plain ERC-20s, EOAs, and non-pair contracts can be rejected before a governance transaction is submitted.

## Validation

- `npm test -- tests/v2-lp-token-validation.test.js`

Part of #271 stacked PR plan:
- PR 1 (this): core validator + tests
- PR 2: submit-time gate in admin form
- PR 3: live form validation UX
- PR 4 (optional): factory/platform cross-check

Made with [Cursor](https://cursor.com)