### PR TITLE
Vendor liberdus wallet module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/liberdus-wallet-module"]
+	path = vendor/liberdus-wallet-module
+	url = https://github.com/Liberdus/liberdus-wallet-module.git

--- a/docs/SUBMODULE.md
+++ b/docs/SUBMODULE.md
@@ -1,0 +1,101 @@
+# Wallet module submodule
+
+`lib-lp-staking-frontend` vendors [`liberdus-wallet-module`](https://github.com/Liberdus/liberdus-wallet-module) as a git submodule at:
+
+```text
+vendor/liberdus-wallet-module/
+```
+
+The parent repo stores a pointer to a specific commit in the wallet module repo. Updating the module means moving that pointer and committing the change in `lib-lp-staking-frontend`.
+
+## First-time setup
+
+Clone with submodules:
+
+```bash
+git clone --recurse-submodules https://github.com/Liberdus/lib-lp-staking-frontend.git
+```
+
+If the repo is already cloned:
+
+```bash
+git submodule update --init --recursive
+```
+
+Verify the wallet files are present:
+
+```bash
+test -f vendor/liberdus-wallet-module/index.js && echo OK
+```
+
+## Update to latest `main`
+
+From the repo root:
+
+```bash
+./scripts/bump-wallet-module.sh
+```
+
+That script:
+
+1. Fetches the latest commit from the submodule's tracked branch
+2. Stages `vendor/liberdus-wallet-module`
+3. Creates a commit in `lib-lp-staking-frontend`
+
+Use `--no-commit` if you only want to update and stage locally:
+
+```bash
+./scripts/bump-wallet-module.sh --no-commit
+```
+
+## Pin to a tag or commit
+
+```bash
+./scripts/bump-wallet-module.sh --ref v0.2.0
+./scripts/bump-wallet-module.sh --ref d393766
+```
+
+## Manual update
+
+Latest remote commit:
+
+```bash
+git submodule update --init --recursive vendor/liberdus-wallet-module
+git submodule update --remote vendor/liberdus-wallet-module
+git add vendor/liberdus-wallet-module
+git commit -m "chore: bump liberdus-wallet-module submodule"
+```
+
+Specific tag or commit:
+
+```bash
+cd vendor/liberdus-wallet-module
+git fetch origin --tags
+git checkout v0.2.0
+cd ../..
+git add vendor/liberdus-wallet-module
+git commit -m "chore: bump wallet module to v0.2.0"
+```
+
+## Inspect current pin
+
+```bash
+git submodule status vendor/liberdus-wallet-module
+git -C vendor/liberdus-wallet-module log -1 --oneline
+```
+
+## Troubleshooting
+
+### Empty `vendor/liberdus-wallet-module` after clone
+
+```bash
+git submodule update --init --recursive
+```
+
+### Submodule shows modified content inside vendor path
+
+You may have detached HEAD state inside the submodule after checkout. From repo root:
+
+```bash
+git submodule update --init vendor/liberdus-wallet-module
+```

--- a/scripts/bump-wallet-module.sh
+++ b/scripts/bump-wallet-module.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SUBMODULE_PATH="vendor/liberdus-wallet-module"
+REF=""
+NO_COMMIT=false
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [--ref <tag|branch|sha>] [--no-commit]
+
+Updates the liberdus-wallet-module submodule and commits the pointer change
+in lib-lp-staking-frontend unless --no-commit is passed.
+
+Examples:
+  $(basename "$0")
+  $(basename "$0") --ref v0.2.0
+  $(basename "$0") --ref main --no-commit
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ref)
+            REF="${2:-}"
+            if [ -z "$REF" ]; then
+                echo "Error: --ref requires a value"
+                exit 1
+            fi
+            shift 2
+            ;;
+        --no-commit)
+            NO_COMMIT=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_DIR"
+
+if [ ! -d "$SUBMODULE_PATH" ]; then
+    echo "Error: submodule path not found: $SUBMODULE_PATH"
+    exit 1
+fi
+
+staged_outside_submodule="$(git diff --cached --name-only | grep -v -E "^${SUBMODULE_PATH}(/|$)" || true)"
+if [ -n "$staged_outside_submodule" ]; then
+    echo "Error: staged changes exist outside $SUBMODULE_PATH"
+    echo "Commit or unstage them before running this script:"
+    echo "$staged_outside_submodule"
+    exit 1
+fi
+
+echo "Initializing submodule..."
+git submodule update --init --recursive "$SUBMODULE_PATH"
+
+OLD_SHA="$(git -C "$SUBMODULE_PATH" rev-parse HEAD)"
+echo "Current submodule commit: $OLD_SHA"
+
+if [ -n "$REF" ]; then
+    echo "Checking out submodule ref: $REF"
+    git -C "$SUBMODULE_PATH" fetch origin --tags
+    git -C "$SUBMODULE_PATH" checkout "$REF"
+else
+    echo "Updating submodule to latest remote commit..."
+    git submodule update --remote "$SUBMODULE_PATH"
+fi
+
+NEW_SHA="$(git -C "$SUBMODULE_PATH" rev-parse HEAD)"
+NEW_SUBJECT="$(git -C "$SUBMODULE_PATH" log -1 --format='%s')"
+
+if [ ! -f "$SUBMODULE_PATH/index.js" ]; then
+    echo "Error: $SUBMODULE_PATH/index.js not found after update"
+    exit 1
+fi
+
+echo
+echo "Submodule updated:"
+echo "  path:    $SUBMODULE_PATH"
+echo "  before:  $OLD_SHA"
+echo "  after:   $NEW_SHA"
+echo "  subject: $NEW_SUBJECT"
+echo
+
+git add "$SUBMODULE_PATH"
+
+if git diff --cached --quiet -- "$SUBMODULE_PATH"; then
+    echo "No submodule pointer change to commit."
+    exit 0
+fi
+
+if [ "$NO_COMMIT" = true ]; then
+    echo "Submodule change staged. Skipping commit (--no-commit)."
+    exit 0
+fi
+
+COMMIT_MSG="chore: bump liberdus-wallet-module submodule to ${NEW_SHA:0:7}"
+git commit -m "$COMMIT_MSG" -- "$SUBMODULE_PATH"
+echo "Created commit: $COMMIT_MSG"

--- a/scripts/bump-wallet-module.sh
+++ b/scripts/bump-wallet-module.sh
@@ -71,7 +71,11 @@ echo "Current submodule commit: $OLD_SHA"
 if [ -n "$REF" ]; then
     echo "Checking out submodule ref: $REF"
     git -C "$SUBMODULE_PATH" fetch origin --tags
-    git -C "$SUBMODULE_PATH" checkout "$REF"
+    CHECKOUT_REF="$REF"
+    if git -C "$SUBMODULE_PATH" show-ref --verify --quiet "refs/remotes/origin/$REF"; then
+        CHECKOUT_REF="origin/$REF"
+    fi
+    git -C "$SUBMODULE_PATH" checkout --detach "$CHECKOUT_REF"
 else
     echo "Updating submodule to latest remote commit..."
     git submodule update --remote "$SUBMODULE_PATH"

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        exclude: [...configDefaults.exclude, 'vendor/**']
+    }
+});


### PR DESCRIPTION
## What Changed

- Added `vendor/liberdus-wallet-module` as a tracked submodule.
- Added `scripts/bump-wallet-module.sh` for updating the vendored wallet module ref.
- Documented the submodule update flow in `docs/SUBMODULE.md`.
- Updated Vitest config to exclude vendored module tests.

## Why

This keeps the LP staking frontend pinned to a known wallet module revision while giving maintainers a repeatable update path.

## Validation

- `npm test`