### PR TITLE
Validate LP address before add-pair submit (issue #271 PR 2)

### DIFF
--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -5197,19 +5197,14 @@ class AdminPage {
     async submitAddPairProposal(event = null) {
         if (event) event.preventDefault();
 
-        const pairAddress = document.getElementById('pair-address').value;
+        const pairAddressInput = document.getElementById('pair-address');
+        const pairAddress = pairAddressInput.value.trim();
         const weight = document.getElementById('pair-weight').value;
         const pairName = document.getElementById('pair-name').value;
         const platform = document.getElementById('pair-platform').value;
 
-        // Enhanced validation with detailed feedback
         if (!pairAddress || !weight || !pairName || !platform) {
             this.showError('Please fill in all required fields: LP Address, Weight, Pair Name, and Platform');
-            return;
-        }
-
-        if (!this.isValidAddress(pairAddress)) {
-            this.showError('Invalid LP token address format. Please enter a valid Ethereum address starting with 0x');
             return;
         }
 
@@ -5231,7 +5226,15 @@ class AdminPage {
 
         try {
             const contractManager = await this.ensureContractReady();
-            const result = await contractManager.proposeAddPair(pairAddress, pairName, platform, weightNum);
+            const lpValidation = await contractManager.validateV2CompatibleLpToken(pairAddress);
+            if (!lpValidation.valid) {
+                document.getElementById('pair-address-error').textContent = lpValidation.error;
+                pairAddressInput.classList.add('error');
+                this.showError('Invalid LP token address', lpValidation.error);
+                return;
+            }
+
+            const result = await contractManager.proposeAddPair(lpValidation.address, pairName, platform, weightNum);
 
             if (result.success) {
                 this.closeModal();


### PR DESCRIPTION
## What Changed

This PR wires the PR 1 validator into add-pair proposal submission.

- `submitAddPairProposal` calls `validateV2CompatibleLpToken()` before `proposeAddPair()`.
- Invalid addresses show an inline field error and modal error, with no transaction submitted.
- Valid submissions use the checksummed `lpValidation.address` from the validator.
- Removed the duplicate local hex-format check; the validator handles address format.

## Fixed Flow

1. Admin fills out the add-pair form and clicks **Create Proposal**.
2. Local field checks run for required values, weight, name, and platform.
3. App validates the LP token address on-chain via `validateV2CompatibleLpToken()`.
4. Invalid addresses are blocked with feedback; valid addresses proceed to `proposeAddPair()`.

## Why

PR 1 added the reusable validator. This PR is the submit-time gate so admins cannot create add-pair proposals for EOAs, plain ERC-20s, or non-pair contracts.

## Validation

- `npm test -- tests/v2-lp-token-validation.test.js`

Stacked on #283 (`issue-271/1-v2-lp-validator`). Part of #271.

Made with [Cursor](https://cursor.com)