### PR TITLE
Add live LP address validation in add-pair form (issue #271 PR 3)

### DIFF
--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -34,6 +34,7 @@ class AdminPage {
 
         // UI state: remember proposal filter preference across refreshes
         this.proposalFilter = 'pending';
+        this.addPairLpValidation = { status: 'idle' };
 
         // Shared selectors for address copy functionality
         this.addressCopySelectors = [
@@ -3928,7 +3929,7 @@ class AdminPage {
                                 <label for="pair-address">LP Token Address *</label>
                                 <input type="text" id="pair-address" class="form-input" required
                                        placeholder="0x..." pattern="^0x[a-fA-F0-9]{40}$">
-                                <small class="form-help">Enter the LP token contract address</small>
+                                <small class="form-help" id="pair-address-help">Enter the LP token contract address</small>
                                 <div class="field-error" id="pair-address-error"></div>
                             </div>
 
@@ -4414,6 +4415,11 @@ class AdminPage {
     }
 
     closeModal() {
+        clearTimeout(this.addPairLpCheckTimer);
+        this.addPairLpCheckTimer = null;
+        this.addPairLpValidation = { status: 'idle' };
+        this.addPairLpCheckSeq = 0;
+
         const modalContainer = document.getElementById('modal-container');
         if (modalContainer) {
             modalContainer.style.display = 'none';
@@ -4440,6 +4446,84 @@ class AdminPage {
     }
 
     // Form validation system
+    initializeAddPairFormValidation() {
+        const form = document.getElementById('add-pair-form');
+        this.addPairLpCheckSeq = 0;
+        this.setAddPairLpValidation({ status: 'idle' });
+
+        form.addEventListener('input', (e) => {
+            if (e.target.id === 'pair-address') {
+                this.scheduleAddPairLpValidation(e.target.value.trim());
+                return;
+            }
+            this.validateField(e.target);
+        });
+    }
+
+    scheduleAddPairLpValidation(address) {
+        clearTimeout(this.addPairLpCheckTimer);
+
+        if (!address) {
+            this.setAddPairLpValidation({ status: 'idle' });
+            return;
+        }
+
+        if (!this.isValidAddress(address)) {
+            this.setAddPairLpValidation({ status: 'invalid', error: 'Invalid Ethereum address format' });
+            return;
+        }
+
+        this.setAddPairLpValidation({ status: 'validating' });
+        const seq = ++this.addPairLpCheckSeq;
+        this.addPairLpCheckTimer = setTimeout(async () => {
+            const contractManager = await this.ensureContractReady();
+            const result = await contractManager.validateV2CompatibleLpToken(address);
+            if (seq !== this.addPairLpCheckSeq) {
+                return;
+            }
+            if (!result.valid) {
+                this.setAddPairLpValidation({ status: 'invalid', error: result.error });
+                return;
+            }
+            this.setAddPairLpValidation({ status: 'valid', token0: result.token0, token1: result.token1 });
+        }, 500);
+    }
+
+    setAddPairLpValidation(state) {
+        this.addPairLpValidation = state;
+
+        const input = document.getElementById('pair-address');
+        const help = document.getElementById('pair-address-help');
+        const error = document.getElementById('pair-address-error');
+        const submitButton = document.getElementById('add-pair-btn');
+
+        input.classList.remove('error', 'valid');
+        error.textContent = '';
+        help.textContent = 'Enter the LP token contract address';
+
+        switch (state.status) {
+            case 'idle':
+                submitButton.disabled = true;
+                return;
+            case 'validating':
+                error.textContent = 'Validating LP token...';
+                submitButton.disabled = true;
+                return;
+            case 'invalid':
+                error.textContent = state.error;
+                input.classList.add('error');
+                submitButton.disabled = true;
+                return;
+            case 'valid':
+                help.textContent = `Valid V2 LP pair: ${state.token0.slice(0, 6)}...${state.token0.slice(-4)} / ${state.token1.slice(0, 6)}...${state.token1.slice(-4)}`;
+                input.classList.add('valid');
+                submitButton.disabled = false;
+                return;
+            default:
+                throw new Error(`Unknown add-pair LP validation status: ${state.status}`);
+        }
+    }
+
     initializeFormValidation(formId) {
         const form = document.getElementById(formId);
         if (!form) return;
@@ -5228,8 +5312,7 @@ class AdminPage {
             const contractManager = await this.ensureContractReady();
             const lpValidation = await contractManager.validateV2CompatibleLpToken(pairAddress);
             if (!lpValidation.valid) {
-                document.getElementById('pair-address-error').textContent = lpValidation.error;
-                pairAddressInput.classList.add('error');
+                this.setAddPairLpValidation({ status: 'invalid', error: lpValidation.error });
                 this.showError('Invalid LP token address', lpValidation.error);
                 return;
             }

--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -5197,19 +5197,14 @@ class AdminPage {
     async submitAddPairProposal(event = null) {
         if (event) event.preventDefault();
 
-        const pairAddress = document.getElementById('pair-address').value;
+        const pairAddressInput = document.getElementById('pair-address');
+        const pairAddress = pairAddressInput.value.trim();
         const weight = document.getElementById('pair-weight').value;
         const pairName = document.getElementById('pair-name').value;
         const platform = document.getElementById('pair-platform').value;
 
-        // Enhanced validation with detailed feedback
         if (!pairAddress || !weight || !pairName || !platform) {
             this.showError('Please fill in all required fields: LP Address, Weight, Pair Name, and Platform');
-            return;
-        }
-
-        if (!this.isValidAddress(pairAddress)) {
-            this.showError('Invalid LP token address format. Please enter a valid Ethereum address starting with 0x');
             return;
         }
 
@@ -5231,7 +5226,15 @@ class AdminPage {
 
         try {
             const contractManager = await this.ensureContractReady();
-            const result = await contractManager.proposeAddPair(pairAddress, pairName, platform, weightNum);
+            const lpValidation = await contractManager.validateV2CompatibleLpToken(pairAddress);
+            if (!lpValidation.valid) {
+                document.getElementById('pair-address-error').textContent = lpValidation.error;
+                pairAddressInput.classList.add('error');
+                this.showError('Invalid LP token address', lpValidation.error);
+                return;
+            }
+
+            const result = await contractManager.proposeAddPair(lpValidation.address, pairName, platform, weightNum);
 
             if (result.success) {
                 this.closeModal();

--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -4479,16 +4479,34 @@ class AdminPage {
         this.setAddPairLpValidation({ status: 'validating' });
         const seq = ++this.addPairLpCheckSeq;
         this.addPairLpCheckTimer = setTimeout(async () => {
-            const contractManager = await this.ensureContractReady();
-            const result = await contractManager.validateV2CompatibleLpToken(address);
-            if (seq !== this.addPairLpCheckSeq) {
-                return;
+            const isCurrentRequest = () => {
+                if (seq !== this.addPairLpCheckSeq) {
+                    return false;
+                }
+                const pairAddressInput = document.getElementById('pair-address');
+                return pairAddressInput && pairAddressInput.value.trim() === address;
+            };
+
+            try {
+                const contractManager = await this.ensureContractReady();
+                const result = await contractManager.validateV2CompatibleLpToken(address);
+                if (!isCurrentRequest()) {
+                    return;
+                }
+                if (!result.valid) {
+                    this.setAddPairLpValidation({ status: 'invalid', error: result.error });
+                    return;
+                }
+                this.setAddPairLpValidation({ status: 'valid', token0: result.token0, token1: result.token1 });
+            } catch (error) {
+                if (!isCurrentRequest()) {
+                    return;
+                }
+                this.setAddPairLpValidation({
+                    status: 'invalid',
+                    error: 'Unable to verify LP token address. Check your network connection and try again.'
+                });
             }
-            if (!result.valid) {
-                this.setAddPairLpValidation({ status: 'invalid', error: result.error });
-                return;
-            }
-            this.setAddPairLpValidation({ status: 'valid', token0: result.token0, token1: result.token1 });
         }, 500);
     }
 

--- a/js/components/admin-page.js
+++ b/js/components/admin-page.js
@@ -779,6 +779,9 @@ class AdminPage {
                                 await this.submitHourlyRateProposal(e);
                                 break;
                             case 'add-pair-form':
+                                if (this.addPairLpValidation.status !== 'valid') {
+                                    return;
+                                }
                                 await this.submitAddPairProposal(e);
                                 break;
                             case 'remove-pair-form':
@@ -3978,7 +3981,7 @@ class AdminPage {
                         <button type="button" class="btn btn-secondary modal-cancel">
                             Cancel
                         </button>
-                        <button type="submit" form="add-pair-form" class="btn btn-primary" id="add-pair-btn">
+                        <button type="submit" form="add-pair-form" class="btn btn-primary" id="add-pair-btn" disabled>
                             <span class="btn-text">Create Proposal</span>
                             <span class="btn-loading" style="display: none;">
                                 <span class="spinner"></span> Creating...
@@ -3999,7 +4002,7 @@ class AdminPage {
             try {
                 // Set flag to prevent immediate validation
                 this.modalJustOpened = true;
-                this.initializeFormValidation('add-pair-form');
+                this.initializeAddPairFormValidation();
 
                 // Clear flag after a short delay
                 setTimeout(() => {
@@ -4558,12 +4561,6 @@ class AdminPage {
 
         // Specific field validations
         switch (fieldId) {
-            case 'pair-address':
-                if (value && !this.isValidAddress(value)) {
-                    isValid = false;
-                    errorMessage = 'Invalid Ethereum address format';
-                }
-                break;
             case 'pair-name':
                 if (value && (value.length < 2 || value.length > 50)) {
                     isValid = false;

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -1104,6 +1104,85 @@ class ContractManager {
     }
 
     /**
+     * Validate that an address is a deployed V2-compatible LP token contract.
+     * @returns {Promise<{ valid: true, address: string, token0: string, token1: string, reserve0: ethers.BigNumber, reserve1: ethers.BigNumber } | { valid: false, error: string }>}
+     */
+    async validateV2CompatibleLpToken(address) {
+        if (!address || typeof address !== 'string' || !address.trim()) {
+            return { valid: false, error: 'LP token address is required' };
+        }
+
+        let lpTokenAddress;
+        try {
+            lpTokenAddress = ethers.utils.getAddress(address.trim());
+        } catch (error) {
+            return { valid: false, error: 'Invalid Ethereum address format' };
+        }
+
+        const provider = this.provider || this.signer?.provider;
+        if (!provider) {
+            return { valid: false, error: 'Network provider is not available' };
+        }
+
+        let contractCode;
+        try {
+            contractCode = await provider.getCode(lpTokenAddress);
+        } catch (error) {
+            return {
+                valid: false,
+                error: 'Unable to verify contract code. Check your network connection and try again.'
+            };
+        }
+
+        if (contractCode === '0x') {
+            return { valid: false, error: 'No contract code found at this address' };
+        }
+
+        const pairContract = new ethers.Contract(lpTokenAddress, [
+            'function token0() view returns (address)',
+            'function token1() view returns (address)',
+            'function getReserves() view returns (uint112,uint112,uint32)'
+        ], provider);
+
+        let token0;
+        let token1;
+        let reserve0;
+        let reserve1;
+        try {
+            const [token0Address, token1Address, reserves] = await Promise.all([
+                pairContract.token0(),
+                pairContract.token1(),
+                pairContract.getReserves()
+            ]);
+
+            if (!ethers.utils.isAddress(token0Address) || !ethers.utils.isAddress(token1Address)) {
+                throw new Error('invalid pair tokens');
+            }
+
+            token0 = ethers.utils.getAddress(token0Address);
+            token1 = ethers.utils.getAddress(token1Address);
+            const zeroAddress = ethers.constants.AddressZero;
+            if (token0 === zeroAddress || token1 === zeroAddress || token0.toLowerCase() === token1.toLowerCase()) {
+                throw new Error('invalid pair tokens');
+            }
+
+            if (!Array.isArray(reserves) || reserves.length < 2) {
+                throw new Error('invalid reserves');
+            }
+
+            reserve0 = ethers.BigNumber.from(reserves[0]);
+            reserve1 = ethers.BigNumber.from(reserves[1]);
+        } catch (error) {
+            return {
+                valid: false,
+                error: 'This address does not appear to be a V2-compatible LP token contract'
+            };
+        }
+
+        return { valid: true, address: lpTokenAddress, token0, token1, reserve0, reserve1 };
+    }
+
+    /**
     * Normalize LP pair names so keys remain consistent regardless of contract formatting
     * @param {string} rawName - Original pair name from the contract
     * @returns {string|null} Normalized pair identifier with an LP prefix, or null when input cannot be normalized

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -1144,32 +1144,55 @@ class ContractManager {
             'function getReserves() view returns (uint112,uint112,uint32)'
         ], provider);
 
-        let token0;
-        let token1;
-        let reserve0;
-        let reserve1;
+        let token0Address;
+        let token1Address;
+        let reserves;
         try {
-            const [token0Address, token1Address, reserves] = await Promise.all([
+            [token0Address, token1Address, reserves] = await Promise.all([
                 pairContract.token0(),
                 pairContract.token1(),
                 pairContract.getReserves()
             ]);
-
-            if (!ethers.utils.isAddress(token0Address) || !ethers.utils.isAddress(token1Address)) {
-                throw new Error('invalid pair tokens');
+        } catch (error) {
+            if (error?.code === 'NETWORK_ERROR' || error?.code === 'TIMEOUT' || error?.code === 'SERVER_ERROR') {
+                return {
+                    valid: false,
+                    error: 'Unable to verify LP token contract. Check your network connection and try again.'
+                };
             }
+            return {
+                valid: false,
+                error: 'This address does not appear to be a V2-compatible LP token contract'
+            };
+        }
 
-            token0 = ethers.utils.getAddress(token0Address);
-            token1 = ethers.utils.getAddress(token1Address);
-            const zeroAddress = ethers.constants.AddressZero;
-            if (token0 === zeroAddress || token1 === zeroAddress || token0.toLowerCase() === token1.toLowerCase()) {
-                throw new Error('invalid pair tokens');
-            }
+        if (!ethers.utils.isAddress(token0Address) || !ethers.utils.isAddress(token1Address)) {
+            return {
+                valid: false,
+                error: 'This address does not appear to be a V2-compatible LP token contract'
+            };
+        }
 
-            if (!Array.isArray(reserves) || reserves.length < 2) {
-                throw new Error('invalid reserves');
-            }
+        const token0 = ethers.utils.getAddress(token0Address);
+        const token1 = ethers.utils.getAddress(token1Address);
+        const zeroAddress = ethers.constants.AddressZero;
+        if (token0 === zeroAddress || token1 === zeroAddress || token0.toLowerCase() === token1.toLowerCase()) {
+            return {
+                valid: false,
+                error: 'This address does not appear to be a V2-compatible LP token contract'
+            };
+        }
 
+        if (!Array.isArray(reserves) || reserves.length < 2) {
+            return {
+                valid: false,
+                error: 'This address does not appear to be a V2-compatible LP token contract'
+            };
+        }
+
+        let reserve0;
+        let reserve1;
+        try {
             reserve0 = ethers.BigNumber.from(reserves[0]);
             reserve1 = ethers.BigNumber.from(reserves[1]);
         } catch (error) {

--- a/tests/v2-lp-token-validation.test.js
+++ b/tests/v2-lp-token-validation.test.js
@@ -137,5 +137,18 @@ describe('ContractManager.validateV2CompatibleLpToken', () => {
             valid: false,
             error: 'Unable to verify contract code. Check your network connection and try again.'
         });
+
+        const pairReadFailure = await loadContractManager(
+            { getCode: vi.fn().mockResolvedValue('0x6000') },
+            {
+                token0: vi.fn().mockRejectedValue(Object.assign(new Error('timeout'), { code: 'TIMEOUT' })),
+                token1: vi.fn(),
+                getReserves: vi.fn()
+            }
+        );
+        await expect(pairReadFailure.validateV2CompatibleLpToken(LP)).resolves.toEqual({
+            valid: false,
+            error: 'Unable to verify LP token contract. Check your network connection and try again.'
+        });
     });
 });

--- a/tests/v2-lp-token-validation.test.js
+++ b/tests/v2-lp-token-validation.test.js
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const scriptSrc = 'https://example.test/repo/js/contracts/contract-manager.js';
+const LP = '0x1111111111111111111111111111111111111111';
+const TOKEN0 = '0x2222222222222222222222222222222222222222';
+const TOKEN1 = '0x3333333333333333333333333333333333333333';
+
+async function loadContractManager(provider, pairContract) {
+    vi.resetModules();
+    globalThis.window = globalThis;
+    globalThis.location = { pathname: '/' };
+    globalThis.document = { currentScript: { src: scriptSrc } };
+    delete globalThis.ContractManager;
+    globalThis.ethers = {
+        constants: { AddressZero: '0x0000000000000000000000000000000000000000' },
+        utils: {
+            isAddress(value) {
+                return typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value);
+            },
+            getAddress(value) {
+                if (!globalThis.ethers.utils.isAddress(value)) {
+                    throw new Error('invalid address');
+                }
+                return value;
+            }
+        },
+        BigNumber: {
+            from(value) {
+                return { toString: () => String(value) };
+            }
+        },
+        Contract: vi.fn(function Contract() {
+            return pairContract;
+        })
+    };
+
+    await import('../js/contracts/contract-manager.js');
+    const manager = new globalThis.ContractManager();
+    manager.provider = provider;
+    return manager;
+}
+
+function validPairContract(token0 = TOKEN0, token1 = TOKEN1, reserve0 = '0', reserve1 = '0') {
+    return {
+        token0: vi.fn().mockResolvedValue(token0),
+        token1: vi.fn().mockResolvedValue(token1),
+        getReserves: vi.fn().mockResolvedValue([reserve0, reserve1, 0])
+    };
+}
+
+describe('ContractManager.validateV2CompatibleLpToken', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete globalThis.ContractManager;
+        delete globalThis.document;
+        delete globalThis.ethers;
+        delete globalThis.location;
+        delete globalThis.window;
+    });
+
+    it('rejects bad addresses before RPC calls', async () => {
+        const getCode = vi.fn();
+        const manager = await loadContractManager({ getCode }, validPairContract());
+
+        await expect(manager.validateV2CompatibleLpToken('')).resolves.toEqual({
+            valid: false,
+            error: 'LP token address is required'
+        });
+        await expect(manager.validateV2CompatibleLpToken('bad')).resolves.toEqual({
+            valid: false,
+            error: 'Invalid Ethereum address format'
+        });
+        expect(getCode).not.toHaveBeenCalled();
+    });
+
+    it('rejects EOAs and non-pair contracts', async () => {
+        const manager = await loadContractManager(
+            { getCode: vi.fn().mockResolvedValue('0x') },
+            validPairContract()
+        );
+        await expect(manager.validateV2CompatibleLpToken(LP)).resolves.toEqual({
+            valid: false,
+            error: 'No contract code found at this address'
+        });
+
+        const brokenPair = {
+            token0: vi.fn().mockRejectedValue(new Error('missing')),
+            token1: vi.fn(),
+            getReserves: vi.fn()
+        };
+        const brokenManager = await loadContractManager(
+            { getCode: vi.fn().mockResolvedValue('0x6000') },
+            brokenPair
+        );
+        await expect(brokenManager.validateV2CompatibleLpToken(LP)).resolves.toEqual({
+            valid: false,
+            error: 'This address does not appear to be a V2-compatible LP token contract'
+        });
+    });
+
+    it('accepts V2-compatible pair contracts', async () => {
+        const pairContract = validPairContract();
+        const manager = await loadContractManager(
+            { getCode: vi.fn().mockResolvedValue('0x6000') },
+            pairContract
+        );
+
+        const result = await manager.validateV2CompatibleLpToken(LP);
+
+        expect(result.valid).toBe(true);
+        expect(result.address).toBe(LP);
+        expect(result.token0).toBe(TOKEN0);
+        expect(result.token1).toBe(TOKEN1);
+        expect(result.reserve0.toString()).toBe('0');
+        expect(result.reserve1.toString()).toBe('0');
+    });
+
+    it('rejects invalid underlying tokens and RPC failures', async () => {
+        const invalidTokens = await loadContractManager(
+            { getCode: vi.fn().mockResolvedValue('0x6000') },
+            validPairContract(TOKEN0, TOKEN0)
+        );
+        await expect(invalidTokens.validateV2CompatibleLpToken(LP)).resolves.toEqual({
+            valid: false,
+            error: 'This address does not appear to be a V2-compatible LP token contract'
+        });
+
+        const rpcFailure = await loadContractManager(
+            { getCode: vi.fn().mockRejectedValue(new Error('timeout')) },
+            validPairContract()
+        );
+        await expect(rpcFailure.validateV2CompatibleLpToken(LP)).resolves.toEqual({
+            valid: false,
+            error: 'Unable to verify contract code. Check your network connection and try again.'
+        });
+    });
+});


### PR DESCRIPTION
## What Changed

This PR adds live LP address validation to the add-pair modal.

- Debounced on-chain LP checks run while the admin types in `pair-address`.
- Feedback shows validating, invalid, or valid V2 pair states under the field.
- **Create Proposal** stays disabled until LP validation reaches `valid`.
- Form submit also returns early unless LP validation is already `valid`.
- Submit-time validation from PR 2 still runs before `proposeAddPair()`.

## Fixed Flow

1. Admin opens **Add New Pair** and enters an LP token address.
2. After 500ms without typing, the app validates the address on-chain.
3. Invalid addresses show an inline error and keep submit disabled.
4. Valid V2 pairs show token addresses in the help text and enable submit.
5. Submit still re-validates on-chain before creating the proposal.

## Why

PR 2 blocked bad addresses at submit time. This PR gives earlier feedback and prevents clicking **Create Proposal** until the LP address is valid.

## Validation

- `npm test -- tests/v2-lp-token-validation.test.js`

Stacked on #284 (`issue-271/2-submit-gate`). Part of #271.

Made with [Cursor](https://cursor.com)