### PR TITLE
chore: bump wallet module to main and trim WalletManager glue

### DIFF
--- a/js/wallet/wallet-manager.js
+++ b/js/wallet/wallet-manager.js
@@ -155,22 +155,7 @@
 
         async disconnect() {
             this.assertReady();
-            await this.revokeWalletPermissions();
             await this.walletCore.disconnect();
-        }
-
-        async revokeWalletPermissions() {
-            const provider = this.walletCore.getEip1193Provider();
-            if (!provider?.request) return;
-
-            try {
-                await provider.request({
-                    method: 'wallet_revokePermissions',
-                    params: [{ eth_accounts: {} }]
-                });
-            } catch {
-                // Not all wallets support permission revocation; local disconnect still applies.
-            }
         }
 
         async checkPreviousConnection() {

--- a/js/wallet/wallet-manager.js
+++ b/js/wallet/wallet-manager.js
@@ -85,10 +85,6 @@
             }
         }
 
-        async connectMetaMask() {
-            return await this.connectWallet('metamask');
-        }
-
         async connect(options) {
             this.assertReady();
             if (this.isConnected()) return this.connectionResult();
@@ -191,10 +187,6 @@
                 return;
             }
 
-            if ((event === 'accountChanged' || event === 'chainChanged') && !this.hasActiveWalletSession()) {
-                return;
-            }
-
             if (event === 'accountChanged' || event === 'chainChanged') {
                 this.syncFromCoreState();
                 this.notifyListeners(event, data);
@@ -225,11 +217,6 @@
             this.account = null;
             this.chainId = null;
             this.walletType = null;
-        }
-
-        hasActiveWalletSession() {
-            const state = this.walletCore.getState();
-            return !!(state.sessionWalletId || state.selectedWalletId);
         }
 
         connectionResult() {


### PR DESCRIPTION
## Summary

Ships merged `liberdus-wallet-module` fixes on `main` (`c4f7059`) and trims redundant `WalletManager` logic now handled by the module.

Implements the frontend step in [#294](https://github.com/Liberdus/lib-lp-staking-frontend/issues/294).

## Submodule (`vendor/liberdus-wallet-module`)

**`d393766` → `c4f7059`** — [liberdus-wallet-module#24](https://github.com/Liberdus/liberdus-wallet-module/pull/24)

- EVM-only namespace discovery (`isEvmProvider` / `eth_chainId` probe, 250ms timeout)
- Session restore (late EIP-6963, rdns fallback, metadata preservation)
- Provider `disconnect` handling and revoke-on-disconnect in module core

## App (`js/wallet/wallet-manager.js`)

- **`disconnect()`** — only calls `walletCore.disconnect()` (module revokes permissions by default; removes duplicate `wallet_revokePermissions`)
- **`handleCoreEvent`** — removes `hasActiveWalletSession()` guard after manual QA (disconnect, network switch, extension chain changes while disconnected)
- **`connectMetaMask()`** — removed unused wrapper

**Unchanged (app-specific):** Phantom-on-BNB guard, picker / `WALLET_SELECTION_REQUIRED`, ethers `Web3Provider` wrapping, `lib_lp_staking:wallet-session` key.

## Commits

1. `aa38ed7` — submodule bump + drop duplicate revoke
2. `9319c3f` — drop session guard + `connectMetaMask`

## Validation

- `cd vendor/liberdus-wallet-module && npm test` — 39/39
- `npm test -- tests/wallet-manager.test.js` — 7/7
- Manual: connect picker excludes non-EVM namespace wallets (Ton/Bitcoin/Tron); disconnect + chain switch while disconnected

## After merge

1. `git checkout main && git pull && git submodule update --init --recursive`
2. `liberdus.github.io`: `./update-farm.sh` then commit `farm/` ([github.io#54](https://github.com/Liberdus/liberdus.github.io/pull/54) or fresh sync from updated `main`)

Closes #294
