### PR TITLE
feat(contract-manager): add reward token funding helper

### DIFF
--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -2735,6 +2735,47 @@ class ContractManager {
         }
     }
 
+    async transferRewardTokensToStaking(amount) {
+        try {
+            await this.ensureSigner();
+
+            if (!this.isRewardTokenContractReady()) {
+                return { success: false, error: new Error('Reward token contract is not available.') };
+            }
+
+            const stakingAddress = this.stakingContract?.address || this.contractAddresses?.get('STAKING');
+            if (!stakingAddress || !this.isValidContractAddress(stakingAddress)) {
+                return { success: false, error: new Error('Staking contract address is not available.') };
+            }
+
+            const amountStr = String(amount);
+            const amountNum = parseFloat(amountStr);
+            if (!amountStr || Number.isNaN(amountNum) || amountNum <= 0) {
+                return { success: false, error: new Error('Amount must be a positive number.') };
+            }
+
+            const recipient = this.validateAndChecksumAddress(stakingAddress, 'Staking Contract Address');
+            const amountWei = ethers.utils.parseEther(amountStr);
+
+            const result = await this.executeTransactionOnce(async () => {
+                const tx = await this.rewardTokenContract.connect(this.signer).transfer(recipient, amountWei);
+                console.log('Reward token funding transaction sent:', tx.hash);
+                return tx;
+            }, 'transferRewardTokensToStaking');
+
+            return {
+                success: true,
+                transactionHash: result.transactionHash,
+                blockNumber: result.blockNumber,
+                gasUsed: result.gasUsed?.toString?.() || result.gasUsed,
+                message: 'Reward tokens transferred to staking contract'
+            };
+        } catch (error) {
+            console.error('Failed to transfer reward tokens to staking contract:', error);
+            return { success: false, error };
+        }
+    }
+
     // ============ ADMIN PROPOSAL FUNCTIONS ============
 
     /**

--- a/js/contracts/contract-manager.js
+++ b/js/contracts/contract-manager.js
@@ -2755,6 +2755,8 @@ class ContractManager {
             }
 
             const recipient = this.validateAndChecksumAddress(stakingAddress, 'Staking Contract Address');
+            // Assumes 18-decimal reward token; matches REWARD_PRECISION and admin UI formatting.
+            // See https://github.com/Liberdus/lib-lp-staking-frontend/issues/289 if we need decimal-agnostic tokens.
             const amountWei = ethers.utils.parseEther(amountStr);
 
             const result = await this.executeTransactionOnce(async () => {

--- a/tests/contract-manager-reward-funding.test.js
+++ b/tests/contract-manager-reward-funding.test.js
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const STAKING_ADDRESS = '0x3333333333333333333333333333333333333333';
+const REWARD_TOKEN_ADDRESS = '0x4444444444444444444444444444444444444444';
+
+function tx(hash) {
+    return Promise.resolve({ hash });
+}
+
+async function createManager(rewardTokenMethods, includeRewardToken = true) {
+    vi.resetModules();
+
+    globalThis.window = globalThis;
+    globalThis.ethers = {
+        utils: {
+            parseEther: vi.fn(value => ({ value, toString: () => String(value) })),
+            isAddress: vi.fn(value => /^0x[a-fA-F0-9]{40}$/.test(String(value))),
+            getAddress: vi.fn(value => String(value))
+        }
+    };
+
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await import('../js/contracts/contract-manager.js');
+    const manager = new globalThis.ContractManager();
+
+    manager.signer = {};
+    manager.ensureSigner = vi.fn().mockResolvedValue(undefined);
+    manager.stakingContract = { address: STAKING_ADDRESS };
+    manager.contractAddresses = new Map([['STAKING', STAKING_ADDRESS]]);
+    manager.rewardTokenContract = includeRewardToken ? {
+        address: REWARD_TOKEN_ADDRESS,
+        interface: {},
+        connect: vi.fn(() => rewardTokenMethods)
+    } : null;
+    manager.isValidContractAddress = vi.fn(() => true);
+    manager.validateAndChecksumAddress = vi.fn(address => address);
+    manager.executeTransactionOnce = vi.fn(async (operation) => {
+        const result = await operation();
+        return {
+            transactionHash: result.hash,
+            blockNumber: 1,
+            gasUsed: '21000'
+        };
+    });
+
+    return manager;
+}
+
+beforeEach(() => {
+    delete globalThis.ContractManager;
+    delete globalThis.contractManager;
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    delete globalThis.window;
+    delete globalThis.ethers;
+    delete globalThis.ContractManager;
+    delete globalThis.contractManager;
+});
+
+describe('ContractManager reward token funding', () => {
+    it('transfers configured reward tokens to the staking contract address', async () => {
+        const transfer = vi.fn(() => tx('0xfund-rewards'));
+        const manager = await createManager({ transfer });
+
+        const result = await manager.transferRewardTokensToStaking('10');
+
+        expect(result.success).toBe(true);
+        expect(transfer).toHaveBeenCalledWith(
+            STAKING_ADDRESS,
+            expect.objectContaining({ value: '10' })
+        );
+        expect(manager.executeTransactionOnce).toHaveBeenCalledWith(
+            expect.any(Function),
+            'transferRewardTokensToStaking'
+        );
+    });
+
+    it('rejects invalid amounts without submitting a transaction', async () => {
+        const transfer = vi.fn(() => tx('0xfund-rewards'));
+        const manager = await createManager({ transfer });
+
+        for (const amount of ['0', 'abc']) {
+            const result = await manager.transferRewardTokensToStaking(amount);
+            expect(result.success).toBe(false);
+            expect(result.error.message).toBe('Amount must be a positive number.');
+        }
+
+        expect(manager.executeTransactionOnce).not.toHaveBeenCalled();
+        expect(transfer).not.toHaveBeenCalled();
+    });
+
+    it('returns an error when the reward token contract is unavailable', async () => {
+        const transfer = vi.fn(() => tx('0xfund-rewards'));
+        const manager = await createManager({ transfer }, false);
+
+        const result = await manager.transferRewardTokensToStaking('5');
+
+        expect(result.success).toBe(false);
+        expect(result.error.message).toBe('Reward token contract is not available.');
+        expect(manager.executeTransactionOnce).not.toHaveBeenCalled();
+        expect(transfer).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- Add `transferRewardTokensToStaking(amount)` to send the configured reward token from the connected wallet to the staking contract
- Resolve recipient and token addresses from contract configuration instead of user input
- Add unit tests for the transfer helper and basic validation guards

## Why
Part 1 of stacked work for #270. PR 2 will add the admin UI that calls this helper.

## Test plan
- [x] `npm test -- tests/contract-manager-reward-funding.test.js`
- [ ] Manual wallet transfer (after PR 2 admin UI lands)